### PR TITLE
adding chunk_limit_size parameter to fluentd helm chart

### DIFF
--- a/incubator/fluentd/Chart.yaml
+++ b/incubator/fluentd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.12.43"
 description: Fluentd for multiple endpoints
 name: fluentd
-version: 4.1.1
+version: 4.1.2
 maintainers:
   - name: dosullivan
   - name: coreypobrien

--- a/incubator/fluentd/files/papertrail.conf
+++ b/incubator/fluentd/files/papertrail.conf
@@ -33,6 +33,7 @@
     @type    file
     path    /var/log/fluentd-buffers-papertrail/fluentd-buffer
     flush_thread_count {{ .Values.papertrail.flush_thread_count }}
+    chunk_limit_size {{ .Values.papertrail.chunk_limit_size }}
   </buffer>
   papertrail_host "{{ .Values.papertrail.host }}"
   papertrail_port "{{ .Values.papertrail.port }}"

--- a/incubator/fluentd/values.yaml
+++ b/incubator/fluentd/values.yaml
@@ -33,6 +33,7 @@ papertrail:
   host: logs3.papertrailapp.com
   port: 12785
   flush_thread_count: 4
+  chunk_limit_size: 256MB
 
 
 #####################


### PR DESCRIPTION
Adding the `chunk_limit_size` parameter to the buffer plugin utilized in the papertrail.conf file template. The default is 256MB. Lint tests passed locally. 