### PR TITLE
Update polaris-dashboard RBAC to allow query against statefulset

### DIFF
--- a/stable/polaris/Chart.yaml
+++ b/stable/polaris/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Validation of best practices in your Kubernetes clusters
 name: polaris
-version: "0.2.0"
+version: "0.2.1"
 appVersion: "0.2"
 maintainers:
   - name: bobby-brennan

--- a/stable/polaris/templates/dashboard.rbac.yaml
+++ b/stable/polaris/templates/dashboard.rbac.yaml
@@ -21,6 +21,7 @@ rules:
       - 'extensions'
     resources:
       - 'deployments'
+      - 'statefulsets'
     verbs:
       - 'get'
       - 'list'

--- a/stable/polaris/templates/webhook.rbac.yaml
+++ b/stable/polaris/templates/webhook.rbac.yaml
@@ -21,6 +21,7 @@ rules:
       - 'extensions'
     resources:
       - 'deployments'
+      - 'statefulsets'
     verbs:
       - 'get'
       - 'list'


### PR DESCRIPTION
0.2.0 polaris added support for statefulset, but RBAC clusterrole doesn't include statefulset