### PR TITLE
fix: home and source URLs in the Chart.yaml

### DIFF
--- a/stable/rbac-manager/Chart.yaml
+++ b/stable/rbac-manager/Chart.yaml
@@ -1,5 +1,5 @@
 name: rbac-manager
-version: 1.3.0
+version: 1.3.1
 appVersion: 0.7.0
 description: A Kubernetes operator that simplifies the management of Role Bindings and Service Accounts.
 keywords:

--- a/stable/rbac-manager/Chart.yaml
+++ b/stable/rbac-manager/Chart.yaml
@@ -5,9 +5,10 @@ description: A Kubernetes operator that simplifies the management of Role Bindin
 keywords:
   - rbac
   - authorization
-home: https://reactiveops.github.io/rbac-manager/
+home: https://fairwindsops.github.io/rbac-manager/
 sources:
-  - https://github.com/reactiveops/rbac-manager
+  - https://github.com/FairwindsOps/charts/tree/master/stable/rbac-manager
+  - https://github.com/FairwindsOps/rbac-manager
 maintainers:
   - name: ejether
     email: ej@fairwinds.com


### PR DESCRIPTION
This is intended to fix the links shown for the chart on https://hub.helm.sh/charts/reactiveops-stable/rbac-manager