### PR TITLE
bump up kubesec timeout

### DIFF
--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 0.10.0
+version: 0.10.1
 appVersion: 0.4.0
 maintainers:
   - name: rbren

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -52,7 +52,7 @@ kubehunter:
 kubesec:
   enabled: false
   schedule: "rand * * * *"
-  timeout: 120
+  timeout: 1200
   image:
     repository: quay.io/fairwinds/fw-kubesec
     tag: "1.2"


### PR DESCRIPTION
Kubesec take O(workloads) to run, and takes 1-2 minutes on a relatively small cluster. Setting to 20 minutes so we can handle larger clusters.