### PR TITLE
Add quotations around helm-release-pruner schedules

### DIFF
--- a/incubator/helm-release-pruner/Chart.yaml
+++ b/incubator/helm-release-pruner/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: 1.0.0
 description: This charts launches a cronjob to purge stale Helm releases and associated namespaces
 name: helm-release-pruner
-version: 1.2.0
+version: 1.2.1
 maintainers:
   - name: coreypobrien

--- a/incubator/helm-release-pruner/templates/cronjob.yml
+++ b/incubator/helm-release-pruner/templates/cronjob.yml
@@ -8,7 +8,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  schedule: {{ .Values.job.schedule }}
+  schedule: {{ .Values.job.schedule | quote }}
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 300
   jobTemplate:


### PR DESCRIPTION
I added quotations around the helm-release-pruner schedule.  Without this schedules that don't start with a number cause the chart install to fail with an error like this:

```
[yaml: line 73: did not find expected alphabetic or numeric character, [invalid character 'a' lo    oking for beginning of value, invalid character 'a' looking for beginning of value]]
```
