### PR TITLE
fluentd chart to API v1

### DIFF
--- a/incubator/fluentd/Chart.yaml
+++ b/incubator/fluentd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.12.43"
 description: Fluentd for multiple endpoints
 name: fluentd
-version: 3.6.0
+version: 4.0.0
 maintainers:
   - name: dosullivan
   - name: coreypobrien

--- a/incubator/fluentd/README.md
+++ b/incubator/fluentd/README.md
@@ -17,12 +17,12 @@ Switching backends requires using a matching image as well as some backend-speci
 | `elasticsearch.port` | `443` |
 | `elasticsearch.scheme` | `https` |
 | `elasticsearch.extraArgs` | [] |
-| `elasticsearch.buffer_chunk_limit` | `5m` |
-| `elasticsearch.buffer_queue_limit` | `100` |
-| `elasticsearch.buffer_queue_full_action` | `exception` |
-| `elasticsearch.request_timeout` | `20s` |
+| `elasticsearch.chunk_limit_size` | `5m` |
+| `elasticsearch.chunk_limit_records` | `100` |
+| `elasticsearch.overflow_action` | `throw_exception` |
+| `elasticsearch.retry_timeout` | `20s` |
 | `elasticsearch.flush_interval` | `5s` |
-| `elasticsearch.num_threads` | `4` |
+| `elasticsearch.flush_thread_count` | `4` |
 
 
 ### Papertrail
@@ -30,7 +30,7 @@ Switching backends requires using a matching image as well as some backend-speci
 | Parameter | Default |
 | --------- | ------- |
 | `image.repository` | `fluent/fluentd-kubernetes-daemonset` |
-| `image.tag` | `v0.12.43-debian-papertrail` |
+| `image.tag` | `v1.4.2-debian-papertrail-1.1` |
 | `papertrail.enabled` | `true` |
 | `papertrail.host` | `logs3.papertrailapp.com` |
 | `papertrail.port` | `12785` |

--- a/incubator/fluentd/README.md
+++ b/incubator/fluentd/README.md
@@ -16,7 +16,6 @@ Switching backends requires using a matching image as well as some backend-speci
 | `elasticsearch.host` | `instance-name.region.es.amazonaws.com` |
 | `elasticsearch.port` | `443` |
 | `elasticsearch.scheme` | `https` |
-| `elasticsearch.extraArgs` | [] |
 | `elasticsearch.chunk_limit_size` | `5m` |
 | `elasticsearch.chunk_limit_records` | `100` |
 | `elasticsearch.overflow_action` | `throw_exception` |
@@ -52,3 +51,4 @@ Switching backends requires using a matching image as well as some backend-speci
 | `log_level` | Log level | `error` |
 | `additional_filters_and_sources` | Custom additional fluentd configuration | `""` |
 | `updateStrategy` | DaemonSet updateStrategy | `{type: RollingUpdate, rollingUpdate: {maxUnavailable: 10}}` |
+| `pluginExtraArgs` | [] | Extra arguments to be added to the container|

--- a/incubator/fluentd/README.md
+++ b/incubator/fluentd/README.md
@@ -11,7 +11,7 @@ Switching backends requires using a matching image as well as some backend-speci
 | Parameter | Default |
 | --------- | ------- |
 | `image.repository` | `fluent/fluentd-kubernetes-daemonset` |
-| `image.tag` | `v0.12.43-debian-elasticsearch` |
+| `image.tag` | `v1.4.2-debian-elasticsearch-1.1` |
 | `elasticsearch.enabled` |  `true` |
 | `elasticsearch.host` | `instance-name.region.es.amazonaws.com` |
 | `elasticsearch.port` | `443` |
@@ -33,7 +33,7 @@ Switching backends requires using a matching image as well as some backend-speci
 | `papertrail.enabled` | `true` |
 | `papertrail.host` | `logs3.papertrailapp.com` |
 | `papertrail.port` | `12785` |
-| `papertrail.extraArgs` | [] |
+| `papertrail.flush_thread_count` | `4` |
 
 ## Other Values
 

--- a/incubator/fluentd/files/elasticsearch.conf
+++ b/incubator/fluentd/files/elasticsearch.conf
@@ -15,7 +15,7 @@
     retry_wait 1s
     retry_max_interval 60s
     retry_timeout {{ .Values.elasticsearch.retry_timeout }}
-    overflow_action {{ .Values.elasticsearch.buffer_queue_full_action }}
+    overflow_action {{ .Values.elasticsearch.overflow_action }}
   </buffer>
   logstash_format true
   reload_connections false

--- a/incubator/fluentd/files/elasticsearch.conf
+++ b/incubator/fluentd/files/elasticsearch.conf
@@ -5,18 +5,18 @@
 
   flatten_hashes true
   flatten_hashes_separator _
-
-  buffer_type memory
-  buffer_chunk_limit {{ .Values.elasticsearch.buffer_chunk_limit }}
-  buffer_queue_limit {{ .Values.elasticsearch.buffer_queue_limit }}
-  flush_interval {{ .Values.elasticsearch.flush_interval }}
-  num_threads {{ .Values.elasticsearch.num_threads }}
-  disable_retry_limit
-  retry_wait 1s
-  max_retry_wait 60s
-  request_timeout {{ .Values.elasticsearch.request_timeout }}
-  buffer_queue_full_action {{ .Values.elasticsearch.buffer_queue_full_action }}
-
+  <buffer>
+    @type memory
+    chunk_limit_size {{ .Values.elasticsearch.chunk_limit_size }}
+    chunk_limit_records {{ .Values.elasticsearch.chunk_limit_records }}
+    flush_interval {{ .Values.elasticsearch.flush_interval }}
+    flush_thread_count {{ .Values.elasticsearch.flush_thread_count }}
+    retry_forever
+    retry_wait 1s
+    retry_max_interval 60s
+    retry_timeout {{ .Values.elasticsearch.retry_timeout }}
+    overflow_action {{ .Values.elasticsearch.buffer_queue_full_action }}
+  </buffer>
   logstash_format true
   reload_connections false
 

--- a/incubator/fluentd/files/kubernetes.conf
+++ b/incubator/fluentd/files/kubernetes.conf
@@ -10,6 +10,7 @@
   tag kubernetes.*
   read_from_head true
   <parse>
+    @type tail
     format json
     time_format %Y-%m-%dT%H:%M:%S.%NZ
   </parse>
@@ -22,6 +23,7 @@
   pos_file /var/log/fluentd-etcd.log.pos
   tag etcd
   <parse>
+    @type tail
     format none
   </parse>
 </source>
@@ -34,6 +36,7 @@
   pos_file /var/log/fluentd-kube-proxy.log.pos
   tag kube-proxy
   <parse>
+    @type tail
     format kubernetes
   </parse>
 </source>
@@ -46,6 +49,7 @@
   pos_file /var/log/fluentd-kube-apiserver.log.pos
   tag kube-apiserver
   <parse>
+    @type tail
     format kubernetes
   </parse>
 </source>
@@ -58,6 +62,7 @@
   pos_file /var/log/fluentd-kube-controller-manager.log.pos
   tag kube-controller-manager
   <parse>
+    @type tail
     format kubernetes
   </parse>
 </source>
@@ -70,6 +75,7 @@
   pos_file /var/log/fluentd-kube-scheduler.log.pos
   tag kube-scheduler
   <parse>
+    @type tail
     format kubernetes
   </parse>
 </source>

--- a/incubator/fluentd/files/kubernetes.conf
+++ b/incubator/fluentd/files/kubernetes.conf
@@ -85,6 +85,7 @@
   pos_file /var/log/fluentd-kube-apiserver-audit.log.pos
   tag kube-apiserver-audit
   <parse>
+    @type tail
     format json
   </parse>
 </source>

--- a/incubator/fluentd/files/kubernetes.conf
+++ b/incubator/fluentd/files/kubernetes.conf
@@ -10,8 +10,7 @@
   tag kubernetes.*
   read_from_head true
   <parse>
-    @type tail
-    format json
+    @type json
     time_format %Y-%m-%dT%H:%M:%S.%NZ
   </parse>
 </source>
@@ -23,8 +22,7 @@
   pos_file /var/log/fluentd-etcd.log.pos
   tag etcd
   <parse>
-    @type tail
-    format none
+    @type none
   </parse>
 </source>
 
@@ -36,8 +34,7 @@
   pos_file /var/log/fluentd-kube-proxy.log.pos
   tag kube-proxy
   <parse>
-    @type tail
-    format kubernetes
+    @type json
   </parse>
 </source>
 
@@ -49,8 +46,7 @@
   pos_file /var/log/fluentd-kube-apiserver.log.pos
   tag kube-apiserver
   <parse>
-    @type tail
-    format kubernetes
+    @type json
   </parse>
 </source>
 
@@ -62,8 +58,7 @@
   pos_file /var/log/fluentd-kube-controller-manager.log.pos
   tag kube-controller-manager
   <parse>
-    @type tail
-    format kubernetes
+    @type json
   </parse>
 </source>
 
@@ -75,8 +70,7 @@
   pos_file /var/log/fluentd-kube-scheduler.log.pos
   tag kube-scheduler
   <parse>
-    @type tail
-    format kubernetes
+    @type json
   </parse>
 </source>
 
@@ -91,8 +85,7 @@
   pos_file /var/log/fluentd-kube-apiserver-audit.log.pos
   tag kube-apiserver-audit
   <parse>
-    @type tail
-    format json
+    @type json
   </parse>
 </source>
 

--- a/incubator/fluentd/files/kubernetes.conf
+++ b/incubator/fluentd/files/kubernetes.conf
@@ -9,8 +9,10 @@
   pos_file /var/log/fluentd-containers.log.pos
   tag kubernetes.*
   read_from_head true
-  format json
-  time_format %Y-%m-%dT%H:%M:%S.%NZ
+  <parse>
+    format json
+    time_format %Y-%m-%dT%H:%M:%S.%NZ
+  </parse>
 </source>
 
 <source>
@@ -19,7 +21,9 @@
   path /var/log/etcd.log
   pos_file /var/log/fluentd-etcd.log.pos
   tag etcd
-  format none
+  <parse>
+    format none
+  </parse>
 </source>
 
 <source>
@@ -29,7 +33,9 @@
   path /var/log/kube-proxy.log
   pos_file /var/log/fluentd-kube-proxy.log.pos
   tag kube-proxy
-  format kubernetes
+  <parse>
+    format kubernetes
+  </parse>
 </source>
 
 <source>
@@ -39,7 +45,9 @@
   path /var/log/kube-apiserver.log
   pos_file /var/log/fluentd-kube-apiserver.log.pos
   tag kube-apiserver
-  format kubernetes
+  <parse>
+    format kubernetes
+  </parse>
 </source>
 
 <source>
@@ -49,7 +57,9 @@
   path /var/log/kube-controller-manager.log
   pos_file /var/log/fluentd-kube-controller-manager.log.pos
   tag kube-controller-manager
-  format kubernetes
+  <parse>
+    format kubernetes
+  </parse>
 </source>
 
 <source>
@@ -59,7 +69,9 @@
   path /var/log/kube-scheduler.log
   pos_file /var/log/fluentd-kube-scheduler.log.pos
   tag kube-scheduler
-  format kubernetes
+  <parse>
+    format kubernetes
+  </parse>
 </source>
 
 # Example:
@@ -72,7 +84,9 @@
   path {{ .Values.kubernetes_audit_log_path }}
   pos_file /var/log/fluentd-kube-apiserver-audit.log.pos
   tag kube-apiserver-audit
-  format json
+  <parse>
+    format json
+  </parse>
 </source>
 
 <filter kube-apiserver-audit>

--- a/incubator/fluentd/files/papertrail.conf
+++ b/incubator/fluentd/files/papertrail.conf
@@ -29,9 +29,11 @@
 <match **>
   @type papertrail
   @id out_papertrail
-  num_threads 4
-  buffer_type    file
-  buffer_path    /var/log/fluentd-buffers-papertrail/fluentd-buffer
+  <buffer>
+    @type    file
+    path    /var/log/fluentd-buffers-papertrail/fluentd-buffer
+    flush_thread_count 4
+  </buffer>
   papertrail_host "{{ .Values.papertrail.host }}"
   papertrail_port "{{ .Values.papertrail.port }}"
 </match>

--- a/incubator/fluentd/files/papertrail.conf
+++ b/incubator/fluentd/files/papertrail.conf
@@ -32,7 +32,7 @@
   <buffer>
     @type    file
     path    /var/log/fluentd-buffers-papertrail/fluentd-buffer
-    flush_thread_count 4
+    flush_thread_count {{ .Values.papertrail.flush_thread_count }}
   </buffer>
   papertrail_host "{{ .Values.papertrail.host }}"
   papertrail_port "{{ .Values.papertrail.port }}"

--- a/incubator/fluentd/templates/daemonset.yaml
+++ b/incubator/fluentd/templates/daemonset.yaml
@@ -66,7 +66,7 @@ spec:
           - --gemfile
           - /fluentd/Gemfile
           - --no-supervisor
-          {{- range .Values.elasticsearch.extraArgs }}
+          {{- range .Values.pluginExtraArgs }}
           - {{ . | quote }}
           {{- end }}
         env:

--- a/incubator/fluentd/values.yaml
+++ b/incubator/fluentd/values.yaml
@@ -3,7 +3,7 @@
 #########################
 image:
   repository: fluent/fluentd-kubernetes-daemonset
-  tag: v0.12.43-debian-elasticsearch
+  tag: v1.4.2-debian-elasticsearch-1.1
   pullPolicy: Always
 
 elasticsearch:
@@ -11,15 +11,14 @@ elasticsearch:
   host: instance-name.region.es.amazonaws.com
   port: 443
   scheme: https
-  extraArgs: []
   # This is set low to accomodate m4.large ES clusters that have a 10m client body limit
-  buffer_chunk_limit: 5m
+  chunk_limit_size: 5m
   # buffer_queue_limit * buffer_chunk_limit ~= total memory usage for the buffer
-  buffer_queue_limit: 100
+  chunk_limit_records: 100
   flush_interval: 5s
-  num_threads: 4
-  request_timeout: 20s
-  buffer_queue_full_action: exception
+  flush_thread_count: 4
+  retry_timeout: 20s
+  overflow_action: throw_exception
 
 ######################
 ##    Papertrail    ##
@@ -33,12 +32,15 @@ papertrail:
   enabled: false
   host: logs3.papertrailapp.com
   port: 12785
-  extraArgs: []
 
 
 #####################
 ## Shared Settings ##
 #####################
+
+
+#plugin command extra args
+pluginExtraArgs: []
 
 # Verify Kubernetes API TLS certs
 # set to false if you're running in a cluster on alibaba or other places with api cert issues

--- a/incubator/fluentd/values.yaml
+++ b/incubator/fluentd/values.yaml
@@ -25,13 +25,14 @@ elasticsearch:
 ######################
 # image:
 #   repository: fluent/fluentd-kubernetes-daemonset
-#   tag: v0.12.43-debian-papertrail
+#   tag: v1.4.2-debian-papertrail-1.1
 #   pullPolicy: IfNotPresent
 #
 papertrail:
   enabled: false
   host: logs3.papertrailapp.com
   port: 12785
+  flush_thread_count: 4
 
 
 #####################


### PR DESCRIPTION
The API has changed. See: https://docs.fluentd.org/quickstart/update-from-v0.12
Might as well bite the bullet and migrated the chart to the new version. Breaking change as I renamed some values.
