### PR TITLE
Update deployment api version and image tag

### DIFF
--- a/stable/rbac-manager/Chart.yaml
+++ b/stable/rbac-manager/Chart.yaml
@@ -1,6 +1,6 @@
 name: rbac-manager
-version: 1.3.1
-appVersion: 0.7.0
+version: 1.3.2
+appVersion: 0.8.3
 description: A Kubernetes operator that simplifies the management of Role Bindings and Service Accounts.
 keywords:
   - rbac

--- a/stable/rbac-manager/templates/deployment.yaml
+++ b/stable/rbac-manager/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "rbac-manager.fullname" . }}

--- a/stable/rbac-manager/values.yaml
+++ b/stable/rbac-manager/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: quay.io/reactiveops/rbac-manager
-  tag: 0.7.0
+  tag: 0.8.3
   pullPolicy: Always
 
 resources:


### PR DESCRIPTION
I updated the rbac-manager helm chart's image version and set the deployment to use `apps/v1` as `extensions/v1beta1` will be deprecated in future kubernetes versions.  This PR brings the chart up to the same format as described in https://github.com/FairwindsOps/rbac-manager/pull/80