### PR TITLE
[incubator/fluentd] ES improvements and kubernetes_cluster

### DIFF
--- a/incubator/fluentd/Chart.yaml
+++ b/incubator/fluentd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.12.43"
 description: Fluentd for multiple endpoints
 name: fluentd
-version: 3.1.1
+version: 3.2.0
 maintainers:
   - name: dosullivan
   - name: coreypobrien

--- a/incubator/fluentd/README.md
+++ b/incubator/fluentd/README.md
@@ -19,6 +19,8 @@ Switching backends requires using a matching image as well as some backend-speci
 | `elasticsearch.extraArgs` | [] |
 | `elasticsearch.buffer_chunk_limit` | `5m` |
 | `elasticsearch.buffer_queue_limit` | `100` |
+| `elasticsearch.buffer_queue_full_action` | `exception` |
+| `elasticsearch.request_timeout` | `20s` |
 | `elasticsearch.flush_interval` | `5s` |
 | `elasticsearch.num_threads` | `4` |
 
@@ -32,13 +34,13 @@ Switching backends requires using a matching image as well as some backend-speci
 | `papertrail.enabled` | `true` |
 | `papertrail.host` | `logs3.papertrailapp.com` |
 | `papertrail.port` | `12785` |
-| `papertrail.cluster_name` | `something` |
 | `papertrail.extraArgs` | [] |
 
 ## Other Values
 
 | Parameter | Description | Default |
 | --------- | ----------- | ------- |
+| `cluster_name` | **Required** Name of the kubernetes_cluster | `""` |
 | `verify_ssl` | Enable/disable TLS validation of Kubernetes API | `true` |
 | `image.pullPolicy` | Pull policy | `Always` |
 | `resources` | Resource requests/limits | `{limits: {cpu: 100m, memory: 500Mi}, requests: {cpu: 100m, memory: 500Mi}` |

--- a/incubator/fluentd/ci/es-values.yaml
+++ b/incubator/fluentd/ci/es-values.yaml
@@ -1,3 +1,3 @@
-es:
+elasticsearch:
   enabled: true
 cluster_name: my.cluster.local

--- a/incubator/fluentd/ci/es-values.yml
+++ b/incubator/fluentd/ci/es-values.yml
@@ -1,2 +1,3 @@
 es:
   enabled: true
+cluster_name: my.cluster.local

--- a/incubator/fluentd/ci/papertrail-values.yaml
+++ b/incubator/fluentd/ci/papertrail-values.yaml
@@ -1,6 +1,9 @@
-papertrail.host: logs1.papertrailtestdummy.local
-papertrail.port: "12345"
-papertrail.enabled: "true"
+elasticsearch:
+  enabled: false
+papertrail:
+  host: logs1.papertrailtestdummy.local
+  port: "12345"
+  enabled: "true"
 cluster_name: my.cluster.local
 image:
   repository: fluent/fluentd-kubernetes-daemonset

--- a/incubator/fluentd/ci/papertrail-values.yml
+++ b/incubator/fluentd/ci/papertrail-values.yml
@@ -1,7 +1,7 @@
 papertrail.host: logs1.papertrailtestdummy.local
 papertrail.port: "12345"
-papertrail.cluster_name: my.cluster.local
 papertrail.enabled: "true"
+cluster_name: my.cluster.local
 image:
   repository: fluent/fluentd-kubernetes-daemonset
   pullPolicy: IfNotPresent

--- a/incubator/fluentd/files/elasticsearch.conf
+++ b/incubator/fluentd/files/elasticsearch.conf
@@ -15,6 +15,8 @@
   disable_retry_limit
   retry_wait 1s
   max_retry_wait 60s
+  request_timeout {{ .Values.elasticsearch.request_timeout }}
+  buffer_queue_full_action {{ .Values.elasticsearch.buffer_queue_full_action }}
 
   logstash_format true
   reload_connections false

--- a/incubator/fluentd/files/kubernetes.conf
+++ b/incubator/fluentd/files/kubernetes.conf
@@ -89,3 +89,7 @@
   @id filter_kube_metadata
   verify_ssl {{ .Values.verify_ssl }}
 </filter>
+
+<match kubernetes.**.fluentd*.**>
+  @type null
+</match>

--- a/incubator/fluentd/templates/configmap.yaml
+++ b/incubator/fluentd/templates/configmap.yaml
@@ -12,6 +12,12 @@ data:
   fluent.conf: |
     {{ tpl (.Files.Get "files/kubernetes.conf") . | nindent 4 }}
     {{ .Values.additional_filters_and_sources | nindent 4 }}
+    <filter **>
+      @type record_transformer
+      <record>
+        kubernetes_cluster {{ required "You must specify cluster_name" .Values.cluster_name }}
+      </record>
+    </filter>
     {{- if .Values.papertrail.enabled }}
     {{ tpl (.Files.Get "files/papertrail.conf") . | nindent 4 }}
     {{- end }}

--- a/incubator/fluentd/values.yaml
+++ b/incubator/fluentd/values.yaml
@@ -18,6 +18,8 @@ elasticsearch:
   buffer_queue_limit: 100
   flush_interval: 5s
   num_threads: 4
+  request_timeout: 20s
+  buffer_queue_full_action: exception
 
 ######################
 ##    Papertrail    ##
@@ -31,7 +33,6 @@ papertrail:
   enabled: false
   host: logs3.papertrailapp.com
   port: 12785
-  cluster_name:
   extraArgs: []
 
 

--- a/incubator/fluentd/values.yaml
+++ b/incubator/fluentd/values.yaml
@@ -44,6 +44,10 @@ papertrail:
 # set to false if you're running in a cluster on alibaba or other places with api cert issues
 verify_ssl: true
 
+# REQUIRED
+# Set to the name of the cluster
+# cluster_name: my.cluster.name
+
 additional_filters_and_sources: ""
 
 resources:


### PR DESCRIPTION
* Add ES settings for buffer_queue_full_action and request_timeout
* Drop all fluentd logs. When there are problems pushing output, generating errors that then need to also be pushed only componds the problem
* Require `cluster_name` to set the `kubernetes_cluster` field on all records
* Remove unused papertrail.cluster_name setting