### PR TITLE
 Add pods to allowed resources in fairwinds-metrics clusterrole

### DIFF
--- a/incubator/fairwinds-metrics/Chart.yaml
+++ b/incubator/fairwinds-metrics/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v0.5.0"
 description: A Helm chart for running Fairwinds Custom Metrics
 name: fairwinds-metrics
-version: 0.3.0
+version: 0.3.1
 maintainers:
   - name: sudermanjr
   - name: mjhuber

--- a/incubator/fairwinds-metrics/templates/controller-clusterrole.yaml
+++ b/incubator/fairwinds-metrics/templates/controller-clusterrole.yaml
@@ -15,6 +15,7 @@ rules:
     resources:
       - 'namespaces'
       - 'secrets'
+      - 'pods'
     verbs:
       - 'get'
       - 'list'


### PR DESCRIPTION
The chart was missing permissions for fairwinds-metrics to query pod resources, which is necessary for the terminating pods check. Without this, you'll see this error message in the pod's logs:

```
E0114 16:30:03.330531       1 terminating_pods.go:27] Error getting pods: pods is forbidden: User "system:serviceaccount:fairwinds-metrics:fairwinds-metrics-controller" cannot list resource "pods" in API group "" at the cluster scope
```