### PR TITLE
[polaris] fix tag version

### DIFF
--- a/stable/polaris/Chart.yaml
+++ b/stable/polaris/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Validation of best practices in your Kubernetes clusters
 name: polaris
-version: 1.0.1
+version: 1.0.2
 appVersion: "1.0"
 icon: https://raw.githubusercontent.com/FairwindsOps/polaris/master/pkg/dashboard/assets/favicon-32x32.png
 maintainers:

--- a/stable/polaris/values.yaml
+++ b/stable/polaris/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: quay.io/fairwinds/polaris
-  tag: 1.0
+  tag: "1.0"
   pullPolicy: Always
   pullSecrets: []
 


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Thanks to `1.0` getting interpreted as a float, tags were getting set to `1` instead of `1.0`

**Checklist:**

* [x ] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x ] Any new values are backwards compatible and/or have sensible default.
* [x ] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
