### PR TITLE
[stable/rbac-manager] Add missing namespace permissions to role

### DIFF
--- a/stable/rbac-manager/Chart.yaml
+++ b/stable/rbac-manager/Chart.yaml
@@ -1,5 +1,5 @@
 name: rbac-manager
-version: 0.2.0
+version: 0.2.1
 appVersion: 0.5.0
 description: A Kubernetes operator that simplifies the management of Role Bindings and Service Accounts.
 keywords:

--- a/stable/rbac-manager/templates/clusterrole.yaml
+++ b/stable/rbac-manager/templates/clusterrole.yaml
@@ -29,3 +29,11 @@ rules:
       - serviceaccounts
     verbs:
       - '*'
+  - apiGroups:
+      - "" # core
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch


### PR DESCRIPTION
Fixes:
```
E0214 13:39:43.478098       1 reflector.go:205] github.com/reactiveops/rbac-manager/vendor/sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:126: Failed to list *v1.Namespace: namespaces is forbidden: User "system:serviceaccount:rbac-manager:rbac-manager" cannot list namespaces at the cluster scope
```