### PR TITLE
[stable/aws-iam-authenticator]: Update to app 0.4.0, add `image.repository|tag` values

### DIFF
--- a/stable/aws-iam-authenticator/Chart.yaml
+++ b/stable/aws-iam-authenticator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: v0.3.0
+appVersion: v0.4.0
 description: Install and configure aws-iam-authenticator on your cluster.
 name: aws-iam-authenticator
-version: v1.1.1
+version: v1.2.0
 maintainers:
   - name: sudermanjr
   - name: davekonopka

--- a/stable/aws-iam-authenticator/ci/test-values.yaml
+++ b/stable/aws-iam-authenticator/ci/test-values.yaml
@@ -1,0 +1,5 @@
+# The 0.4.0 image is hosted on ECR and can not be pulled from a non-EC2 CI instance.
+# For now, we use the 0.3.0 image for testing, which is more accessible.
+image:
+  repository: gcr.io/heptio-images/authenticator
+  tag: v0.3.0

--- a/stable/aws-iam-authenticator/templates/daemonset.yaml
+++ b/stable/aws-iam-authenticator/templates/daemonset.yaml
@@ -36,7 +36,7 @@ spec:
       # - output (output kubeconfig to plug into your apiserver configuration, mounted from the host)
       containers:
       - name: aws-iam-authenticator
-        image: gcr.io/heptio-images/authenticator:v0.3.0
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         args:
         - server
         - --config={{ .Values.volumes.config.mountPath }}config.yaml

--- a/stable/aws-iam-authenticator/values.yaml
+++ b/stable/aws-iam-authenticator/values.yaml
@@ -2,6 +2,15 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# The 0.4.0 image repository was determined from https://github.com/kubernetes-sigs/aws-iam-authenticator/blob/master/example.yaml
+image:
+  repository: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-iam-authenticator
+  tag: v0.4.0
+# To instead use the previous 0.3.0 image:
+# image:
+#  repository: gcr.io/heptio-images/authenticator
+#  tag: v0.3.0
+
 volumes:
   output:
     mountPath: /etc/kubernetes/aws-iam-authenticator/


### PR DESCRIPTION
I bumped the chart from version 1.1.1 to 1.2.0 to match the aws-iam-authenticator app server bump from 0.3.0 to 0.4.0.

I added the `image.repository|tag` values to make testing new ws-iam-authenticator versions easier in the future.
