### PR TITLE
[polaris] add resources option to chart

### DIFF
--- a/stable/polaris/Chart.yaml
+++ b/stable/polaris/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Validation of best practices in your Kubernetes clusters
 name: polaris
-version: 1.0.2
+version: 1.1.0
 appVersion: "1.0"
 icon: https://raw.githubusercontent.com/FairwindsOps/polaris/master/pkg/dashboard/assets/favicon-32x32.png
 maintainers:

--- a/stable/polaris/README.md
+++ b/stable/polaris/README.md
@@ -32,6 +32,7 @@ Parameter | Description | Default
 `image.pullSecrets` | Image pull secrets | []
 `templateOnly` | | false
 `dashboard.enable` | Whether to run the dashboard | true
+`dashboard.resources` | Requests and limits for the dashboard | (see values.yaml)
 `dashboard.replicas` | Number of replicas | 1
 `dashboard.service.type` | Service type | ClusterIP
 `dashboard.service.annotatotions` | Service annotations | {}
@@ -42,6 +43,7 @@ Parameter | Description | Default
 `dashboard.ingress.tls` | ingress tls configuration |
 `dashboard.ingress.annotations` | Web ingress annotations | {}
 `webhook.enable` | Whether to run the dashboard | false
+`webhook.resources` | Requests and limits for the webhook | (see values.yaml)
 `webhook.replicas` | Number of replicas | 1
 `webhook.service.type` | Service type | ClusterIP
 `webhook.nodeSelector` | Webhook pod nodeSelector | {}

--- a/stable/polaris/templates/dashboard.deployment.yaml
+++ b/stable/polaris/templates/dashboard.deployment.yaml
@@ -61,12 +61,7 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 20
         resources:
-          limits:
-            cpu: 100m
-            memory: 128Mi
-          requests:
-            cpu: 100m
-            memory: 128Mi
+          {{- toYaml .Values.dashboard.resources | nindent 10 }}
         securityContext:
           allowPrivilegeEscalation: false
           privileged: false

--- a/stable/polaris/templates/webhook.deployment.yaml
+++ b/stable/polaris/templates/webhook.deployment.yaml
@@ -58,12 +58,7 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 5
           resources:
-            limits:
-              cpu: 100m
-              memory: 128Mi
-            requests:
-              cpu: 100m
-              memory: 128Mi
+            {{- toYaml .Values.webhook.resources | nindent 12 }}
           securityContext:
             allowPrivilegeEscalation: false
             privileged: false

--- a/stable/polaris/values.yaml
+++ b/stable/polaris/values.yaml
@@ -19,12 +19,26 @@ dashboard:
     hosts: []
     annotations: {}
     tls: {}
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 150m
+      memory: 512Mi
 
 webhook:
   enable: false
   replicas: 1
   nodeSelector: {}
   tolerations: []
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 100m
+      memory: 128Mi
 
 audit:
   enable: false


### PR DESCRIPTION
**Why This PR?**
Changes to polaris now cause more variability in memory usage

Fixes #
https://github.com/FairwindsOps/polaris/issues/330

**Changes**
Changes proposed in this pull request:

* Bump limits for polaris dashboard
* make resources configuratble for both webhook and dash

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
