### PR TITLE
Add a basePath value which passes --base-path arg to the dashboard container

### DIFF
--- a/stable/goldilocks/Chart.yaml
+++ b/stable/goldilocks/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v2.0.0"
 description: A Helm chart for running Fairwinds Goldilocks
 name: goldilocks
-version: 1.0.0
+version: 1.0.1
 icon: https://github.com/FairwindsOps/charts/raw/master/stable/goldilocks/icon.svg
 maintainers:
   - name: sudermanjr

--- a/stable/goldilocks/README.md
+++ b/stable/goldilocks/README.md
@@ -36,6 +36,7 @@ VPA Can be installed using a post-install hook if `installVPA` is set to true in
 | `dashboard.enabled`                    | If true, the dashboard component will be installed.                                                                              | `True`                         |
 | `dashboard.affinity`                   | Affinity for the dashbaord pods.                                                                                                 | `{}`                           |
 | `dashboard.excludeContainer`           | A comma-separated list of container names to ignore in the dashboard globally.                                                   | `linkderd-proxy,istio-proxy`   |
+| `dashboard.basePath`                   | Customize the basePath passed as `--base-path` to the dashboard container (useful for instance if using an ingress path)
 | `dashboard.ingress.enabled`            | If true, an ingress object will be created. Further configuration is necessary. See [values.yaml](values.yaml) for an example.   | `False`                        |
 | `dashboard.ingress.annotations`        | Annotations on the ingress object.                                                                                               | `{}`                           |
 | `dashboard.ingress.hosts.0.host`       | Ingress host. See [values.yaml](values.yaml) for an example.                                                                     | `chart-example.local`          |

--- a/stable/goldilocks/README.md
+++ b/stable/goldilocks/README.md
@@ -36,7 +36,7 @@ VPA Can be installed using a post-install hook if `installVPA` is set to true in
 | `dashboard.enabled`                    | If true, the dashboard component will be installed.                                                                              | `True`                         |
 | `dashboard.affinity`                   | Affinity for the dashbaord pods.                                                                                                 | `{}`                           |
 | `dashboard.excludeContainer`           | A comma-separated list of container names to ignore in the dashboard globally.                                                   | `linkderd-proxy,istio-proxy`   |
-| `dashboard.basePath`                   | Customize the basePath passed as `--base-path` to the dashboard container (useful for instance if using an ingress path)
+| `dashboard.basePath`                   | Customize the basePath passed as `--base-path` to the dashboard container (useful for instance if using an ingress path)                                          |
 | `dashboard.ingress.enabled`            | If true, an ingress object will be created. Further configuration is necessary. See [values.yaml](values.yaml) for an example.   | `False`                        |
 | `dashboard.ingress.annotations`        | Annotations on the ingress object.                                                                                               | `{}`                           |
 | `dashboard.ingress.hosts.0.host`       | Ingress host. See [values.yaml](values.yaml) for an example.                                                                     | `chart-example.local`          |

--- a/stable/goldilocks/templates/dashboard-deployment.yaml
+++ b/stable/goldilocks/templates/dashboard-deployment.yaml
@@ -36,6 +36,9 @@ spec:
             - /goldilocks
             - dashboard
             - --exclude-containers={{ .Values.dashboard.excludeContainers }}
+            {{- if .Values.dashboard.basePath }}
+            - --base-path={{ trimSuffix "/" .Values.dashboard.basePath }}/
+            {{- end }}
             - -v{{ .Values.dashboard.logVerbosity }}
           securityContext:
             readOnlyRootFilesystem: true

--- a/stable/goldilocks/values.yaml
+++ b/stable/goldilocks/values.yaml
@@ -47,6 +47,8 @@ dashboard:
     create: true
     # name: ExistingServiceAccountName
 
+  # Sets the web app's basePath/base href
+  # basePath: goldilocks
   ingress:
     enabled: false
     annotations: {}

--- a/stable/goldilocks/values.yaml
+++ b/stable/goldilocks/values.yaml
@@ -50,7 +50,7 @@ dashboard:
   # Sets the web app's basePath/base href
   # basePath: goldilocks
   ingress:
-    enabled: true
+    enabled: false
     annotations: {}
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"

--- a/stable/goldilocks/values.yaml
+++ b/stable/goldilocks/values.yaml
@@ -50,7 +50,7 @@ dashboard:
   # Sets the web app's basePath/base href
   # basePath: goldilocks
   ingress:
-    enabled: false
+    enabled: true
     annotations: {}
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"


### PR DESCRIPTION
If you enable an ingress with path on this chart install, for instance using `my.cluster.com` with a path `/goldilocks`, the dashboard will not work because resources are requested as e.g., `my.cluster.com/main.js` rather than `my.cluster.com/goldilocks/main.js`.

This just allows the user to set the `basePath` which then gets passed along in the dashboard container's command.