### PR TITLE
Disable both ES and papertrail fluentd plugins by default

### DIFF
--- a/incubator/fluentd/Chart.yaml
+++ b/incubator/fluentd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.12.43"
 description: Fluentd for multiple endpoints
 name: fluentd
-version: 4.0.0
+version: 4.0.1
 maintainers:
   - name: dosullivan
   - name: coreypobrien

--- a/incubator/fluentd/Chart.yaml
+++ b/incubator/fluentd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.12.43"
 description: Fluentd for multiple endpoints
 name: fluentd
-version: 4.0.1
+version: 4.0.2
 maintainers:
   - name: dosullivan
   - name: coreypobrien

--- a/incubator/fluentd/README.md
+++ b/incubator/fluentd/README.md
@@ -12,7 +12,7 @@ Switching backends requires using a matching image as well as some backend-speci
 | --------- | ------- |
 | `image.repository` | `fluent/fluentd-kubernetes-daemonset` |
 | `image.tag` | `v1.4.2-debian-elasticsearch-1.1` |
-| `elasticsearch.enabled` |  `true` |
+| `elasticsearch.enabled` |  `false` |
 | `elasticsearch.host` | `instance-name.region.es.amazonaws.com` |
 | `elasticsearch.port` | `443` |
 | `elasticsearch.scheme` | `https` |
@@ -30,7 +30,7 @@ Switching backends requires using a matching image as well as some backend-speci
 | --------- | ------- |
 | `image.repository` | `fluent/fluentd-kubernetes-daemonset` |
 | `image.tag` | `v1.4.2-debian-papertrail-1.1` |
-| `papertrail.enabled` | `true` |
+| `papertrail.enabled` | `false` |
 | `papertrail.host` | `logs3.papertrailapp.com` |
 | `papertrail.port` | `12785` |
 | `papertrail.flush_thread_count` | `4` |

--- a/incubator/fluentd/README.md
+++ b/incubator/fluentd/README.md
@@ -1,6 +1,6 @@
 # Fluentd
 
-Deploys fluentd daemonset with defaults for various backends.
+Deploys fluentd daemonset with defaults for various backends. Note that you need to specifically choose to enable Elasticsearch or Papertrail plugins via `elasticsearch.enabled` or `papertrail.enabled`. See options below for details.
 
 ## Backend images
 

--- a/incubator/fluentd/values.yaml
+++ b/incubator/fluentd/values.yaml
@@ -40,7 +40,7 @@ papertrail:
 #####################
 
 
-#plugin command extra args
+# plugin command extra args
 pluginExtraArgs: []
 
 # Verify Kubernetes API TLS certs

--- a/incubator/fluentd/values.yaml
+++ b/incubator/fluentd/values.yaml
@@ -7,7 +7,7 @@ image:
   pullPolicy: Always
 
 elasticsearch:
-  enabled: true
+  enabled: false
   host: instance-name.region.es.amazonaws.com
   port: 443
   scheme: https


### PR DESCRIPTION
I think it's a slightly-more-user-friendly behavior to make the user specifically choose the plugin they want enabled by default (be it papertrail or elasticsearch). 