### PR TITLE
Fixing permissions for goldilocks dashboard

### DIFF
--- a/incubator/goldilocks/Chart.yaml
+++ b/incubator/goldilocks/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.2.3"
 description: A Helm chart for running Fairwinds Goldilocks
 name: goldilocks
-version: 0.1.1
+version: 0.1.2
 maintainers:
   - name: sudermanjr
   - name: dosullivan

--- a/incubator/goldilocks/templates/dashboard-clusterrole.yaml
+++ b/incubator/goldilocks/templates/dashboard-clusterrole.yaml
@@ -17,4 +17,12 @@ rules:
     verbs:
       - 'get'
       - 'list'
+  - apiGroups:
+      - 'apps'
+      - 'extensions'
+    resources:
+      - 'deployments'
+    verbs:
+      - 'get'
+      - 'list'
 {{- end }}


### PR DESCRIPTION
The dashboard didn't have permissions to view deployments, which is what allows it to see existing resource requests/limits as well as see the container names.  

This will give the dashboard those permissions