### PR TITLE
removing runAsUser from deployment and increase rbac-manager version

### DIFF
--- a/stable/rbac-manager/Chart.yaml
+++ b/stable/rbac-manager/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: rbac-manager
-version: 1.5.2
-appVersion: 0.9.2
+version: 1.5.3
+appVersion: 0.9.3
 description: A Kubernetes operator that simplifies the management of Role Bindings and Service Accounts.
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/rbac-manager/icon.png
 keywords:

--- a/stable/rbac-manager/templates/deployment.yaml
+++ b/stable/rbac-manager/templates/deployment.yaml
@@ -49,7 +49,6 @@ spec:
             path: /metrics
             port: 8080
         securityContext:
-          runAsUser: 1200
           allowPrivilegeEscalation: false
           privileged: false
           readOnlyRootFilesystem: true

--- a/stable/rbac-manager/values.yaml
+++ b/stable/rbac-manager/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: quay.io/reactiveops/rbac-manager
-  tag: v0.9.2
+  tag: v0.9.3
   pullPolicy: Always
 
 resources:


### PR DESCRIPTION
fix #270

Corresponds with this change in the rbac-manager repo: https://github.com/FairwindsOps/rbac-manager/pull/127