### PR TITLE
[incubator/fluentd] Fix k8s audit log processing

### DIFF
--- a/incubator/fluentd/Chart.yaml
+++ b/incubator/fluentd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.12.43"
 description: Fluentd for multiple endpoints
 name: fluentd
-version: 3.2.0
+version: 3.3.0
 maintainers:
   - name: dosullivan
   - name: coreypobrien

--- a/incubator/fluentd/files/elasticsearch.conf
+++ b/incubator/fluentd/files/elasticsearch.conf
@@ -2,7 +2,6 @@
   @type "elasticsearch"
   @id out_es
   include_tag_key true
-  #time_key time
 
   flatten_hashes true
   flatten_hashes_separator _
@@ -25,5 +24,4 @@
   port "{{ .Values.elasticsearch.port }}"
   scheme "{{ .Values.elasticsearch.scheme }}"
   ssl_verify "{{ .Values.verify_ssl }}"
-
 </match>

--- a/incubator/fluentd/files/kubernetes.conf
+++ b/incubator/fluentd/files/kubernetes.conf
@@ -69,20 +69,22 @@
   @type tail
   @id in_tail_kube_apiserver_audit
   multiline_flush_interval 5s
-  path /var/log/kubernetes/kube-apiserver-audit.log
+  path {{ .Values.kubernetes_audit_log_path }}
   pos_file /var/log/fluentd-kube-apiserver-audit.log.pos
   tag kube-apiserver-audit
-  format multiline
-  format_firstline /^\S+\s+AUDIT:/
-  # Fields must be explicitly captured by name to be parsed into the record.
-  # Fields may not always be present, and order may change, so this just looks
-  # for a list of key="\"quoted\" value" pairs separated by spaces.
-  # Unknown fields are ignored.
-  # Note: We can't separate query/response lines as format1/format2 because
-  #       they don't always come one after the other for a given query.
-  format1 /^(?<time>\S+) AUDIT:(?: (?:id="(?<id>(?:[^"\\]|\\.)*)"|ip="(?<ip>(?:[^"\\]|\\.)*)"|method="(?<method>(?:[^"\\]|\\.)*)"|user="(?<user>(?:[^"\\]|\\.)*)"|groups="(?<groups>(?:[^"\\]|\\.)*)"|as="(?<as>(?:[^"\\]|\\.)*)"|asgroups="(?<asgroups>(?:[^"\\]|\\.)*)"|namespace="(?<namespace>(?:[^"\\]|\\.)*)"|uri="(?<uri>(?:[^"\\]|\\.)*)"|response="(?<response>(?:[^"\\]|\\.)*)"|\w+="(?:[^"\\]|\\.)*"))*/
-  time_format %FT%T.%L%Z
+  format json
 </source>
+
+<filter kube-apiserver-audit>
+  @id kube_api_audit_normalize
+  @type record_transformer
+  auto_typecast false
+  enable_ruby true
+  <record>
+    responseObject ${record["responseObject"].nil? ? "none": record["responseObject"].to_json}
+    requestObject ${record["requestObject"].nil? ? "none": record["requestObject"].to_json}
+  </record>
+</filter>
 
 <filter kubernetes.**>
   @type kubernetes_metadata

--- a/incubator/fluentd/values.yaml
+++ b/incubator/fluentd/values.yaml
@@ -50,6 +50,8 @@ verify_ssl: true
 
 additional_filters_and_sources: ""
 
+kubernetes_audit_log_path: /var/log/kube-apiserver-audit.log
+
 resources:
   limits:
     cpu: 100m


### PR DESCRIPTION
* Parse as JSON
* Fix default path but allow for other paths
* Pass responseObject and requestObject as strings to avoid having the whole k8s api spec as separate fields