### PR TITLE
set ingressClass in default values

### DIFF
--- a/incubator/letsencrypt-setup/Chart.yaml
+++ b/incubator/letsencrypt-setup/Chart.yaml
@@ -1,6 +1,6 @@
 name: letsencrypt-setup
 apiVersion: v1
-version: v1.1.0
+version: v1.1.1
 appVersion: v0.9.1
 description: Setup clusterIssuers for cert-manager
 maintainers:

--- a/incubator/letsencrypt-setup/README.md
+++ b/incubator/letsencrypt-setup/README.md
@@ -21,7 +21,7 @@ The following table lists the configurable parameters of the chart and their def
 | `clusterIssuers.primary.issuerUrl` | The URL to use for ACME | `https://acme-v02.api.letsencrypt.org/directory` | yes |
 | `clusterIssuers.primary.email` | The email used for ACME registration | `someone@example.com` | yes |
 | `clusterIssuers.primary.solvers.http.enabled` | Enables http01 validation on primary issuer | `false` | yes |
-| `clusterIssuers.primary.solvers.http.ingressClass` | Use http01 solver with a specific ingress class | `""` | no |
+| `clusterIssuers.primary.solvers.http.ingressClass` | Use http01 solver with a specific ingress class | `nginx` | no |
 | `clusterIssuers.primary.solvers.http.ingressName` | Use this solver with a specific ingress name | `""` | no |
 | `clusterIssuers.primary.solvers.dns` | List of DNS solvers and optional selectors for each. See below for configuration | `[]` | no |
 

--- a/incubator/letsencrypt-setup/values.yaml
+++ b/incubator/letsencrypt-setup/values.yaml
@@ -5,7 +5,7 @@ clusterIssuers:
     solvers:
       http:
         enabled: false
-        # ingressClass: nginx
+        ingressClass: nginx
         # ingressName: ""
       # dns:
       # - type: route53


### PR DESCRIPTION
I set the `ingressClass` to `nginx` in values.yml.  When this is not set and the http solver is enabled the ingress object in the issuer gets set to `null`, causing cert-manager to fail on every http01 validation:
```
cert-manager  Error presenting challenge: challenge's 'solver' field is specified but no HTTP01 ingress config provided. Ensure solvers[].http01.ingress is specified on your issuer resource
```
Setting this to `nginx` by default will allow the http01 solver to work out of the box with the default ingress class setting for nginx-ingress.