### PR TITLE
Rename ReactiveOps to Fairwinds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
       - run:
           name: lint
           command: |
-            git remote add ro https://github.com/reactiveops/charts
+            git remote add ro https://github.com/FairwindsOps/charts
             git fetch ro master
             ct lint --config scripts/ct.yaml  --chart-yaml-schema scripts/schema.yaml
   e2e-tests:

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2017, Reactive Ops Inc.
+   Copyright 2017, FairwindsOps Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/incubator/autospotting/README.md
+++ b/incubator/autospotting/README.md
@@ -6,7 +6,7 @@ This chart will do the following:
 
 ## Container
 
-This version of the autospotting container is built and maintained by ReactiveOps in [reactiveops/autospotting-ci](https://github.com/reactiveops/autospotting-ci).  The appVersion and the container tag correspond to tags on that repository.
+This version of the autospotting container is built and maintained by Fairwinds in [fairwinds/autospotting-ci](https://github.com/FairwindsOps/autospotting-ci).  The appVersion and the container tag correspond to tags on that repository.
 
 ## Configuration
 | Parameter               | Description                           | Default                                                    |
@@ -41,7 +41,7 @@ This version of the autospotting container is built and maintained by ReactiveOp
 charts:
   autospotting:
     repository:
-      git: https://github.com/reactiveops/autospotting-ci.git
+      git: https://github.com/FairwindsOps/autospotting-ci.git
     chart: chart
     namespace: default
     values:

--- a/incubator/basic-demo/README.md
+++ b/incubator/basic-demo/README.md
@@ -9,7 +9,7 @@ Credit for the app goes to [ehazlett](https://github.com/ehazlett/docker-demo)
 | Parameter | Description | Default | Required |
 | --------- | ----------- | ------- | -------- |
 | `affinity` | Pod Affinity  | `{}` | no |
-| `demo.metadata` | Flavor text on demo app page  | `ehazlett/docker-demo - Chart by ReactiveOps` | |
+| `demo.metadata` | Flavor text on demo app page  | `ehazlett/docker-demo - Chart by Fairwinds` | |
 | `demo.refreshInterval` | How often the demo frontend should refresh (ms)  | `500` | yes |
 | `demo.title` | Title on the demo app page | `Kuberneteseckoner Demo` | no |
 | `hpa.max` | Maximum replicas  | `20` | yes |

--- a/incubator/ro-cert-manager/README.md
+++ b/incubator/ro-cert-manager/README.md
@@ -10,7 +10,7 @@ When this chart is installed too quickly after versions 0.6+ of the cert-manager
 
 Until this chart is updated to address this issue, we recommend setting `cert-manager.enabled` to `false` for this chart, and installing the cert-manager chart separately. Allow one minute for the cert-manager webhook to initialize before installing this chart.
 
-For discussion and updates, see [this issue](https://github.com/reactiveops/charts/issues/97).
+For discussion and updates, see [this issue](https://github.com/FairwindsOps/charts/issues/97).
 
 ## Configuration
 

--- a/incubator/route53sync/README.md
+++ b/incubator/route53sync/README.md
@@ -17,4 +17,4 @@ The following table lists the configurable parameters of the route53sync chart a
 | `sync.source_zone_id` | The Route53 Zone ID of the source | `''` | yes |
 | `sync.dest_zone_id` | The Route53 Zone ID of the destination | `''` | yes |
 | `sync.check_dest_tag` | Whether or not the script should verify a tag on the destination zone. | `"False"` | no |
-| `sync.dest_tag` | If sync.check_dest_tag is True, this tag will be required on the destination zone in order to run the sync. | `"Author:ReactiveOps"` | no |
+| `sync.dest_tag` | If sync.check_dest_tag is True, this tag will be required on the destination zone in order to run the sync. | `"Author:Fairwinds"` | no |

--- a/incubator/route53sync/values.yaml
+++ b/incubator/route53sync/values.yaml
@@ -12,7 +12,7 @@ sync:
   source_zone_id: ''
   dest_zone_id: ''
   check_dest_tag: "False"
-  dest_tag: "Author:ReactiveOps"
+  dest_tag: "Author:Fairwinds"
 
 nodeSelector: {}
 

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2018 ReactiveOps. All rights reserved.
+# Copyright 2018 FairwindsOps Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -89,7 +89,7 @@ prep_tests () {
 
     docker exec "$EXEC_CONTAINER_NAME" sh -c 'helm version'
 
-    docker exec "$EXEC_CONTAINER_NAME" sh -c 'git clone https://github.com/reactiveops/charts && cd charts && git remote add ro https://github.com/reactiveops/charts  &> /dev/null || true'
+    docker exec "$EXEC_CONTAINER_NAME" sh -c 'git clone https://github.com/FairwindsOps/charts && cd charts && git remote add ro https://github.com/FairwindsOps/charts  &> /dev/null || true'
     docker exec "$EXEC_CONTAINER_NAME" sh -c 'cd charts && git fetch ro master'
     if [ -z "${CIRCLE_PR_NUMBER:-}" ]; then
         docker exec "$EXEC_CONTAINER_NAME" sh -c "cd charts && git checkout $CI_REF"
@@ -107,7 +107,7 @@ prep_tests_local () {
 
     docker exec "$EXEC_CONTAINER_NAME" sh -c 'helm version'
     docker cp . "$EXEC_CONTAINER_NAME":/workdir/charts/
-    docker exec "$EXEC_CONTAINER_NAME" sh -c 'cd charts && git remote | xargs -n 1 git remote remove && git remote add ro https://github.com/reactiveops/charts && git fetch ro master'
+    docker exec "$EXEC_CONTAINER_NAME" sh -c 'cd charts && git remote | xargs -n 1 git remote remove && git remote add ro https://github.com/FairwindsOps/charts && git fetch ro master'
 }
 
 

--- a/scripts/repo-sync.sh
+++ b/scripts/repo-sync.sh
@@ -20,10 +20,10 @@ set -o pipefail
 
 readonly HELM_URL=https://storage.googleapis.com/kubernetes-helm
 readonly HELM_TARBALL=helm-v2.12.3-linux-amd64.tar.gz
-readonly STABLE_REPO_URL=https://charts.reactiveops.com/stable/
-readonly INCUBATOR_REPO_URL=https://charts.reactiveops.com/incubator/
-readonly S3_BUCKET_STABLE=s3://charts.reactiveops.com/stable
-readonly S3_BUCKET_INCUBATOR=s3://charts.reactiveops.com/incubator
+readonly STABLE_REPO_URL=https://charts.fairwinds.com/stable/
+readonly INCUBATOR_REPO_URL=https://charts.fairwinds.com/incubator/
+readonly S3_BUCKET_STABLE=s3://charts.fairwinds.com/stable
+readonly S3_BUCKET_INCUBATOR=s3://charts.fairwinds.com/incubator
 
 main() {
     setup_helm_client
@@ -46,8 +46,8 @@ setup_helm_client() {
     PATH="$(pwd)/linux-amd64/:$PATH"
 
     helm init --client-only
-    helm repo add reactiveops-stable "$STABLE_REPO_URL"
-    helm repo add reactiveops-incubator "$INCUBATOR_REPO_URL"
+    helm repo add fairwinds-stable "$STABLE_REPO_URL"
+    helm repo add fairwinds-incubator "$INCUBATOR_REPO_URL"
 }
 
 authenticate() {

--- a/stable/polaris/README.md
+++ b/stable/polaris/README.md
@@ -1,6 +1,6 @@
 # Polaris
 
-[Polaris](https://github.com/reactiveops/polaris)
+[Polaris](https://github.com/FairwindsOps/polaris)
 is a tool for auditing and enforcing best practices in Kubernetes.
 
 ## Installation
@@ -8,21 +8,21 @@ We recommend installing polaris in its own namespace.
 
 ### Dashboard
 ```
-helm repo add reactiveops-stable https://charts.reactiveops.com/stable
-helm install reactiveops-stable/polaris --name polaris --namespace polaris
+helm repo add fairwinds-stable https://charts.fairwinds.com/stable
+helm install fairwinds-stable/polaris --name polaris --namespace polaris
 ```
 
 ### Webhook
 ```
-helm repo add reactiveops-stable https://charts.reactiveops.com/stable
-helm install reactiveops-stable/polaris --name polaris --namespace polaris --set webhook.enable=true --set dashboard.enable=false
+helm repo add fairwinds-stable https://charts.fairwinds.com/stable
+helm install fairwinds-stable/polaris --name polaris --namespace polaris --set webhook.enable=true --set dashboard.enable=false
 ```
 
 
 ## Configuration
 Parameter | Description | Default
 --------- | ----------- | -------
-`config`  | The [polaris configuration](https://github.com/reactiveops/polaris#configuration) | see values.yaml
+`config`  | The [polaris configuration](https://github.com/FairwindsOps/polaris#configuration) | see values.yaml
 `dashboard.enable` | Whether to run the dashboard | true
 `dashboard.replicas` | Number of replicas | 1
 `dashboard.service.type` | Service type | ClusterIP

--- a/stable/rbac-manager/Chart.yaml
+++ b/stable/rbac-manager/Chart.yaml
@@ -5,9 +5,9 @@ description: A Kubernetes operator that simplifies the management of Role Bindin
 keywords:
   - rbac
   - authorization
-home: https://reactiveops.github.io/rbac-manager/
+home: https://fairwinds.github.io/rbac-manager/
 sources:
-  - https://github.com/reactiveops/rbac-manager
+  - https://github.com/FairwindsOps/rbac-manager
 maintainers:
   - name: ejether
     email: ej@fairwinds.com

--- a/stable/rbac-manager/README.md
+++ b/stable/rbac-manager/README.md
@@ -1,6 +1,6 @@
 # RBAC Manager
 
-[RBAC Manager](https://reactiveops.github.io/rbac-manager/) was designed to simplify authorization in Kubernetes. This is an operator that supports declarative configuration for RBAC with new custom resources. Instead of managing role bindings or service accounts directly, you can specify a desired state and RBAC Manager will make the necessary changes to achieve that state.
+[RBAC Manager](https://fairwinds.github.io/rbac-manager/) was designed to simplify authorization in Kubernetes. This is an operator that supports declarative configuration for RBAC with new custom resources. Instead of managing role bindings or service accounts directly, you can specify a desired state and RBAC Manager will make the necessary changes to achieve that state.
 
 This project has three main goals:
 
@@ -8,15 +8,15 @@ This project has three main goals:
 2. Reduce the amount of configuration required for great auth.
 3. Enable automation of RBAC configuration updates with CI/CD.
 
-More information about RBAC Manager is available on [GitHub](https://github.com/reactiveops/rbac-manager) as well as from the [official documentation](https://reactiveops.github.io/rbac-manager/).
+More information about RBAC Manager is available on [GitHub](https://github.com/FairwindsOps/rbac-manager) as well as from the [official documentation](https://fairwinds.github.io/rbac-manager/).
 
 ## Installation
 
 We recommend installing rbac-manager in its own namespace and a simple release name:
 
 ```
-helm repo add reactiveops-stable https://charts.reactiveops.com/stable
-helm install reactiveops-stable/rbac-manager --name rbac-manager --namespace rbac-manager
+helm repo add fairwinds-stable https://charts.fairwinds.com/stable
+helm install fairwinds-stable/rbac-manager --name rbac-manager --namespace rbac-manager
 ```
 
 ## Prerequisites
@@ -53,9 +53,9 @@ If either of the following apply and you are upgrading from an earlier version o
 
 The following process has worked repeatedly for us to upgrade from an older version of this chart to 1.0.0. These steps worked with Helm and Tiller 2.12.3 for us, but due to the absurdity of this process, we can't guarantee it will work for you.
 
-1. Install rbac-manager with chart that uses install-crd hook (reactiveops-stable/rbac-manager@0.2.1)
-2. Upgrade to rbac-manager chart that doesn't use install-crd hook (reactiveops-stable/rbac-manager@1.0.0) - this upgrade fails but is important later
-3. Upgrade to original rbac-manager chart that uses install-crd hook (reactiveops-stable/rbac-manager@0.2.1) - this works
+1. Install rbac-manager with chart that uses install-crd hook (fairwinds-stable/rbac-manager@0.2.1)
+2. Upgrade to rbac-manager chart that doesn't use install-crd hook (fairwinds-stable/rbac-manager@1.0.0) - this upgrade fails but is important later
+3. Upgrade to original rbac-manager chart that uses install-crd hook (fairwinds-stable/rbac-manager@0.2.1) - this works
 4. Rollback to revision 2 - this fails
 5. Rollback to revision 2 - this works
 

--- a/stable/rbac-manager/templates/NOTES.txt
+++ b/stable/rbac-manager/templates/NOTES.txt
@@ -1,7 +1,7 @@
 Thanks for installing RBAC Manager! To see what it's doing, use `kubectl logs` for your new RBAC Manager pod.
 
-If you haven't already installed an RBAC Definition to configure your authorization, visit https://reactiveops.github.io/rbac-manager/rbacdefinitions.html for more information.
+If you haven't already installed an RBAC Definition to configure your authorization, visit https://fairwinds.github.io/rbac-manager/rbacdefinitions.html for more information.
 
-For more information on integrating RBAC with common authentication patterns, visit https://reactiveops.github.io/rbac-manager/.
+For more information on integrating RBAC with common authentication patterns, visit https://fairwinds.github.io/rbac-manager/.
 
-If you run into any problems or find something missing in the documentation, don't hesitate to open an issue here: https://github.com/reactiveops/rbac-manager/issues.
+If you run into any problems or find something missing in the documentation, don't hesitate to open an issue here: https://github.com/FairwindsOps/rbac-manager/issues.


### PR DESCRIPTION
Remaining mentions: 
```
./stable/polaris/values.yaml:    repository: quay.io/reactiveops/polaris
./stable/polaris/values.yaml:    repository: quay.io/reactiveops/polaris
./stable/polaris/values.yaml:    repository: quay.io/reactiveops/polaris
./stable/polaris/README.md:`dashboard.image.repository` | Image repo | quay.io/reactiveops/polaris
./stable/polaris/README.md:`webhook.image.repository` | Image repo | quay.io/reactiveops/polaris
./stable/polaris/README.md:`audit.image.repository` | Image repo | quay.io/reactiveops/polaris
./stable/rbac-manager/values.yaml:  repository: quay.io/reactiveops/rbac-manager
./stable/rbac-manager/templates/customresourcedefinition.yaml:  name: rbacdefinitions.rbacmanager.reactiveops.io
./stable/rbac-manager/templates/customresourcedefinition.yaml:  group: rbacmanager.reactiveops.io
./stable/rbac-manager/templates/clusterrole.yaml:      - rbacmanager.reactiveops.io
./stable/rbac-manager/README.md:| `image.repository`          | Docker image repo        | `quay.io/reactiveops/rbac-manager` |
./incubator/kubebench/values.yaml:    repository: quay.io/reactiveops/kubebench-exporter
./incubator/kubebench/readme.md:| exporter.image.repository | docker repo for the exporter that exports the results to datadog | quay.io/reactiveops/kubebench-exporter |
./incubator/opa/templates/ca-updater-cronjob.yaml:            image: quay.io/reactiveops/ci-images:v8-alpine
./incubator/opa/templates/ca-updater-hook.yaml:        image: quay.io/reactiveops/ci-images:v8-alpine
./incubator/opa/templates/tests/check-custom-policy.yaml:    image: quay.io/reactiveops/ci-images:v8-alpine
./incubator/opa/templates/tests/check-default-policy.yaml:    image: quay.io/reactiveops/ci-images:v8-alpine
./incubator/opa/templates/selfsigned-hook.yaml:        image: quay.io/reactiveops/ci-images:v8-alpine
./incubator/autospotting/values.yaml:image: quay.io/reactiveops/autospotting:1.0.0
./incubator/autospotting/README.md:| `image`                 | uri to pull the image from            | `quay.io/reactiveops/autospotting:1.0.0`                   |
./incubator/autospotting/README.md:      image: quay.io/reactiveops/autospotting:0.1.3
./incubator/helm-release-pruner/values.yaml:  repository: quay.io/reactiveops/ci-images
./incubator/helm-release-pruner/templates/rbac.yml:apiVersion: rbacmanager.reactiveops.io/v1beta1
```