### PR TITLE
updating notes for dashboard component

### DIFF
--- a/stable/goldilocks/Chart.yaml
+++ b/stable/goldilocks/Chart.yaml
@@ -4,7 +4,7 @@ description: |
   A Helm chart for running Fairwinds Goldilocks. See https://github.com/FairwindsOps/goldilocks
 name: goldilocks
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/goldilocks/icon.png
-version: 2.2.3
+version: 2.2.4
 maintainers:
   - name: sudermanjr
   - name: dosullivan

--- a/stable/goldilocks/templates/NOTES.txt
+++ b/stable/goldilocks/templates/NOTES.txt
@@ -15,7 +15,7 @@
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "goldilocks.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
   echo http://$SERVICE_IP:{{ .Values.dashboard.service.port }}
 {{- else if contains "ClusterIP" .Values.dashboard.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "goldilocks.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "goldilocks.name" . }},app.kubernetes.io/instance={{ .Release.Name }},app.kubernetes.io/component=dashboard" -o jsonpath="{.items[0].metadata.name}")
   echo "Visit http://127.0.0.1:8080 to use your application"
   kubectl port-forward $POD_NAME 8080:80
 {{- end }}


### PR DESCRIPTION
get pods with the original label selector providers access to the controller, instead of the dashboard