### PR TITLE
Add Blacklist for Trivy on Insights-Agent

### DIFF
--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 0.11.1
+version: 0.12.0
 appVersion: 0.6.0
 maintainers:
   - name: rbren

--- a/stable/insights-agent/README.md
+++ b/stable/insights-agent/README.md
@@ -55,4 +55,5 @@ Parameter | Description | Default
 `{report}.image.tag` | Image tag to use for the report |
 `trivy.privateImages.dockerConfigSecret` | Name of a secret containing a docker `config.json` | ""
 `trivy.maxConcurrentScans` | Maximum number of scans to run concurrently | 5
+`trivy.namespaceBlacklist` | Specifies which namespaces to not scan, takes an array of namespaces for example: `--set trivy.namespaceBlacklist="{kube-system,default}"` | nil
 `goldilocks.controller.exclude-namespaces` | Namespaces to exclude from the goldilocks report | `kube-system`

--- a/stable/insights-agent/templates/trivy/_job.yaml
+++ b/stable/insights-agent/templates/trivy/_job.yaml
@@ -18,6 +18,10 @@ containers:
   env:
     - name: MAX_CONCURRENT_SCANS
       value: {{ .Values.trivy.maxConcurrentScans | quote }}
+    {{ if .Values.trivy.namespaceBlacklist }}
+    - name: NAMESPACE_BLACKLIST
+      value: {{ join "," .Values.trivy.namespaceBlacklist | lower }}
+    {{ end }}
   volumeMounts:
   - name: output
     mountPath: /output

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -123,6 +123,7 @@ releasewatcher:
 
 trivy:
   enabled: true
+  namespaceBlacklist: nil
   schedule: "rand */3 * * *"
   privateImages:
     dockerConfigSecret: ""


### PR DESCRIPTION
I added an extra parameter to the helm chart to allow users to exclude namespaces from Trivy scans. I'm also going to be modifying the code on our Trivy agent to use this.

Since this added a new piece of functionality it felt appropriate to bump the minor version of the chart. Since a new version of the insights-agent isn't out there yet it felt appropriate to not bump the appVersion yet.