### PR TITLE
[polaris] add basePath support to health check

### DIFF
--- a/stable/polaris/Chart.yaml
+++ b/stable/polaris/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Validation of best practices in your Kubernetes clusters
 name: polaris
-version: 1.0.0
+version: 1.0.1
 appVersion: "1.0"
 icon: https://raw.githubusercontent.com/FairwindsOps/polaris/master/pkg/dashboard/assets/favicon-32x32.png
 maintainers:

--- a/stable/polaris/templates/dashboard.deployment.yaml
+++ b/stable/polaris/templates/dashboard.deployment.yaml
@@ -50,13 +50,13 @@ spec:
         - containerPort: 8080
         livenessProbe:
           httpGet:
-            path: /health
+            path: {{.Values.dashboard.basePath | default "/" }}health
             port: 8080
           initialDelaySeconds: 5
           periodSeconds: 20
         readinessProbe:
           httpGet:
-            path: /health
+            path: {{.Values.dashboard.basePath | default "/" }}health
             port: 8080
           initialDelaySeconds: 5
           periodSeconds: 20


### PR DESCRIPTION
**Why This PR?**
The health check path is hard-coded in the Polaris dashboard template. Therefore, using basePath will break the redinessProbe and livenessProbe health check.


**Changes**
Changes proposed in this pull request:

* Added default path to health check path.
* Adedd basePath prefix to health check path while specifying basePath.

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.