### PR TITLE
[incubator/fluentd] Limit program names for papertrail to 32 characters

### DIFF
--- a/incubator/fluentd/Chart.yaml
+++ b/incubator/fluentd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.12.43"
 description: Fluentd for multiple endpoints
 name: fluentd
-version: 3.5.0
+version: 3.6.0
 maintainers:
   - name: dosullivan
   - name: coreypobrien

--- a/incubator/fluentd/files/papertrail.conf
+++ b/incubator/fluentd/files/papertrail.conf
@@ -6,7 +6,7 @@
   enable_ruby true
   <record>
     hostname "{{ .Values.cluster_name }}-#{ENV['FLUENT_HOSTNAME']}"
-    program "${tag_parts[0]}"
+    program "${tag_parts[0][0..31]}"
     facility local0
     severity info
     message ${record}
@@ -19,7 +19,7 @@
   enable_ruby true
   <record>
     hostname {{ .Values.cluster_name }}-${record["kubernetes"]["namespace_name"]}-${record["kubernetes"]["pod_name"]}
-    program ${record["kubernetes"]["container_name"]}
+    program ${record["kubernetes"]["container_name"][0..31]}
     severity info
     facility local0
     message ${record['log']}


### PR DESCRIPTION
Papertrail requires `program` to be <= 32 chars: https://github.com/papertrail/remote_syslog_logger#default-program-name