### PR TITLE
[incubator/fluentd] Papertrail improvements

### DIFF
--- a/incubator/fluentd/Chart.yaml
+++ b/incubator/fluentd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.12.43"
 description: Fluentd for multiple endpoints
 name: fluentd
-version: 3.4.0
+version: 3.5.0
 maintainers:
   - name: dosullivan
   - name: coreypobrien

--- a/incubator/fluentd/files/papertrail.conf
+++ b/incubator/fluentd/files/papertrail.conf
@@ -1,14 +1,14 @@
 # Additional filters because papertrail has such limited/rigid logging requirements
 
-<filter kube-apiserver-audit>
+<filter **>
   @type record_transformer
-  @id filter_rt_kube_apiserver_audit
+  @id filter_rt_default_hostname_program_severity
   enable_ruby true
   <record>
-    hostname #{ENV['FLUENT_HOSTNAME']}
-    program kube-apiserver-audit
-    severity info
+    hostname "{{ .Values.cluster_name }}-#{ENV['FLUENT_HOSTNAME']}"
+    program "${tag_parts[0]}"
     facility local0
+    severity info
     message ${record}
   </record>
 </filter>
@@ -18,20 +18,11 @@
   @id filter_rt_kube_logs
   enable_ruby true
   <record>
-    hostname #{ENV['FLUENT_HOSTNAME']}-${record["kubernetes"]["namespace_name"]}-${record["kubernetes"]["pod_name"]}
+    hostname {{ .Values.cluster_name }}-${record["kubernetes"]["namespace_name"]}-${record["kubernetes"]["pod_name"]}
     program ${record["kubernetes"]["container_name"]}
     severity info
     facility local0
     message ${record['log']}
-  </record>
-</filter>
-
-<filter kube-**>
-  @type record_transformer
-  @id filter_rt_force_info_severity
-  enable_ruby true
-  <record>
-    severity info
   </record>
 </filter>
 
@@ -41,6 +32,6 @@
   num_threads 4
   buffer_type    file
   buffer_path    /var/log/fluentd-buffers-papertrail/fluentd-buffer
-  papertrail_host "#{ENV['FLUENT_PAPERTRAIL_HOST']}"
-  papertrail_port "#{ENV['FLUENT_PAPERTRAIL_PORT']}"
+  papertrail_host "{{ .Values.papertrail.host }}"
+  papertrail_port "{{ .Values.papertrail.port }}"
 </match>

--- a/incubator/fluentd/templates/daemonset.yaml
+++ b/incubator/fluentd/templates/daemonset.yaml
@@ -49,7 +49,7 @@ spec:
               fi; if [ -z "$(ls -A /var/log/fluentd-buffers-papertrail)" ]; then
                 echo "/var/log/fluentd-buffers-papertrail is empty. There are no buffers...I think that is good?";
                 exit 0;
-              fi; if [[ -z $(find /var/log/fluentd-buffers-papertrail -mmin -${LIVENESS_THRESHOLD_MINUTES}) ]]; then
+              fi; if [ -n "$(find /var/log/fluentd-buffers-papertrail -mmin ${LIVENESS_THRESHOLD_MINUTES} -name *.log)" ]; then
                 echo "Buffer files have not been modified in the last ${LIVENESS_THRESHOLD_MINUTES} minutes";
                 rm -f /var/log/fluentd-buffers-papertrail/*
                 exit 1;
@@ -74,6 +74,10 @@ spec:
             value: fluent.conf
           - name: FLUENT_UID
             value: "0"
+          - name: FLUENT_HOSTNAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
         volumeMounts:
         - name: varlog
           mountPath: /var/log


### PR DESCRIPTION
- Fix logic for livenessprobe
- Fix configuration to use configured hostname/port
- Make sure to pass in hostname of node for non-kubernetes logs
- Use the actual hostname in combination with the clustername for non-kubernetes logs
- All records needs a hostname not just audit logs