### PR TITLE
update release watcher version

### DIFF
--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 0.18.10
-appVersion: 1.2.0
+version: 0.19.0
+appVersion: 1.3.2
 maintainers:
   - name: rbren
   - name: makoscafee

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
 version: 0.19.0
-appVersion: 1.3.2
+appVersion: 1.4.0
 maintainers:
   - name: rbren
   - name: makoscafee

--- a/stable/insights-agent/templates/release-watcher/_job.yaml
+++ b/stable/insights-agent/templates/release-watcher/_job.yaml
@@ -22,6 +22,8 @@ containers:
     - file
     - --file-path
     - /output/release-watcher.json
+    - --helm-version
+    - auto
   volumeMounts:
   - name: output
     mountPath: /output

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -132,7 +132,7 @@ releasewatcher:
   timeout: 300
   image:
     repository: quay.io/fairwinds/release-watcher
-    tag: "v1.7"
+    tag: "v1.8"
   resources:
     limits:
       cpu: 100m


### PR DESCRIPTION
**Why This PR?**
Updating `release-watcher` to include helm 2 support

Fixes #

**Changes**
Changes proposed in this pull request:

* update `release-watcher` image tag
* update `--helm-version` tag to include both version 2 and 3 with `auto` value
* update chart version and app version

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [ ] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
