### PR TITLE
[rbac-manager] adding imagePullSecrets to rbac-manager chart

### DIFF
--- a/stable/rbac-manager/Chart.yaml
+++ b/stable/rbac-manager/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rbac-manager
-version: 1.5.3
+version: 1.5.4
 appVersion: 0.9.3
 description: A Kubernetes operator that simplifies the management of Role Bindings and Service Accounts.
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/rbac-manager/icon.png

--- a/stable/rbac-manager/README.md
+++ b/stable/rbac-manager/README.md
@@ -30,6 +30,7 @@ Kubernetes 1.8+, Helm 2.10+
 | `image.repository`          | Docker image repo                           | `quay.io/reactiveops/rbac-manager` |
 | `image.tag`                 | Docker image tag                            | `0.7.0`                            |
 | `image.pullPolicy`          | Docker image pull policy                    | `Always`                           |
+| `image.imagePullSecrets`    | Docker registry credentials                 | `[]`                               |
 | `resources.requests.cpu`    | CPU resource request                        | `100m`                             |
 | `resources.requests.memory` | Memory resource request                     | `128Mi`                            |
 | `resources.limits.cpu`      | CPU resource limit                          | `100m`                             |

--- a/stable/rbac-manager/templates/deployment.yaml
+++ b/stable/rbac-manager/templates/deployment.yaml
@@ -34,6 +34,10 @@ spec:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+{{- if .Values.image.imagePullSecrets }}
+        imagePullSecrets:
+        {{ toYaml .Values.image.imagePullSecrets }}
+{{- end }}
         readinessProbe:
           httpGet:
             scheme: HTTP

--- a/stable/rbac-manager/values.yaml
+++ b/stable/rbac-manager/values.yaml
@@ -2,6 +2,7 @@ image:
   repository: quay.io/reactiveops/rbac-manager
   tag: v0.9.3
   pullPolicy: Always
+  imagePullSecrets: []
 
 resources:
   requests:


### PR DESCRIPTION
**Why This PR?**
We are using rbac-manager in environments were we might not have external internet access and rely on an internal Private Docker registry.

Fixes #

**Changes**
Changes proposed in this pull request:

* Adding the ability to define imagePullSecrets to the rbac-manager deployment through the values.yaml

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
