### PR TITLE
 changes for astro chart 1.0.0

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,6 @@
 *       @bambash @sudermanjr
 
+/incubator/astro/ @mjhuber @lucasreed
 /incubator/autospotting/ @sudermanjr @coreypobrien
 /incubator/basic-demo/ @sudermanjr
 /incubator/capsize/ @sudermanjr

--- a/incubator/astro/Chart.yaml
+++ b/incubator/astro/Chart.yaml
@@ -1,7 +1,7 @@
 name: astro
-version: 0.0.1
+version: 1.0.0
 apiVersion: v1
-appVersion: "1.2.0"
+appVersion: "1.5.2"
 description: Emit datadog monitors based on kubernetes state.
 keywords:
   - datadog

--- a/incubator/astro/README.md
+++ b/incubator/astro/README.md
@@ -9,6 +9,17 @@ We recommend installing astro in its own namespace and with a simple release nam
 ```
 helm install incubator/astro --name astro --namespace astro
 ```
+## Changes to chart values in 1.0.0+
+When upgrading from a chart version below 1.0.0 to 1.0.0+ take into account the following changes in values:
+
+< 1.0.0 Value | 1.0.0+ Value
+--- | ---
+`controller.rbac.create` | `rbac.create`
+`controller.serviceAccount.create` | `deployment.serviceAccount.create`
+`controller.serviceAccount.name` | `deployment.serviceAccount.name`
+
+New values that were previously not available:
+- `deployment.replicas`
 
 ## Prerequisites
 Kubernetes 1.11+, Helm 2.13+
@@ -17,7 +28,7 @@ Kubernetes 1.11+, Helm 2.13+
 Parameter | Description | Default
 --- | --- | ---
 `image.repository` | Docker image repo  | `quay.io/fairwinds/astro`
-`image.tag` | Docker image tag  | `v1.2.0`
+`image.tag` | Docker image tag  | `v1.5.2`
 `image.pullPolicy` | Docker image pull policy  | `IfNotPresent`
 `resources.requests.cpu` | CPU resource request | `100m`
 `resources.requests.memory` | Memory resource request | `128Mi`
@@ -28,9 +39,10 @@ Parameter | Description | Default
 `affinity` | Deployment affinity | `{}`
 `datadog.apiKey` | Datadog api key | `""`
 `datadog.appKey` | Datadog app key | `""`
-`controller.rbac.create` | if true, rbac resources will be created. | `true`
-`controller.serviceAccount.create` | if true, a service account will be created.  If false, you must set `controller.serviceAccount.name`. | `true`
-`controller.serviceAccount.name` | The name of an existing service account to use. | `''`
+`rbac.create` | if true, rbac resources will be created. | `true`
+`deployment.serviceAccount.create` | if true, a service account will be created.  If false, you must set `deployment.serviceAccount.name`. | `true`
+`deployment.serviceAccount.name` | The name of an existing service account to use. | `''`
+`deployment.replicas` | The number of replicas to use | `2`
 `secret.create` | if true, a secret with api credentials will be created.  If false, you must set `secret.name` | `true`
 `secret.name` | The name of an existing secret to mount to the container. | `""`
 `definitionsPath` | The path to the monitor definitions configuration. This can be a local path or a URL. | `""`

--- a/incubator/astro/templates/clusterrole.yaml
+++ b/incubator/astro/templates/clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.controller.rbac.create }}
+{{- if .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
@@ -27,4 +27,16 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+      - delete
+      - update
+      - patch
 {{- end }}

--- a/incubator/astro/templates/clusterrolebinding.yaml
+++ b/incubator/astro/templates/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.controller.rbac.create }}
+{{- if .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
@@ -14,10 +14,10 @@ roleRef:
   name: {{ include "astro.fullname" . }}
 subjects:
   - kind: ServiceAccount
-{{- if .Values.controller.serviceAccount.create }}
+{{- if .Values.deployment.serviceAccount.create }}
     name: {{ template "astro.fullname" . }}
 {{- else }}
-    name: {{ .Values.controller.serviceAccount.name }}
+    name: {{ .Values.deployment.serviceAccount.name }}
 {{- end }}
     namespace: {{ .Release.Namespace | quote }}
 {{- end }}

--- a/incubator/astro/templates/deployment.yaml
+++ b/incubator/astro/templates/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.deployment.replicas }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "astro.name" . }}
@@ -19,15 +19,18 @@ spec:
         app.kubernetes.io/name: {{ include "astro.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
-      {{- if .Values.controller.serviceAccount.create }}
+      {{- if .Values.deployment.serviceAccount.create }}
       serviceAccountName: {{ include "astro.fullname" . }}
       {{- else }}
-      serviceAccountName: {{ .Values.controller.serviceAccount.name }}
+      serviceAccountName: {{ .Values.deployment.serviceAccount.name }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - ./astro
+            - --namespace={{ .Release.Namespace }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           envFrom:

--- a/incubator/astro/templates/serviceaccount.yaml
+++ b/incubator/astro/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.controller.serviceAccount.create }}
+{{- if .Values.deployment.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/incubator/astro/values.yaml
+++ b/incubator/astro/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: quay.io/fairwinds/astro
-  tag: "v1.2.0"
+  tag: "v1.5.2"
   pullPolicy: IfNotPresent
 resources:
   limits:
@@ -15,10 +15,10 @@ affinity: {}
 datadog:
   apiKey: ""
   appKey: ""
-controller:
-  enabled: true
-  rbac:
-    create: true
+rbac:
+  create: true
+deployment:
+  replicas: 2
   serviceAccount:
     create: true
     # name: ExistingServiceAccountName


### PR DESCRIPTION
- changed config value names starting with "controller" to start with "deployment" instead
- added permissions to coordination api for leader election
- made rbac a toplevel config value
- made replicas configurable
- added a command to the container spec to allow specification of an argument
- updated chart version to 1.0.0
- default img version to 1.5.2

I think after this is merged we can open a PR to move this chart into `stable/`

