### PR TITLE
Bump versions of Insights-Agent dependencies

### DIFF
--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 0.12.1
+version: 0.12.2
 appVersion: 0.6.0
 maintainers:
   - name: rbren

--- a/stable/insights-agent/templates/trivy/_job.yaml
+++ b/stable/insights-agent/templates/trivy/_job.yaml
@@ -32,8 +32,8 @@ containers:
   resources:
     {{- toYaml .Values.trivy.resources | nindent 4 }}
   securityContext:
-    privileged: true
-    allowPrivilegeEscalation: true
+    privileged: false
+    allowPrivilegeEscalation: false
     readOnlyRootFilesystem: false
     capabilities:
       drop:

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -72,7 +72,7 @@ goldilocks:
   timeout: 120
   image:
     repository: quay.io/fairwinds/goldilocks
-    tag: "v2.1.0"
+    tag: "v2.2.0"
   controller:
     flags:
       on-by-default: true
@@ -99,7 +99,7 @@ workloads:
   schedule: "rand * * * *"
   image:
     repository: quay.io/fairwinds/workloads
-    tag: "1.1"
+    tag: "1.2"
   resources:
     limits:
       cpu: 100m
@@ -132,7 +132,7 @@ trivy:
   timeout: 10800
   image:
     repository: quay.io/fairwinds/fw-trivy
-    tag: "0.1"
+    tag: "0.2"
   resources:
     limits:
       cpu: 250m


### PR DESCRIPTION
Increased the versions of golidlocks, fw-trivy, and workloads to the latest versions.

Run Trivy as non-privileged now