### PR TITLE
adding configurable-hpa chart

### DIFF
--- a/incubator/configurable-hpa/.helmignore
+++ b/incubator/configurable-hpa/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/incubator/configurable-hpa/Chart.yaml
+++ b/incubator/configurable-hpa/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+appVersion: "0.0.1"
+description: A chart to install configurable HPA
+name: configurable-hpa
+version: 0.1.0
+maintainers:
+    - name: crmejia

--- a/incubator/configurable-hpa/templates/_helpers.tpl
+++ b/incubator/configurable-hpa/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "configurable-hpa.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "configurable-hpa.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "configurable-hpa.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/incubator/configurable-hpa/templates/deployment.yaml
+++ b/incubator/configurable-hpa/templates/deployment.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "configurable-hpa.name" . }}
+  labels:
+    app: {{ template "configurable-hpa.name" . }}
+    chart: {{ template "configurable-hpa.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ template "configurable-hpa.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "configurable-hpa.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      serviceAccountName: kube-system-configurable-hpa-controller
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.name }}:{{ .Values.image.tag }}"
+          imagePullPolicy: IfNotPresent
+          resources:
+{{ toYaml .Values.resources | indent 12 }}

--- a/incubator/configurable-hpa/values.yaml
+++ b/incubator/configurable-hpa/values.yaml
@@ -1,0 +1,8 @@
+image:
+  tag: latest
+  name: quay.io/reactiveops/configurable-hpa
+
+resources: 
+  cpu: "100m"
+  mem: "128Mi"
+

--- a/incubator/configurable-hpa/values.yaml
+++ b/incubator/configurable-hpa/values.yaml
@@ -2,7 +2,10 @@ image:
   tag: latest
   name: quay.io/reactiveops/configurable-hpa
 
-resources: 
-  cpu: "100m"
-  mem: "128Mi"
-
+resources:
+  requests:
+    memory: 100Mi
+    cpu: 10m
+  limits:
+    memory: 100Mi
+    cpu: 10m


### PR DESCRIPTION
**Why This PR?**
Adding configurable-hpa as a tool that a client wants.

**Changes**
Changes proposed in this pull request:
* new chart

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
