### PR TITLE
[incubator/fluentd] Fix duplicate system config for elasticsearch

### DIFF
--- a/incubator/fluentd/Chart.yaml
+++ b/incubator/fluentd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.19"
 description: Fluentd for multiple endpoints
 name: fluentd
-version: 1.1.2
+version: 1.1.3
 maintainers:
   - name: dosullivan
   - name: coreypobrien

--- a/incubator/fluentd/files/elasticsearch.conf
+++ b/incubator/fluentd/files/elasticsearch.conf
@@ -27,6 +27,3 @@
   </endpoint>
 </match>
 
-<system>
-  log_level {{ .Values.log_level }}
-</system>


### PR DESCRIPTION
The `<system>` section is in the global config so we need to remove this so we don't have a duplicate invalid config