### PR TITLE
lowering failureThreshold to 1 for fluentd-papertrail

### DIFF
--- a/incubator/fluentd/Chart.yaml
+++ b/incubator/fluentd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.19"
 description: Fluentd for multiple endpoints
 name: fluentd
-version: 1.1.1
+version: 1.1.2
 maintainers:
   - name: dosullivan
   - name: coreypobrien

--- a/incubator/fluentd/templates/daemonset.yaml
+++ b/incubator/fluentd/templates/daemonset.yaml
@@ -37,6 +37,7 @@ spec:
         livenessProbe:
           initialDelaySeconds: 600
           periodSeconds: 60
+          failureThreshold: 1
           exec:
             command:
             - '/bin/sh'


### PR DESCRIPTION
Based on finicky behavior we've seen with the papertrail plugin and fluentd, this lowers the failureThreshold to 1 for the fluentd daemonset's pods. 