### PR TITLE
KubeBench for Insights Agent

### DIFF
--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
 version: 0.14.0
-appVersion: 0.7.1
+appVersion: 0.8.0
 maintainers:
   - name: rbren
   - name: makoscafee

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 0.13.1
+version: 0.14.0
 appVersion: 0.7.1
 maintainers:
   - name: rbren

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 0.13.0
-appVersion: 0.6.0
+version: 0.13.1
+appVersion: 0.7.1
 maintainers:
   - name: rbren
   - name: makoscafee

--- a/stable/insights-agent/README.md
+++ b/stable/insights-agent/README.md
@@ -54,6 +54,9 @@ Parameter | Description | Default
 `{report}.resources` | CPU/memory requests and limits for the report |
 `{report}.image.repository` | Repository to use for the report image |
 `{report}.image.tag` | Image tag to use for the report |
+`kubebench.deploymentMode` | Changes the way this plugin is deployed, either `cronjob` where it will run a single pod on the `schedule` that will pull the data necessary from a single node and report that back to Insights. `daemonset` which deploys a daemonset to the cluster which gathers data then a cronjob will gather data from each of those pods. `daemonsetMaster`  is the same as `daemonset` except the daemonset can also run on masters. | `daemonsetMaster`
+`kubebench.hourInterval` | If running in `daemonset` or `daemonsetMaster` this configuration changes how often the daemonset pods will rescan the node they are running on | 2
+`kubebench.aggregator` | contains `resources` and `image.repository` and `image.tag`, this controls the pod scheduled via a CronJob that aggregates from the daemonset in `daemonset` or `daemonsetMaster` deployment modes. |
 `trivy.privateImages.dockerConfigSecret` | Name of a secret containing a docker `config.json` | ""
 `trivy.maxConcurrentScans` | Maximum number of scans to run concurrently | 5
 `trivy.namespaceBlacklist` | Specifies which namespaces to not scan, takes an array of namespaces for example: `--set trivy.namespaceBlacklist="{kube-system,default}"` | nil

--- a/stable/insights-agent/README.md
+++ b/stable/insights-agent/README.md
@@ -54,7 +54,7 @@ Parameter | Description | Default
 `{report}.resources` | CPU/memory requests and limits for the report |
 `{report}.image.repository` | Repository to use for the report image |
 `{report}.image.tag` | Image tag to use for the report |
-`kubebench.deploymentMode` | Changes the way this plugin is deployed, either `cronjob` where it will run a single pod on the `schedule` that will pull the data necessary from a single node and report that back to Insights. `daemonset` which deploys a daemonset to the cluster which gathers data then a cronjob will gather data from each of those pods. `daemonsetMaster`  is the same as `daemonset` except the daemonset can also run on masters. | `daemonsetMaster`
+`kubebench.mode` | Changes the way this plugin is deployed, either `cronjob` where it will run a single pod on the `schedule` that will pull the data necessary from a single node and report that back to Insights. `daemonset` which deploys a daemonset to the cluster which gathers data then a cronjob will gather data from each of those pods. `daemonsetMaster`  is the same as `daemonset` except the daemonset can also run on masters. | `cronjob`
 `kubebench.hourInterval` | If running in `daemonset` or `daemonsetMaster` this configuration changes how often the daemonset pods will rescan the node they are running on | 2
 `kubebench.aggregator` | contains `resources` and `image.repository` and `image.tag`, this controls the pod scheduled via a CronJob that aggregates from the daemonset in `daemonset` or `daemonsetMaster` deployment modes. |
 `trivy.privateImages.dockerConfigSecret` | Name of a secret containing a docker `config.json` | ""

--- a/stable/insights-agent/templates/cronjob-executor/rbac.yaml
+++ b/stable/insights-agent/templates/cronjob-executor/rbac.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.cronjobs.runJobsImmediately -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -39,3 +40,4 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "insights-agent.fullname" . }}-cronjob-executor
   namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/stable/insights-agent/templates/kube-bench/_container.yaml
+++ b/stable/insights-agent/templates/kube-bench/_container.yaml
@@ -1,0 +1,72 @@
+{{- define "kubebench.container.spec" -}}
+hostPID: true
+{{- if eq .Values.kubebench.mode "daemonsetMaster" }}
+tolerations:
+- key: node-role.kubernetes.io/master
+  effect: NoSchedule
+{{- end }}
+volumes:
+- name: output
+  emptyDir: {}
+- name: tmp
+  emptyDir: {}
+- name: var-lib
+  hostPath:
+    path: "/var/lib"
+    type: Directory
+- name: etc-systemd
+  hostPath:
+    path: "/etc/systemd"
+    type: Directory
+- name: etc-kubernetes
+  hostPath:
+    path: "/etc/kubernetes"
+    type: Directory
+- name: usr-bin
+  hostPath:
+    path: "/usr/bin"
+    type: Directory
+containers:
+- image: "{{ .Values.kubebench.image.repository }}:{{ .Values.kubebench.image.tag }}"
+  imagePullPolicy: Always
+  name: kube-bench
+  env:
+  - name: NODE_NAME
+    valueFrom:
+      fieldRef:
+        fieldPath: spec.nodeName
+  {{- if eq .Values.kubebench.mode "cronjob" }}
+  - name: RUN_ONCE
+    value: "true"
+  {{- end }}
+  - name: INTERVAL_HOURS
+    value: {{ .Values.kubebench.hourInterval | quote }}
+  resources:
+    {{- toYaml .Values.kubebench.resources | nindent 2 }}
+  volumeMounts:
+  - name: output
+    mountPath: /output
+  - name: tmp
+    mountPath: /tmp
+  - name: var-lib # for /var/lib/kubelet and /var/lib/etcd
+    mountPath: /var/lib
+    readOnly: true
+  - name: etc-systemd
+    mountPath: /etc/systemd
+    readOnly: true
+  - name: etc-kubernetes
+    mountPath: /etc/kubernetes
+    readOnly: true
+    # /usr/local/mount-from-host/bin is mounted to access kubectl / kubelet, for auto-detecting the Kubernetes version.
+    # You can omit this mount if you specify --version as part of the command.
+  - name: usr-bin
+    mountPath: /usr/local/mount-from-host/bin
+    readOnly: true
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - ALL
+    privileged: false
+    readOnlyRootFilesystem: true
+{{- end -}}

--- a/stable/insights-agent/templates/kube-bench/cronjob.yaml
+++ b/stable/insights-agent/templates/kube-bench/cronjob.yaml
@@ -1,0 +1,36 @@
+{{- define "kubebench.job.spec" -}}
+{{- $_ := set . "Label" "kubebench" }}
+{{- $_ := set . "Config" .Values.kubebench }}
+restartPolicy: Never
+serviceAccountName: {{ include "insights-agent.fullname" . }}
+volumes:
+- name: output
+  emptyDir: {}
+containers:
+- name: kube-bench-aggregator
+  image: "{{ .Values.kubebench.aggregator.image.repository }}:{{ .Values.kubebench.aggregator.image.tag }}"
+  imagePullPolicy: Always
+  env:
+  - name: DAEMONSET_SERVICE
+    value: {{ include "insights-agent.fullname" . }}-kube-bench-svc
+  resources:
+    {{- toYaml .Values.kubebench.aggregator.resources | nindent 4 }}
+  volumeMounts:
+  - name: output
+    mountPath: /output
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - ALL
+    privileged: false
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+{{- include "uploaderContainer" . }}
+{{- end -}}
+{{- if .Values.kubebench.enabled -}}
+{{- $_ := set . "Label" "kubebench" }}
+{{- $_ := set . "Config" .Values.kubebench }}
+{{- $_ := set . "Template" "kubebench.job.spec" }}
+{{- include "cronjob" . }}
+{{- end -}}

--- a/stable/insights-agent/templates/kube-bench/cronjob.yaml
+++ b/stable/insights-agent/templates/kube-bench/cronjob.yaml
@@ -1,9 +1,9 @@
 {{- define "kubebench.job.spec" -}}
-{{- $_ := set . "Label" "kube-bench" }}
-{{- $_ := set . "Config" .Values.kubebench }}
+{{- $_ := set . "Label" "kube-bench" -}}
+{{- $_ := set . "Config" .Values.kubebench -}}
 restartPolicy: Never
 serviceAccountName: {{ include "insights-agent.fullname" . }}
-{{- if or (eq .Values.kubebench.deploymentMode "daemonsetMaster") (eq .Values.kubebench.deploymentMode "daemonset") }}
+{{- if or (eq .Values.kubebench.mode "daemonsetMaster") (eq .Values.kubebench.mode "daemonset") }}
 volumes:
 - name: output
   emptyDir: {}
@@ -28,67 +28,7 @@ containers:
     readOnlyRootFilesystem: true
     runAsNonRoot: true
 {{- else }}
-hostPID: true
-volumes:
-- name: output
-  emptyDir: {}
-- name: tmp
-  emptyDir: {}
-- name: var-lib
-  hostPath:
-    path: "/var/lib"
-    type: Directory
-- name: etc-systemd
-  hostPath:
-    path: "/etc/systemd"
-    type: Directory
-- name: etc-kubernetes
-  hostPath:
-    path: "/etc/kubernetes"
-    type: Directory
-- name: usr-bin
-  hostPath:
-    path: "/usr/bin"
-    type: Directory
-containers:
-- image: "{{ .Values.kubebench.image.repository }}:{{ .Values.kubebench.image.tag }}"
-  imagePullPolicy: Always
-  name: kube-bench
-  env:
-  - name: NODE_NAME
-    valueFrom:
-      fieldRef:
-        fieldPath: spec.nodeName
-  - name: RUN_ONCE
-    value: "true"
-  resources:
-    {{- toYaml .Values.kubebench.resources | nindent 10 }}
-  volumeMounts:
-  - name: output
-    mountPath: /output
-  - name: tmp
-    mountPath: /tmp
-  - name: var-lib # for /var/lib/kubelet and /var/lib/etcd
-    mountPath: /var/lib
-    readOnly: true
-  - name: etc-systemd
-    mountPath: /etc/systemd
-    readOnly: true
-  - name: etc-kubernetes
-    mountPath: /etc/kubernetes
-    readOnly: true
-    # /usr/local/mount-from-host/bin is mounted to access kubectl / kubelet, for auto-detecting the Kubernetes version.
-    # You can omit this mount if you specify --version as part of the command.
-  - name: usr-bin
-    mountPath: /usr/local/mount-from-host/bin
-    readOnly: true
-  securityContext:
-    allowPrivilegeEscalation: false
-    capabilities:
-      drop:
-      - ALL
-    privileged: false
-    readOnlyRootFilesystem: true
+{{- include "kubebench.container.spec" . | nindent 0}}
 {{- end }}
 {{- include "uploaderContainer" . }}
 {{- end -}}

--- a/stable/insights-agent/templates/kube-bench/cronjob.yaml
+++ b/stable/insights-agent/templates/kube-bench/cronjob.yaml
@@ -1,5 +1,5 @@
 {{- define "kubebench.job.spec" -}}
-{{- $_ := set . "Label" "kubebench" }}
+{{- $_ := set . "Label" "kube-bench" }}
 {{- $_ := set . "Config" .Values.kubebench }}
 restartPolicy: Never
 serviceAccountName: {{ include "insights-agent.fullname" . }}
@@ -29,7 +29,7 @@ containers:
 {{- include "uploaderContainer" . }}
 {{- end -}}
 {{- if .Values.kubebench.enabled -}}
-{{- $_ := set . "Label" "kubebench" }}
+{{- $_ := set . "Label" "kube-bench" }}
 {{- $_ := set . "Config" .Values.kubebench }}
 {{- $_ := set . "Template" "kubebench.job.spec" }}
 {{- include "cronjob" . }}

--- a/stable/insights-agent/templates/kube-bench/cronjob.yaml
+++ b/stable/insights-agent/templates/kube-bench/cronjob.yaml
@@ -3,6 +3,7 @@
 {{- $_ := set . "Config" .Values.kubebench }}
 restartPolicy: Never
 serviceAccountName: {{ include "insights-agent.fullname" . }}
+{{- if or (eq .Values.kubebench.deploymentMode "daemonsetMaster") (eq .Values.kubebench.deploymentMode "daemonset") }}
 volumes:
 - name: output
   emptyDir: {}
@@ -26,6 +27,69 @@ containers:
     privileged: false
     readOnlyRootFilesystem: true
     runAsNonRoot: true
+{{- else }}
+hostPID: true
+volumes:
+- name: output
+  emptyDir: {}
+- name: tmp
+  emptyDir: {}
+- name: var-lib
+  hostPath:
+    path: "/var/lib"
+    type: Directory
+- name: etc-systemd
+  hostPath:
+    path: "/etc/systemd"
+    type: Directory
+- name: etc-kubernetes
+  hostPath:
+    path: "/etc/kubernetes"
+    type: Directory
+- name: usr-bin
+  hostPath:
+    path: "/usr/bin"
+    type: Directory
+containers:
+- image: "{{ .Values.kubebench.image.repository }}:{{ .Values.kubebench.image.tag }}"
+  imagePullPolicy: Always
+  name: kube-bench
+  env:
+  - name: NODE_NAME
+    valueFrom:
+      fieldRef:
+        fieldPath: spec.nodeName
+  - name: RUN_ONCE
+    value: "true"
+  resources:
+    {{- toYaml .Values.kubebench.resources | nindent 10 }}
+  volumeMounts:
+  - name: output
+    mountPath: /output
+  - name: tmp
+    mountPath: /tmp
+  - name: var-lib # for /var/lib/kubelet and /var/lib/etcd
+    mountPath: /var/lib
+    readOnly: true
+  - name: etc-systemd
+    mountPath: /etc/systemd
+    readOnly: true
+  - name: etc-kubernetes
+    mountPath: /etc/kubernetes
+    readOnly: true
+    # /usr/local/mount-from-host/bin is mounted to access kubectl / kubelet, for auto-detecting the Kubernetes version.
+    # You can omit this mount if you specify --version as part of the command.
+  - name: usr-bin
+    mountPath: /usr/local/mount-from-host/bin
+    readOnly: true
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - ALL
+    privileged: false
+    readOnlyRootFilesystem: true
+{{- end }}
 {{- include "uploaderContainer" . }}
 {{- end -}}
 {{- if .Values.kubebench.enabled -}}

--- a/stable/insights-agent/templates/kube-bench/daemonset.yaml
+++ b/stable/insights-agent/templates/kube-bench/daemonset.yaml
@@ -42,7 +42,7 @@ spec:
               fieldRef:
                 fieldPath: spec.nodeName
           - name: INTERVAL_HOURS
-            value: {{ .Values.kubebench.hourInterval }}
+            value: {{ .Values.kubebench.hourInterval | quote }}
           - name: RUN_ONCE
             value: "Not used"
         resources:
@@ -62,15 +62,14 @@ spec:
         - name: usr-bin
           mountPath: /usr/local/mount-from-host/bin
           readOnly: true
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
       restartPolicy: Always
-      securityContext:
-        allowPrivilegeEscalation: false
-        capabilities:
-          drop:
-          - ALL
-        privileged: false
-        readOnlyRootFilesystem: true
-        runAsNonRoot: true
       volumes:
         - name: var-lib
           hostPath:

--- a/stable/insights-agent/templates/kube-bench/daemonset.yaml
+++ b/stable/insights-agent/templates/kube-bench/daemonset.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.kubebench.enabled) (or (eq .Values.kubebench.deploymentMode "daemonsetMaster") (eq .Values.kubebench.deploymentMode "daemonset")) -}}
+{{- if and (.Values.kubebench.enabled) (or (eq .Values.kubebench.mode "daemonsetMaster") (eq .Values.kubebench.mode "daemonset")) -}}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -26,63 +26,5 @@ spec:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/component: daemonset
     spec:
-      hostPID: true
-      {{- if eq .Values.kubebench.deploymentMode "daemonsetMaster" }}
-      tolerations:
-      - key: node-role.kubernetes.io/master
-        effect: NoSchedule
-      {{- end }}
-      containers:
-      - image: "{{ .Values.kubebench.image.repository }}:{{ .Values.kubebench.image.tag }}"
-        imagePullPolicy: Always
-        name: kube-bench
-        env:
-          - name: NODE_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.nodeName
-          - name: INTERVAL_HOURS
-            value: {{ .Values.kubebench.hourInterval | quote }}
-        resources:
-          {{- toYaml .Values.kubebench.aggregator.resources | nindent 10 }}
-        volumeMounts:
-        - name: var-lib # for /var/lib/kubelet and /var/lib/etcd
-          mountPath: /var/lib
-          readOnly: true
-        - name: etc-systemd
-          mountPath: /etc/systemd
-          readOnly: true
-        - name: etc-kubernetes
-          mountPath: /etc/kubernetes
-          readOnly: true
-          # /usr/local/mount-from-host/bin is mounted to access kubectl / kubelet, for auto-detecting the Kubernetes version.
-          # You can omit this mount if you specify --version as part of the command.
-        - name: usr-bin
-          mountPath: /usr/local/mount-from-host/bin
-          readOnly: true
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-          privileged: false
-          readOnlyRootFilesystem: true
-      restartPolicy: Always
-      volumes:
-        - name: var-lib
-          hostPath:
-            path: "/var/lib"
-            type: Directory
-        - name: etc-systemd
-          hostPath:
-            path: "/etc/systemd"
-            type: Directory
-        - name: etc-kubernetes
-          hostPath:
-            path: "/etc/kubernetes"
-            type: Directory
-        - name: usr-bin
-          hostPath:
-            path: "/usr/bin"
-            type: Directory
+      {{- include "kubebench.container.spec" . | nindent 6}}
 {{- end -}}

--- a/stable/insights-agent/templates/kube-bench/daemonset.yaml
+++ b/stable/insights-agent/templates/kube-bench/daemonset.yaml
@@ -43,8 +43,6 @@ spec:
                 fieldPath: spec.nodeName
           - name: INTERVAL_HOURS
             value: {{ .Values.kubebench.hourInterval | quote }}
-          - name: RUN_ONCE
-            value: "Not used"
         resources:
           {{- toYaml .Values.kubebench.aggregator.resources | nindent 10 }}
         volumeMounts:

--- a/stable/insights-agent/templates/kube-bench/daemonset.yaml
+++ b/stable/insights-agent/templates/kube-bench/daemonset.yaml
@@ -1,0 +1,91 @@
+{{- if and (.Values.kubebench.enabled) (or (eq .Values.kubebench.deploymentMode "daemonsetMaster") (eq .Values.kubebench.deploymentMode "daemonset")) -}}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app.kubernetes.io/name: {{ include "insights-agent.fullname" . }}
+    helm.sh/chart: {{ include "insights-agent.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/component: daemonset
+  name: {{ include "insights-agent.fullname" . }}-kube-bench
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "insights-agent.fullname" . }}
+      helm.sh/chart: {{ include "insights-agent.chart" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/managed-by: {{ .Release.Service }}
+      app.kubernetes.io/component: daemonset
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "insights-agent.fullname" . }}
+        helm.sh/chart: {{ include "insights-agent.chart" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/component: daemonset
+    spec:
+      hostPID: true
+      {{- if eq .Values.kubebench.deploymentMode "daemonsetMaster" }}
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      {{- end }}
+      containers:
+      - image: "{{ .Values.kubebench.image.repository }}:{{ .Values.kubebench.image.tag }}"
+        imagePullPolicy: Always
+        name: kube-bench
+        env:
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: INTERVAL_HOURS
+            value: {{ .Values.kubebench.hourInterval }}
+          - name: RUN_ONCE
+            value: "Not used"
+        resources:
+          {{- toYaml .Values.kubebench.aggregator.resources | nindent 10 }}
+        volumeMounts:
+        - name: var-lib # for /var/lib/kubelet and /var/lib/etcd
+          mountPath: /var/lib
+          readOnly: true
+        - name: etc-systemd
+          mountPath: /etc/systemd
+          readOnly: true
+        - name: etc-kubernetes
+          mountPath: /etc/kubernetes
+          readOnly: true
+          # /usr/local/mount-from-host/bin is mounted to access kubectl / kubelet, for auto-detecting the Kubernetes version.
+          # You can omit this mount if you specify --version as part of the command.
+        - name: usr-bin
+          mountPath: /usr/local/mount-from-host/bin
+          readOnly: true
+      restartPolicy: Always
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        privileged: false
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+      volumes:
+        - name: var-lib
+          hostPath:
+            path: "/var/lib"
+            type: Directory
+        - name: etc-systemd
+          hostPath:
+            path: "/etc/systemd"
+            type: Directory
+        - name: etc-kubernetes
+          hostPath:
+            path: "/etc/kubernetes"
+            type: Directory
+        - name: usr-bin
+          hostPath:
+            path: "/usr/bin"
+            type: Directory
+{{- end -}}

--- a/stable/insights-agent/templates/kube-bench/service.yaml
+++ b/stable/insights-agent/templates/kube-bench/service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.kubebench.enabled -}}
+{{- if and (.Values.kubebench.enabled) (or (eq .Values.kubebench.deploymentMode "daemonsetMaster") (eq .Values.kubebench.deploymentMode "daemonset")) -}}
 apiVersion: v1
 kind: Service
 metadata:

--- a/stable/insights-agent/templates/kube-bench/service.yaml
+++ b/stable/insights-agent/templates/kube-bench/service.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.kubebench.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "insights-agent.fullname" . }}-kube-bench-svc
+spec:
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: {{ include "insights-agent.fullname" . }}
+    helm.sh/chart: {{ include "insights-agent.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/component: daemonset
+{{- end -}}

--- a/stable/insights-agent/templates/kube-bench/service.yaml
+++ b/stable/insights-agent/templates/kube-bench/service.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.kubebench.enabled) (or (eq .Values.kubebench.deploymentMode "daemonsetMaster") (eq .Values.kubebench.deploymentMode "daemonset")) -}}
+{{- if and (.Values.kubebench.enabled) (or (eq .Values.kubebench.mode "daemonsetMaster") (eq .Values.kubebench.mode "daemonset")) -}}
 apiVersion: v1
 kind: Service
 metadata:

--- a/stable/insights-agent/templates/trivy/rbac.yaml
+++ b/stable/insights-agent/templates/trivy/rbac.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.trivy.enabled -}} 
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
@@ -28,3 +29,4 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "insights-agent.fullname" . }}
     namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -148,6 +148,33 @@ rbacreporter:
       cpu: 10m
       memory: 64Mi
 
+kubebench:
+  enabled: true
+  schedule: "rand * * * *"
+  deploymentMode: "daemonsetMaster"
+  hourInterval: 2
+  image:
+    repository: quay.io/fairwinds/fw-kube-bench
+    tag: 0.1
+  aggregator:
+    image:
+      repository: quay.io/fairwinds/fw-kube-bench-aggregator
+      tag: 0.1
+    resources:
+      limits:
+        cpu: 50m
+        memory: 64Mi
+      requests:
+        cpu: 10m
+        memory: 16Mi
+  resources:
+    limits:
+      cpu: 250m
+      memory: 512Mi
+    requests:
+      cpu: 10m
+      memory: 64Mi
+
 trivy:
   enabled: true
   namespaceBlacklist: []

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -170,11 +170,11 @@ kubebench:
         memory: 16Mi
   resources:
     limits:
-      cpu: 250m
-      memory: 512Mi
+      cpu: 500m
+      memory: 128Mi
     requests:
-      cpu: 10m
-      memory: 64Mi
+      cpu: 1m
+      memory: 16Mi
 
 trivy:
   enabled: true

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -153,6 +153,7 @@ kubebench:
   schedule: "rand * * * *"
   deploymentMode: "daemonsetMaster"
   hourInterval: 2
+  timeout: 240
   image:
     repository: quay.io/fairwinds/fw-kube-bench
     tag: 0.1

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -151,7 +151,7 @@ rbacreporter:
 kubebench:
   enabled: true
   schedule: "rand * * * *"
-  deploymentMode: "daemonsetMaster"
+  mode: "cronjob"
   hourInterval: 2
   timeout: 240
   image:


### PR DESCRIPTION
Added kube-bench as an option.

Bumped the app version number, I bumped the chart version only as a patch change because we're already doing a new minor release for the next version of Insights anyways.

Some of the RBAC we didn't have gated, so I added a few IFs.

The CronJob I wanted to make use of the _cronjob template that already exists but didn't want to continue the pattern of the _job file because there's not 2 separate job/cronjobs.

Depending on `kubebench.deploymentMode` this can deploy in one of three different ways. Kube-Bench has to run with hostPID and as root.
