### PR TITLE
Update to Polaris 1.0

### DIFF
--- a/stable/polaris/CHANGELOG.md
+++ b/stable/polaris/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this Helm chart will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this chart adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 1.0.0
+Updated to Polaris 1.0.
+
+In addition to changes needed for Polaris 1.0, there are some chart changes:
+* RBAC has been simplified to remove duplication
+* `config` now uses the built-in Polaris config by default
+* `ingress` is now attached to the dashboard values
+* only a single `image` is specified for the entire chart
+
 ## 0.6.0
 
 ### Fixed

--- a/stable/polaris/Chart.yaml
+++ b/stable/polaris/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 description: Validation of best practices in your Kubernetes clusters
 name: polaris
-version: 0.10.2
-appVersion: "0.6"
+version: 1.0.0
+appVersion: "1.0"
 icon: https://raw.githubusercontent.com/FairwindsOps/polaris/master/pkg/dashboard/assets/favicon-32x32.png
 maintainers:
-  - name: bobby-brennan
+  - name: rbren
     email: robertb@fairwinds.com

--- a/stable/polaris/README.md
+++ b/stable/polaris/README.md
@@ -30,7 +30,6 @@ Parameter | Description | Default
 `image.tag` | Image tag | 1.0
 `image.pullPolicy` | Image pull policy | Always
 `image.pullSecrets` | Image pull secrets | []
-`rbac.create` | Whether to create RBAC | true
 `templateOnly` | | false
 `dashboard.enable` | Whether to run the dashboard | true
 `dashboard.replicas` | Number of replicas | 1

--- a/stable/polaris/README.md
+++ b/stable/polaris/README.md
@@ -25,36 +25,28 @@ Due to the [future deprecation](https://kubernetes.io/blog/2019/07/18/api-deprec
 ## Configuration
 Parameter | Description | Default
 --------- | ----------- | -------
-`config`  | The [polaris configuration](https://github.com/FairwindsOps/polaris#configuration) | see values.yaml
+`config`  | The [polaris configuration](https://github.com/FairwindsOps/polaris#configuration) | [taken from Polaris](https://github.com/FairwindsOps/polaris/blob/master/examples/config.yaml)
+`image.repository` | Image repo | quay.io/fairwinds/polaris
+`image.tag` | Image tag | 1.0
+`image.pullPolicy` | Image pull policy | Always
+`image.pullSecrets` | Image pull secrets | []
+`rbac.create` | Whether to create RBAC | true
+`templateOnly` | | false
 `dashboard.enable` | Whether to run the dashboard | true
 `dashboard.replicas` | Number of replicas | 1
 `dashboard.service.type` | Service type | ClusterIP
 `dashboard.service.annotatotions` | Service annotations | {}
-`dashboard.image.repository` | Image repo | quay.io/fairwinds/polaris
-`dashboard.image.tag` | Image tag | 0.6
-`dashboard.image.pullPolicy` | Image pull policy | Always
-`dashboard.image.imagePullSecrets` | Image pull secrets | []
 `dashboard.nodeSelector` | Dashboard pod nodeSelector | {}
 `dashboard.tolerations` | Dashboard pod tolerations | []
+`dashboard.ingress.enabled` | Whether to enable ingress to the dashboard | false
+`dashboard.ingress.hosts` | Web ingress hostnames | []
+`dashboard.ingress.tls` | ingress tls configuration |
+`dashboard.ingress.annotations` | Web ingress annotations | {}
 `webhook.enable` | Whether to run the dashboard | false
 `webhook.replicas` | Number of replicas | 1
 `webhook.service.type` | Service type | ClusterIP
-`webhook.image.repository` | Image repo | quay.io/fairwinds/polaris
-`webhook.image.tag` | Image tag | 0.6
-`webhook.image.pullPolicy` | Image pull policy | Always
-`webhook.image.imagePullSecrets` | Image pull secrets | []
 `webhook.nodeSelector` | Webhook pod nodeSelector | {}
 `webhook.tolerations` | Webhook pod tolerations | []
 `audit.enable` | Runs a one-time audit. This is used internally at Fairwinds, and may not be useful for others | false
 `audit.outputURL` | A URL which will receive a POST request with audit results | ""
 `audit.cleanup` | Whether to delete the namespace once the audit is finished | false
-`audit.image.repository` | Image repo | quay.io/fairwinds/polaris
-`audit.image.tag` | Image tag | 0.6
-`audit.image.pullPolicy` | Image pull policy | Always
-`audit.image.imagePullSecrets` | Image pull secrets | []
-`rbac.create` | Whether to create RBAC | true
-`templateOnly` | | false
-`ingress.enabled` | Whether to enable ingress to the dashboard | false
-`ingress.hosts` | Web ingress hostnames | []
-`ingress.tls` | ingress tls configuration |
-`ingress.annotations` | Web ingress annotations | {}

--- a/stable/polaris/templates/audit.job.yaml
+++ b/stable/polaris/templates/audit.job.yaml
@@ -2,8 +2,10 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
+  {{- with .Values.config }}
   annotations:
     checksum/config: '{{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}'
+  {{- end }}
   name: {{ include "polaris.fullname" . }}
   {{- if .Values.templateOnly }}
   namespace: {{ .Release.Namespace }}
@@ -24,10 +26,12 @@ spec:
         - {{ required "Must set audit.outputURL in values if you enable the audit job." .Values.audit.outputURL }}
         - --output-file
         - /tmp/results/done
+        {{- with .Values.config }}
         - --config
         - /opt/app/config.yaml
-        image: '{{.Values.audit.image.repository}}:{{.Values.audit.image.tag}}'
-        imagePullPolicy: '{{.Values.audit.image.pullPolicy}}'
+        {{- end }}
+        image: '{{.Values.image.repository}}:{{.Values.image.tag}}'
+        imagePullPolicy: '{{.Values.image.pullPolicy}}'
         name: audit
         resources:
           limits:
@@ -45,10 +49,12 @@ spec:
             drop:
               - ALL
         volumeMounts:
+        {{- with .Values.config }}
         - name: config
           mountPath: /opt/app/config.yaml
           subPath: config.yaml
           readOnly: true
+        {{- end }}
         - name: results
           mountPath: /tmp/results
       {{- if .Values.audit.cleanup }}
@@ -65,8 +71,10 @@ spec:
           mountPath: /tmp/results
       {{- end }}
       volumes:
+      {{- with .Values.config }}
       - name: config
         configMap:
           name: {{ include "polaris.fullname" . }}
+      {{- end }}
       - name: results
 {{- end -}}

--- a/stable/polaris/templates/audit.job.yaml
+++ b/stable/polaris/templates/audit.job.yaml
@@ -16,7 +16,7 @@ metadata:
 spec:
   template:
     spec:
-      serviceAccountName: {{ include "polaris.fullname" . }}-audit
+      serviceAccountName: {{ include "polaris.fullname" . }}
       restartPolicy: Never
       containers:
       - command:

--- a/stable/polaris/templates/audit.job.yaml
+++ b/stable/polaris/templates/audit.job.yaml
@@ -21,7 +21,7 @@ spec:
       containers:
       - command:
         - polaris
-        - --audit
+        - audit
         - --output-url
         - {{ required "Must set audit.outputURL in values if you enable the audit job." .Values.audit.outputURL }}
         - --output-file

--- a/stable/polaris/templates/audit.rbac.yaml
+++ b/stable/polaris/templates/audit.rbac.yaml
@@ -1,82 +1,8 @@
-{{- if and .Values.audit.enable .Values.rbac.create -}}
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: {{ include "polaris.fullname" . }}-audit
-  {{- if .Values.templateOnly }}
-  namespace: {{ .Release.Namespace }}
-  {{- end }}
-  labels:
-    {{- include "polaris.labels" . | nindent 4 }}
-{{- if .Values.image.pullSecrets }}
-imagePullSecrets:
-{{- range .Values.image.pullSecrets }}
-  - name: {{ . }}
-{{- end }}
-{{- end }}
----
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRole
-metadata:
-  name: {{ include "polaris.fullname" . }}-audit
-  {{- if .Values.templateOnly }}
-  namespace: {{ .Release.Namespace }}
-  {{- end }}
-  labels:
-    {{- include "polaris.labels" . | nindent 4 }}
-rules:
-  - apiGroups:
-      - 'apps'
-      - 'extensions'
-    resources:
-      - 'deployments'
-      - 'statefulsets'
-      - 'daemonsets'
-    verbs:
-      - 'get'
-      - 'list'
-  - apiGroups:
-      - 'batch'
-    resources:
-      - 'jobs'
-      - 'cronjobs'
-    verbs:
-      - 'get'
-      - 'list'
-  - apiGroups:
-      - ''
-    resources:
-      - 'nodes'
-      - 'namespaces'
-      - 'pods'
-      - 'replicationcontrollers'
-    verbs:
-      - 'get'
-      - 'list'
----
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRoleBinding
-metadata:
-  name: {{ include "polaris.fullname" . }}-audit
-  {{- if .Values.templateOnly }}
-  namespace: {{ .Release.Namespace }}
-  {{- end }}
-  labels:
-    {{- include "polaris.labels" . | nindent 4 }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: {{ include "polaris.fullname" . }}-audit
-subjects:
-  - kind: ServiceAccount
-    name: {{ include "polaris.fullname" . }}-audit
-    namespace: {{ .Release.Namespace }}
----
 {{- if .Values.audit.cleanup }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
-  name: polaris-cleanup
+  name: {{ include "polaris.fullname" . }}-audit-cleanup
   {{- if .Values.templateOnly }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -95,7 +21,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
-  name: polaris-cleanup
+  name: {{ include "polaris.fullname" . }}-audit-cleanup
   {{- if .Values.templateOnly }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -104,10 +30,9 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: polaris-cleanup
+  name: {{ include "polaris.fullname" . }}-audit-cleanup
 subjects:
   - kind: ServiceAccount
-    name: {{ include "polaris.fullname" . }}-audit
+    name: {{ include "polaris.fullname" . }}
     namespace: {{ .Release.Namespace }}
-{{- end -}}
 {{- end -}}

--- a/stable/polaris/templates/audit.rbac.yaml
+++ b/stable/polaris/templates/audit.rbac.yaml
@@ -8,9 +8,9 @@ metadata:
   {{- end }}
   labels:
     {{- include "polaris.labels" . | nindent 4 }}
-{{- if .Values.audit.image.imagePullSecrets }}
+{{- if .Values.image.pullSecrets }}
 imagePullSecrets:
-{{- range .Values.audit.image.imagePullSecrets }}
+{{- range .Values.image.pullSecrets }}
   - name: {{ . }}
 {{- end }}
 {{- end }}

--- a/stable/polaris/templates/configmap.yaml
+++ b/stable/polaris/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.config }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -9,3 +10,4 @@ metadata:
     {{- include "polaris.labels" . | nindent 4 }}
 data:
   config.yaml: {{- toYaml .Values.config | indent 2 -}}
+{{- end }}

--- a/stable/polaris/templates/configmap.yaml
+++ b/stable/polaris/templates/configmap.yaml
@@ -1,13 +1,14 @@
-{{- if .Values.config }}
+{{- with .Values.config }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "polaris.fullname" . }}
-  {{- if .Values.templateOnly }}
-  namespace: {{ .Release.Namespace }}
+  name: {{ include "polaris.fullname" $ }}
+  {{- if $.Values.templateOnly }}
+  namespace: {{ $.Release.Namespace }}
   {{- end }}
   labels:
-    {{- include "polaris.labels" . | nindent 4 }}
+    {{- include "polaris.labels" $ | nindent 4 }}
 data:
-  config.yaml: {{- toYaml .Values.config | indent 2 -}}
+  config.yaml: |
+    {{- toYaml . | nindent 4 }}
 {{- end }}

--- a/stable/polaris/templates/dashboard.deployment.yaml
+++ b/stable/polaris/templates/dashboard.deployment.yaml
@@ -17,8 +17,10 @@ spec:
       component: dashboard
   template:
     metadata:
+      {{- with .Values.config }}
       annotations:
-        checksum/config: '{{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}'
+        checksum/config: '{{ include (print $.Template.BasePath "/configmap.yaml") $ | sha256sum }}'
+      {{- end }}
       labels:
         {{- include "polaris.selectors" . | nindent 8 }}
         component: dashboard
@@ -27,7 +29,7 @@ spec:
       volumes:
       - name: config
         configMap:
-          name: {{ include "polaris.fullname" . }}
+          name: {{ include "polaris.fullname" $ }}
       {{- end }}
       containers:
       - command:

--- a/stable/polaris/templates/dashboard.deployment.yaml
+++ b/stable/polaris/templates/dashboard.deployment.yaml
@@ -80,7 +80,7 @@ spec:
           subPath: config.yaml
           readOnly: true
         {{- end }}
-      serviceAccountName: {{ include "polaris.fullname" . }}-dashboard
+      serviceAccountName: {{ include "polaris.fullname" . }}
       nodeSelector:
       {{- with .Values.dashboard.nodeSelector }}
 {{ toYaml . | indent 8 }}

--- a/stable/polaris/templates/dashboard.deployment.yaml
+++ b/stable/polaris/templates/dashboard.deployment.yaml
@@ -23,22 +23,26 @@ spec:
         {{- include "polaris.selectors" . | nindent 8 }}
         component: dashboard
     spec:
+      {{- with .Values.config }}
       volumes:
       - name: config
         configMap:
           name: {{ include "polaris.fullname" . }}
+      {{- end }}
       containers:
       - command:
         - polaris
         - --dashboard
+        {{- with .Values.config }}
         - --config
         - /opt/app/config.yaml
+        {{- end }}
         {{- with .Values.dashboard.basePath }}
         - --dashboard-base-path
         - {{ . }}
         {{- end }}
-        image: '{{.Values.dashboard.image.repository}}:{{.Values.dashboard.image.tag}}'
-        imagePullPolicy: '{{.Values.dashboard.image.pullPolicy}}'
+        image: '{{.Values.image.repository}}:{{.Values.image.tag}}'
+        imagePullPolicy: '{{.Values.image.pullPolicy}}'
         name: dashboard
         ports:
         - containerPort: 8080
@@ -69,11 +73,13 @@ spec:
           capabilities:
             drop:
               - ALL
+        {{- with .Values.config }}
         volumeMounts:
         - name: config
           mountPath: /opt/app/config.yaml
           subPath: config.yaml
           readOnly: true
+        {{- end }}
       serviceAccountName: {{ include "polaris.fullname" . }}-dashboard
       nodeSelector:
       {{- with .Values.dashboard.nodeSelector }}

--- a/stable/polaris/templates/dashboard.deployment.yaml
+++ b/stable/polaris/templates/dashboard.deployment.yaml
@@ -32,13 +32,13 @@ spec:
       containers:
       - command:
         - polaris
-        - --dashboard
+        - dashboard
         {{- with .Values.config }}
         - --config
         - /opt/app/config.yaml
         {{- end }}
         {{- with .Values.dashboard.basePath }}
-        - --dashboard-base-path
+        - --base-path
         - {{ . }}
         {{- end }}
         image: '{{.Values.image.repository}}:{{.Values.image.tag}}'

--- a/stable/polaris/templates/dashboard.rbac.yaml
+++ b/stable/polaris/templates/dashboard.rbac.yaml
@@ -8,9 +8,9 @@ metadata:
   {{- end }}
   labels:
     {{- include "polaris.labels" . | nindent 4 }}
-{{- if .Values.dashboard.image.imagePullSecrets }}
+{{- if .Values.image.pullSecrets }}
 imagePullSecrets:
-{{- range .Values.dashboard.image.imagePullSecrets }}
+{{- range .Values.image.pullSecrets }}
   - name: {{ . }}
 {{- end }}
 {{- end }}

--- a/stable/polaris/templates/ingress.yaml
+++ b/stable/polaris/templates/ingress.yaml
@@ -1,10 +1,10 @@
-{{- if .Values.ingress.enabled -}}
+{{- if .Values.dashboard.ingress.enabled -}}
 {{ $serviceName := printf "%s-dashboard" (include "polaris.fullname" .) -}}
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   annotations:
-    {{- range $key, $value := .Values.ingress.annotations }}
+    {{- range $key, $value := .Values.dashboard.ingress.annotations }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
   labels:
@@ -14,7 +14,7 @@ metadata:
   name: polaris
 spec:
   rules:
-  {{- range .Values.ingress.hosts }}
+  {{- range .Values.dashboard.ingress.hosts }}
   - host: {{ . }}
     http:
       paths:
@@ -22,8 +22,8 @@ spec:
           serviceName: {{ $serviceName }}
           servicePort: 80
   {{- end -}}
-{{- if .Values.ingress.tls }}
+{{- if .Values.dashboard.ingress.tls }}
   tls:
-{{ toYaml .Values.ingress.tls | indent 4 }}
+{{ toYaml .Values.dashboard.ingress.tls | indent 4 }}
 {{- end -}}
 {{- end -}}

--- a/stable/polaris/templates/rbac.yaml
+++ b/stable/polaris/templates/rbac.yaml
@@ -1,8 +1,7 @@
-{{- if and .Values.dashboard.enable .Values.rbac.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "polaris.fullname" . }}-dashboard
+  name: {{ include "polaris.fullname" . }}
   {{- if .Values.templateOnly }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -16,37 +15,33 @@ imagePullSecrets:
 {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "polaris.fullname" . }}-view
+  labels:
+    {{- include "polaris.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "polaris.fullname" . }}
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
-  name: {{ include "polaris.fullname" . }}-dashboard
+  name: {{ include "polaris.fullname" . }}
   labels:
     {{- include "polaris.labels" . | nindent 4 }}
 rules:
-  - apiGroups:
-      - 'apps'
-      - 'extensions'
-    resources:
-      - 'deployments'
-      - 'statefulsets'
-      - 'daemonsets'
-    verbs:
-      - 'get'
-      - 'list'
-  - apiGroups:
-      - 'batch'
-    resources:
-      - 'jobs'
-      - 'cronjobs'
-    verbs:
-      - 'get'
-      - 'list'
+  # required by controller-runtime code doing a cluster wide lookup
+  # when it seems namespace would suffice
   - apiGroups:
       - ''
     resources:
       - 'nodes'
-      - 'namespaces'
-      - 'pods'
-      - 'replicationcontrollers'
     verbs:
       - 'get'
       - 'list'
@@ -54,15 +49,14 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "polaris.fullname" . }}-dashboard
+  name: {{ include "polaris.fullname" . }}
   labels:
     {{- include "polaris.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "polaris.fullname" . }}-dashboard
+  name: {{ include "polaris.fullname" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ include "polaris.fullname" . }}-dashboard
+    name: {{ include "polaris.fullname" . }}
     namespace: {{ .Release.Namespace }}
-{{- end -}}

--- a/stable/polaris/templates/webhook.deployment.yaml
+++ b/stable/polaris/templates/webhook.deployment.yaml
@@ -29,7 +29,7 @@ spec:
         - name: webhook
           command:
             - polaris
-            - --webhook
+            - webhook
             {{- with .Values.config }}
             - --config
             - /opt/app/config.yaml

--- a/stable/polaris/templates/webhook.deployment.yaml
+++ b/stable/polaris/templates/webhook.deployment.yaml
@@ -85,7 +85,7 @@ spec:
             - name: cr-logs
               mountPath: /tmp/
               readOnly: false
-      serviceAccountName:  {{ include "polaris.fullname" . }}-webhook
+      serviceAccountName:  {{ include "polaris.fullname" . }}
       nodeSelector:
       {{- with .Values.webhook.nodeSelector }}
 {{ toYaml . | indent 8 }}

--- a/stable/polaris/templates/webhook.deployment.yaml
+++ b/stable/polaris/templates/webhook.deployment.yaml
@@ -22,7 +22,6 @@ spec:
         checksum/config: '{{ include (print $.Template.BasePath "/configmap.yaml") $ | sha256sum }}'
       {{- end }}
       labels:
-      labels:
         {{- include "polaris.selectors" . | nindent 8 }}
         component: webhook
     spec:

--- a/stable/polaris/templates/webhook.deployment.yaml
+++ b/stable/polaris/templates/webhook.deployment.yaml
@@ -18,7 +18,9 @@ spec:
   template:
     metadata:
       annotations:
+        {{- with .Values.config }}
         checksum/config: '{{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}'
+        {{- end }}
       labels:
         {{- include "polaris.selectors" . | nindent 8 }}
         component: webhook
@@ -28,10 +30,12 @@ spec:
           command:
             - polaris
             - --webhook
+            {{- with .Values.config }}
             - --config
             - /opt/app/config.yaml
-          image: '{{.Values.webhook.image.repository}}:{{.Values.webhook.image.tag}}'
-          imagePullPolicy: '{{.Values.webhook.image.pullPolicy}}'
+            {{- end }}
+          image: '{{.Values.image.repository}}:{{.Values.image.tag}}'
+          imagePullPolicy: '{{.Values.image.pullPolicy}}'
           ports:
             - containerPort: 9876
           # These are fairly useless readiness/liveness probes for now
@@ -69,10 +73,12 @@ spec:
               drop:
                 - ALL
           volumeMounts:
+            {{- with .Values.config }}
             - name: config
               mountPath: /opt/app/config.yaml
               subPath: config.yaml
               readOnly: true
+            {{- end }}
             - name: secret
               mountPath: /opt/cert/
               readOnly: true
@@ -89,9 +95,11 @@ spec:
 {{ toYaml . | indent 6 }}
       {{- end }}
       volumes:
+        {{- with .Values.config }}
         - name: config
           configMap:
             name: {{ include "polaris.fullname" . }}
+        {{- end }}
         - name: secret
           secret:
             secretName: polaris-webhook

--- a/stable/polaris/templates/webhook.deployment.yaml
+++ b/stable/polaris/templates/webhook.deployment.yaml
@@ -17,10 +17,11 @@ spec:
       component: webhook
   template:
     metadata:
+      {{- with .Values.config }}
       annotations:
-        {{- with .Values.config }}
-        checksum/config: '{{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}'
-        {{- end }}
+        checksum/config: '{{ include (print $.Template.BasePath "/configmap.yaml") $ | sha256sum }}'
+      {{- end }}
+      labels:
       labels:
         {{- include "polaris.selectors" . | nindent 8 }}
         component: webhook
@@ -98,7 +99,7 @@ spec:
         {{- with .Values.config }}
         - name: config
           configMap:
-            name: {{ include "polaris.fullname" . }}
+            name: {{ include "polaris.fullname" $ }}
         {{- end }}
         - name: secret
           secret:

--- a/stable/polaris/templates/webhook.rbac.yaml
+++ b/stable/polaris/templates/webhook.rbac.yaml
@@ -1,20 +1,4 @@
-{{- if and .Values.webhook.enable .Values.rbac.create -}}
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: {{ include "polaris.fullname" . }}-webhook
-  {{- if .Values.templateOnly }}
-  namespace: {{ .Release.Namespace }}
-  {{- end }}
-  labels:
-    {{- include "polaris.labels" . | nindent 4 }}
-{{- if .Values.image.pullSecrets }}
-imagePullSecrets:
-{{- range .Values.image.pullSecrets }}
-  - name: {{ . }}
-{{- end }}
-{{- end }}
----
+{{- if and .Values.webhook.enable -}}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
@@ -22,35 +6,6 @@ metadata:
   labels:
     {{- include "polaris.labels" . | nindent 4 }}
 rules:
-  # auditor rules rbac
-  - apiGroups:
-      - 'apps'
-      - 'extensions'
-    resources:
-      - 'deployments'
-      - 'statefulsets'
-      - 'daemonsets'
-    verbs:
-      - 'get'
-      - 'list'
-  - apiGroups:
-      - 'batch'
-    resources:
-      - 'jobs'
-      - 'cronjobs'
-    verbs:
-      - 'get'
-      - 'list'
-  - apiGroups:
-      - ''
-    resources:
-      - 'nodes'
-      - 'namespaces'
-      - 'pods'
-      - 'replicationcontrollers'
-    verbs:
-      - 'get'
-      - 'list'
   # required by controller-runtime code doing a cluster wide lookup
   # when it seems namespace would suffice
   - apiGroups:
@@ -81,7 +36,7 @@ roleRef:
   name: {{ include "polaris.fullname" . }}-webhook
 subjects:
   - kind: ServiceAccount
-    name: {{ include "polaris.fullname" . }}-webhook
+    name: {{ include "polaris.fullname" . }}
     namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -118,6 +73,6 @@ roleRef:
   name: {{ include "polaris.fullname" . }}-webhook
 subjects:
   - kind: ServiceAccount
-    name: {{ include "polaris.fullname" . }}-webhook
+    name: {{ include "polaris.fullname" . }}
     namespace: {{ .Release.Namespace }}
 {{- end -}}

--- a/stable/polaris/templates/webhook.rbac.yaml
+++ b/stable/polaris/templates/webhook.rbac.yaml
@@ -8,9 +8,9 @@ metadata:
   {{- end }}
   labels:
     {{- include "polaris.labels" . | nindent 4 }}
-{{- if .Values.webhook.image.imagePullSecrets }}
+{{- if .Values.image.pullSecrets }}
 imagePullSecrets:
-{{- range .Values.webhook.image.imagePullSecrets }}
+{{- range .Values.image.pullSecrets }}
   - name: {{ . }}
 {{- end }}
 {{- end }}

--- a/stable/polaris/values.yaml
+++ b/stable/polaris/values.yaml
@@ -1,83 +1,31 @@
----
-config: |
-  resources:
-    cpuRequestsMissing: warning
-    cpuLimitsMissing: warning
-    memoryRequestsMissing: warning
-    memoryLimitsMissing: warning
-  images:
-    tagNotSpecified: error
-  healthChecks:
-    readinessProbeMissing: warning
-    livenessProbeMissing: warning
-  networking:
-    hostNetworkSet: warning
-    hostPortSet: warning
-  security:
-    hostIPCSet: error
-    hostPIDSet: error
-    notReadOnlyRootFileSystem: warning
-    privilegeEscalationAllowed: error
-    runAsRootAllowed: warning
-    runAsPrivileged: error
-    capabilities:
-      error:
-        ifAnyAdded:
-          - SYS_ADMIN
-          - NET_ADMIN
-          - ALL
-      warning:
-        ifAnyAddedBeyond:
-          - CHOWN
-          - DAC_OVERRIDE
-          - FSETID
-          - FOWNER
-          - MKNOD
-          - NET_RAW
-          - SETGID
-          - SETUID
-          - SETFCAP
-          - SETPCAP
-          - NET_BIND_SERVICE
-          - SYS_CHROOT
-          - KILL
-          - AUDIT_WRITE
-  controllers_to_scan:
-    - Deployments
-    - StatefulSets
-    - DaemonSets
-    - Jobs
-    - CronJobs
-    - ReplicationControllers
+image:
+  repository: quay.io/fairwinds/polaris
+  tag: 1.0
+  pullPolicy: Always
+  pullSecrets: []
+
+rbac:
+  create: true
+
+templateOnly: false
+
 dashboard:
   enable: true
   replicas: 1
   service:
     type: ClusterIP
     annotations: {}
-  image:
-    repository: quay.io/fairwinds/polaris
-    tag: 0.6
-    pullPolicy: Always
-    imagePullSecrets: []
   nodeSelector: {}
   tolerations: []
-
-ingress:
-  enabled: false
-  hosts: []
-  annotations: {}
-  tls:
-
+  ingress:
+    enabled: false
+    hosts: []
+    annotations: {}
+    tls: {}
 
 webhook:
   enable: false
   replicas: 1
-  image:
-    repository: quay.io/fairwinds/polaris
-    tag: 0.6
-    pullPolicy: Always
-    imagePullSecrets: []
   nodeSelector: {}
   tolerations: []
 
@@ -85,13 +33,4 @@ audit:
   enable: false
   cleanup: false
   outputURL: ""
-  image:
-    repository: quay.io/fairwinds/polaris
-    tag: 0.6
-    pullPolicy: Always
-    imagePullSecrets: []
 
-rbac:
-  create: true
-
-templateOnly: false

--- a/stable/polaris/values.yaml
+++ b/stable/polaris/values.yaml
@@ -4,9 +4,6 @@ image:
   pullPolicy: Always
   pullSecrets: []
 
-rbac:
-  create: true
-
 templateOnly: false
 
 dashboard:

--- a/stable/polaris/values.yaml
+++ b/stable/polaris/values.yaml
@@ -33,4 +33,3 @@ audit:
   enable: false
   cleanup: false
   outputURL: ""
-


### PR DESCRIPTION
**Why This PR?**
Polaris 1.0 is shipping with some breaking changes.

**Changes**
In addition to changes needed for Polaris 1.0, there are some chart changes:
* RBAC has been simplified to remove duplication
* `config` now uses the built-in Polaris config by default
* `ingress` is now attached to the dashboard values
* only a single `image` is specified for the entire chart

**Checklist:**

* [x ] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x ] Any new values are backwards compatible and/or have sensible default.
* [x ] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
