### PR TITLE
remove quotes around audit URL

### DIFF
--- a/stable/polaris/Chart.yaml
+++ b/stable/polaris/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Validation of best practices in your Kubernetes clusters
 name: polaris
-version: "0.5.0"
+version: "0.5.1"
 appVersion: "0.4"
 maintainers:
   - name: bobby-brennan

--- a/stable/polaris/templates/audit.job.yaml
+++ b/stable/polaris/templates/audit.job.yaml
@@ -21,7 +21,7 @@ spec:
         - polaris
         - --audit
         - --output-url
-        - "{{ required "Must set audit.outputURL in values if you enable the audit job." .Values.audit.outputURL }}"
+        - {{ required "Must set audit.outputURL in values if you enable the audit job." .Values.audit.outputURL }}
         - --output-file
         - /tmp/results/done
         - --config


### PR DESCRIPTION
This field needs to get set with `--set 'audit.outputURL="{{ .host }}/session/{{ .sessionID }}/data"'`. Unfortunately I can't make that work as-is.

Any ideas on a better solution?