### PR TITLE
updating livenessProbe for fluentd to match Corey's live patch

### DIFF
--- a/incubator/fluentd/Chart.yaml
+++ b/incubator/fluentd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.19"
 description: Fluentd for multiple endpoints
 name: fluentd
-version: 1.1.3
+version: 1.1.4
 maintainers:
   - name: dosullivan
   - name: coreypobrien

--- a/incubator/fluentd/templates/daemonset.yaml
+++ b/incubator/fluentd/templates/daemonset.yaml
@@ -49,7 +49,7 @@ spec:
               fi; if [ -z "$(ls -A /var/log/fluentd-buffers-papertrail)" ]; then
                 echo "/var/log/fluentd-buffers-papertrail is empty. There are no buffers...I think that is good?";
                 exit 0;
-              fi; touch -d $(date -d@"$(( `date +%s`-300))" +%m%d%H%M) /tmp/marker-liveness; if [[ -z "$(find /var/log/fluentd-buffers-papertrail -type f -newer /tmp/marker-liveness -print)" ]]; then
+              fi; touch -d $(date -d@"$(( `date +%s`-300))" +%m%d%H%M) /tmp/marker-liveness; if [[ -n "$(find /var/log/fluentd-buffers-papertrail -type f ! -newer /tmp/marker-liveness -print)" ]]; then
                 echo "Buffer files have not been modified in the last ${LIVENESS_THRESHOLD_SECONDS} seconds";
                 rm -f /var/log/fluentd-buffers-papertrail/*
                 exit 1;


### PR DESCRIPTION
Updating the fluentd chart to use a slightly more effective search pattern in it's livenessProbe. If any buffer files are found to be older than 5 minutes, it will immediately fail the livenessProbe.