### PR TITLE
Changes for 1.16 and future

### DIFF
--- a/incubator/basic-demo/Chart.yaml
+++ b/incubator/basic-demo/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Basic Kubernetes Demo Chart
 name: basic-demo
-version: 0.2.3
+version: 0.3.0
 maintainers:
   - name: sudermanjr

--- a/incubator/basic-demo/README.md
+++ b/incubator/basic-demo/README.md
@@ -4,6 +4,10 @@ Runs a frontend that shows which pods it is connecting to.  Good for scaling dem
 
 Credit for the app goes to [ehazlett](https://github.com/ehazlett/docker-demo)
 
+## A Note on Chart Version 0.3.0+
+
+Due to the [future deprecation](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/) of various `extensions/v1beta1` API's, the 0.3.0 version of this chart will only work on kubernetes 1.14.0+
+
 ## Values
 
 | Parameter | Description | Default | Required |

--- a/incubator/basic-demo/templates/hpa.yaml
+++ b/incubator/basic-demo/templates/hpa.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "basic-demo.fullname" . }}
 spec:
   scaleTargetRef:
-    apiVersion: extensions/v1beta1
+    apiVersion: apps/v1
     kind: Deployment
     name: {{ include "basic-demo.fullname" . }}
   minReplicas: {{ .Values.hpa.min }}

--- a/incubator/basic-demo/templates/ingress.yaml
+++ b/incubator/basic-demo/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "basic-demo.fullname" . -}}
 {{- $ingressPaths := .Values.ingress.paths -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/incubator/fairwinds-metrics/Chart.yaml
+++ b/incubator/fairwinds-metrics/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v0.5.0"
 description: A Helm chart for running Fairwinds Custom Metrics
 name: fairwinds-metrics
-version: 0.3.1
+version: 0.4.0
 maintainers:
   - name: sudermanjr
   - name: mjhuber

--- a/incubator/fairwinds-metrics/README.md
+++ b/incubator/fairwinds-metrics/README.md
@@ -2,6 +2,10 @@
 
 A controller for a collection of non-standard metrics.
 
+## A Note on Chart Version 0.4.0+
+
+Due to the [future deprecation](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/) of various `extensions/v1beta1` API's, the 0.4.0 version of this chart will only work on kubernetes 1.14.0+
+
 ## Usage
 
 | Parameter | Description | Default | Required |

--- a/incubator/fairwinds-metrics/templates/listener-ingress.yaml
+++ b/incubator/fairwinds-metrics/templates/listener-ingress.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.listener.enabled  .Values.listener.ingress.enabled }}
 {{- $fullName := include "fairwinds-metrics.fullname" . -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ include "fairwinds-metrics.fullname" . }}

--- a/incubator/fluentd/Chart.yaml
+++ b/incubator/fluentd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.12.43"
 description: Fluentd for multiple endpoints
 name: fluentd
-version: 4.0.2
+version: 4.1.0
 maintainers:
   - name: dosullivan
   - name: coreypobrien

--- a/incubator/fluentd/templates/daemonset.yaml
+++ b/incubator/fluentd/templates/daemonset.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ template "fluentd.fullname" . }}

--- a/incubator/logentries/Chart.yaml
+++ b/incubator/logentries/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for managing LogEntries Kubernetes agent
 name: logentries
-version: 0.1.0
+version: 0.2.0
 maintainers:
   - name: mjhuber

--- a/incubator/logentries/templates/ds.yaml
+++ b/incubator/logentries/templates/ds.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
     name: {{ include "logentries.fullname" . }}

--- a/stable/aws-iam-authenticator/Chart.yaml
+++ b/stable/aws-iam-authenticator/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: v0.4.0
 description: Install and configure aws-iam-authenticator on your cluster.
 name: aws-iam-authenticator
-version: v1.2.2
+version: v1.3.0
 maintainers:
   - name: sudermanjr

--- a/stable/aws-iam-authenticator/templates/daemonset.yaml
+++ b/stable/aws-iam-authenticator/templates/daemonset.yaml
@@ -1,22 +1,30 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ template "aws-iam-authenticator.fullname" . }}
   labels:
-    k8s-app: {{ template "aws-iam-authenticator.name" . }}
+    app.kubernetes.io/name: {{ include "aws-iam-authenticator.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "aws-iam-authenticator.chart" . }}
   annotations:
     checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
 spec:
   updateStrategy:
     type: RollingUpdate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "aws-iam-authenticator.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         scheduler.alpha.kubernetes.io/critical-pod: ""
       labels:
-        k8s-app: {{ template "aws-iam-authenticator.name" . }}
+        app.kubernetes.io/name: {{ include "aws-iam-authenticator.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       # run on the host network (don't depend on CNI)
       hostNetwork: true

--- a/stable/polaris/Chart.yaml
+++ b/stable/polaris/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Validation of best practices in your Kubernetes clusters
 name: polaris
-version: "0.9.0"
+version: "0.10.0"
 appVersion: "0.6"
 icon: https://raw.githubusercontent.com/FairwindsOps/polaris/master/pkg/dashboard/assets/favicon-32x32.png
 maintainers:

--- a/stable/polaris/README.md
+++ b/stable/polaris/README.md
@@ -18,6 +18,9 @@ helm repo add fairwinds-stable https://charts.fairwinds.com/stable
 helm install fairwinds-stable/polaris --name polaris --namespace polaris --set webhook.enable=true --set dashboard.enable=false
 ```
 
+## A Note on Chart Version 0.10.0+
+
+Due to the [future deprecation](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/) of various `extensions/v1beta1` API's, the 0.10.0 version of this chart will only work on kubernetes 1.14.0+
 
 ## Configuration
 Parameter | Description | Default

--- a/stable/polaris/templates/ingress.yaml
+++ b/stable/polaris/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{ $serviceName := printf "%s-dashboard" (include "polaris.fullname" .) -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   annotations:


### PR DESCRIPTION
- Updated a few daemonset templates to use apps/v1
- Updated some ingress objects to use networking.k8s.io/v1beta1 (not
breaking in 1.16, but will in 1.20)
- Updated chart minor versions for all modified

local testing results below:

With changes made, launched into v1.15.3 cluster:
 ✔︎ basic-demo => (version: "0.3.0", path: "incubator/basic-demo")
 ✔︎ fairwinds-metrics => (version: "0.4.0", path: "incubator/fairwinds-metrics")
 ✔︎ fluentd => (version: "4.1.0", path: "incubator/fluentd")
 ✔︎ logentries => (version: "0.2.0", path: "incubator/logentries")
 ✔︎ aws-iam-authenticator => (version: "v1.3.0", path: "stable/aws-iam-authenticator")
 ✔︎ polaris => (version: "0.10.0", path: "stable/polaris")

With changes made, launched into v1.16.4 cluster:
 ✔︎ basic-demo => (version: "0.3.0", path: "incubator/basic-demo")
 ✔︎ fairwinds-metrics => (version: "0.4.0", path: "incubator/fairwinds-metrics")
 ✔︎ fluentd => (version: "4.1.0", path: "incubator/fluentd")
 ✔︎ logentries => (version: "0.2.0", path: "incubator/logentries")
 ✔︎ aws-iam-authenticator => (version: "v1.3.0", path: "stable/aws-iam-authenticator")
 ✔︎ polaris => (version: "0.10.0", path: "stable/polaris")

Current repository (No changes other than Chart version) launched into v1.16.4 cluster:
 ✔︎ basic-demo => (version: "0.3.0", path: "incubator/basic-demo")
 ✔︎ fairwinds-metrics => (version: "0.4.0", path: "incubator/fairwinds-metrics")
 ✖︎ fluentd => (version: "4.1.0", path: "incubator/fluentd") > Error waiting for process: exit status 1
 ✖︎ logentries => (version: "0.2.0", path: "incubator/logentries") > Error waiting for process: exit status 1
 ✖︎ aws-iam-authenticator => (version: "v1.3.0", path: "stable/aws-iam-authenticator") > Error waiting for process: exit status 1
 ✔︎ polaris => (version: "0.10.0", path: "stable/polaris")