### PR TITLE
Move workload to its own service account

### DIFF
--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 0.15.2
+version: 0.15.3
 appVersion: 0.8.0
 maintainers:
   - name: rbren

--- a/stable/insights-agent/templates/workloads/_job.yaml
+++ b/stable/insights-agent/templates/workloads/_job.yaml
@@ -1,6 +1,6 @@
 {{- define "workloads.job.spec" -}}
 restartPolicy: Never
-serviceAccountName: {{ include "insights-agent.fullname" . }}
+serviceAccountName: {{ include "insights-agent.fullname" . }}-workloads
 volumes:
 - name: output
   emptyDir: {}

--- a/stable/insights-agent/templates/workloads/rbac.yaml
+++ b/stable/insights-agent/templates/workloads/rbac.yaml
@@ -1,4 +1,11 @@
 {{- if .Values.workloads.enabled -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "insights-agent.fullname" . }}-workloads
+  labels:
+    app: insights-agent
+---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
@@ -12,6 +19,7 @@ rules:
     resources:
       - 'deployments'
       - 'statefulsets'
+      - 'replicasets'
       - 'daemonsets'
     verbs:
       - 'get'
@@ -47,6 +55,6 @@ roleRef:
   name: {{ include "insights-agent.fullname" . }}-workloads
 subjects:
   - kind: ServiceAccount
-    name: {{ include "insights-agent.fullname" . }}
+    name: {{ include "insights-agent.fullname" . }}-workloads
     namespace: {{ .Release.Namespace }}
 {{- end -}}


### PR DESCRIPTION
I noticed workloads were missing a permission if not installed with one of the other plugins so I'm going ahead and moving it to its own service account to make it easier to catch these overlaps.