### PR TITLE
In Ingress tls is an array

### DIFF
--- a/stable/polaris/Chart.yaml
+++ b/stable/polaris/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Validation of best practices in your Kubernetes clusters
 name: polaris
-version: 1.1.0
+version: 1.1.1
 appVersion: "1.0"
 icon: https://raw.githubusercontent.com/FairwindsOps/polaris/master/pkg/dashboard/assets/favicon-32x32.png
 maintainers:

--- a/stable/polaris/values.yaml
+++ b/stable/polaris/values.yaml
@@ -18,7 +18,7 @@ dashboard:
     enabled: false
     hosts: []
     annotations: {}
-    tls: {}
+    tls: []
   resources:
     requests:
       cpu: 100m


### PR DESCRIPTION
I'm getting this error:
`helm upgrade --install polaris charts/polaris --namespace polaris -f overrides.yaml`
`coalesce.go:192: warning: cannot overwrite table with non table for tls (map[])`

API docs say this:
```
$ kubectl explain ingress.spec.tls
KIND:     Ingress
VERSION:  extensions/v1beta1

RESOURCE: tls <[]Object>

DESCRIPTION:
     TLS configuration. Currently the Ingress only supports a single TLS port,
     443. If multiple members of this list specify different hosts, they will be
     multiplexed on the same port according to the hostname specified through
     the SNI TLS extension, if the ingress controller fulfilling the ingress
     supports SNI.

     IngressTLS describes the transport layer security associated with an
     Ingress.

FIELDS:
   hosts        <[]string>
     Hosts are a list of hosts included in the TLS certificate. The values in
     this list must match the name/s used in the tlsSecret. Defaults to the
     wildcard host setting for the loadbalancer controller fulfilling this
     Ingress, if left unspecified.

   secretName   <string>
     SecretName is the name of the secret used to terminate SSL traffic on 443.
     Field is left optional to allow SSL routing based on SNI hostname alone. If
     the SNI host in a listener conflicts with the "Host" header field used by
     an IngressRule, the SNI host is used for termination and value of the Host
     header is used for routing.
```

**Why This PR?**
_a short description of why this PR is needed_

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [ ] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
