### PR TITLE
Change HPA CPU format to match apiVersion

### DIFF
--- a/incubator/basic-demo/Chart.yaml
+++ b/incubator/basic-demo/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Basic Kubernetes Demo Chart
 name: basic-demo
-version: 0.2.0
+version: 0.2.1
 maintainers:
   - name: sudermanjr

--- a/incubator/basic-demo/templates/hpa.yaml
+++ b/incubator/basic-demo/templates/hpa.yaml
@@ -17,6 +17,10 @@ spec:
       metricName: {{ .Values.hpa.customMetric.metric }}
       targetAverageValue: {{ .Values.hpa.customMetric.target }}
 {{- else }}
-  targetCPUUtilizationPercentage: {{ .Values.hpa.cpuTarget }}
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      targetAverageUtilization: {{ .Values.hpa.cpuTarget }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
The HPA is set to `autoscaling/v2beta1` but was setting the `v1` style
`targetCPUUtilizationPercentage` field. Under some situations this was
causing failures to create or update the HPA. This updates the CPU
resource to use the new style format to match the `apiVersion`
expectations.