### PR TITLE
Update sync job to use helm 3.2.0

### DIFF
--- a/scripts/repo-sync-fw.sh
+++ b/scripts/repo-sync-fw.sh
@@ -18,8 +18,8 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-readonly HELM_URL=https://storage.googleapis.com/kubernetes-helm
-readonly HELM_TARBALL=helm-v2.14.3-linux-amd64.tar.gz
+readonly HELM_URL=https://get.helm.sh
+readonly HELM_TARBALL=helm-v3.2.0-linux-amd64.tar.gz
 readonly STABLE_REPO_URL=https://charts.fairwinds.com/stable/
 readonly INCUBATOR_REPO_URL=https://charts.fairwinds.com/incubator/
 readonly JETSTACK_REPO_URL=https://charts.jetstack.io

--- a/scripts/repo-sync.sh
+++ b/scripts/repo-sync.sh
@@ -18,8 +18,8 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-readonly HELM_URL=https://storage.googleapis.com/kubernetes-helm
-readonly HELM_TARBALL=helm-v2.14.3-linux-amd64.tar.gz
+readonly HELM_URL=https://get.helm.sh
+readonly HELM_TARBALL=helm-v3.2.0-linux-amd64.tar.gz
 readonly STABLE_REPO_URL=https://charts.reactiveops.com/stable/
 readonly INCUBATOR_REPO_URL=https://charts.reactiveops.com/incubator/
 readonly JETSTACK_REPO_URL=https://charts.jetstack.io


### PR DESCRIPTION
**Why This PR?**
The sync job is using an older version of helm that will not work with 3.2.0