### PR TITLE
Fix to letsencrypt-setup README documentation

### DIFF
--- a/incubator/letsencrypt-setup/Chart.yaml
+++ b/incubator/letsencrypt-setup/Chart.yaml
@@ -1,6 +1,6 @@
 name: letsencrypt-setup
 apiVersion: v1
-version: v1.0.0
+version: v1.0.1
 appVersion: v0.8.1
 description: Setup clusterIssuers for cert-manager
 maintainers:

--- a/incubator/letsencrypt-setup/README.md
+++ b/incubator/letsencrypt-setup/README.md
@@ -45,6 +45,7 @@ The following table lists the configurable parameters of the chart and their def
 | `project` | Name of the project in Google Cloud where Cloud DNS is used |
 | `secretName` | optional kubernetes secret name in same namespace |
 | `secretKey` | key in the kubernetes secret with the service account creds |
+| `type` | Defines the type of DNS solver, should be set to `clouddns` |
 
 ### Cloudflare
 
@@ -53,6 +54,7 @@ The following table lists the configurable parameters of the chart and their def
 | `email` | Email associated with the Cloudflare account |
 | `secretName` | Name of kubernetes secret that contains the secret access key |
 | `secretKey` | Key within a kubernetes secret data block that holds the secret access key |
+| `type` | Defines the type of DNS solver, should be set to `cloudflare` |
 
 ## Selector Settings
 


### PR DESCRIPTION
Adding 'type' settings documentation for clouddns and cloudflare in letsencrypt-setup chart README