### PR TITLE
Expose dns policy

### DIFF
--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
 version: 0.20.0
-appVersion: 1.5.1
+appVersion: 1.6.2
 maintainers:
   - name: rbren
   - name: makoscafee

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 0.19.1
-appVersion: 1.4.0
+version: 0.19.2
+appVersion: 1.5.1
 maintainers:
   - name: rbren
   - name: makoscafee

--- a/stable/insights-agent/README.md
+++ b/stable/insights-agent/README.md
@@ -52,6 +52,7 @@ Parameter | Description | Default
 `cronjobs.successfulJobHistoryLimit` | Number of successful jobs to keep in history for each report | 2
 `cronjobs.nodeSelector` | Node selector to use for cronjobs | null
 `cronjobs.runJobsImmediately` | Run each of the reports immediately upon install of the Insights Agent | true
+`cronjobs.dnsPolicy` | Add pod DNS policy. If dnsPolicy is not explicitly specified, then “ClusterFirst” is used |
 `{report}.enabled` | Enable the report type |
 `{report}.schedule` | Cron expression for running the report | `rand * * * *`
 `{report}.timeout` | Maximum time in seconds to wait for the report |

--- a/stable/insights-agent/README.md
+++ b/stable/insights-agent/README.md
@@ -52,7 +52,7 @@ Parameter | Description | Default
 `cronjobs.successfulJobHistoryLimit` | Number of successful jobs to keep in history for each report | 2
 `cronjobs.nodeSelector` | Node selector to use for cronjobs | null
 `cronjobs.runJobsImmediately` | Run each of the reports immediately upon install of the Insights Agent | true
-`cronjobs.dnsPolicy` | Add pod DNS policy. If dnsPolicy is not explicitly specified, then “ClusterFirst” is used |
+`cronjobs.dnsPolicy` | Adds pod DNS policy |
 `{report}.enabled` | Enable the report type |
 `{report}.schedule` | Cron expression for running the report | `rand * * * *`
 `{report}.timeout` | Maximum time in seconds to wait for the report |

--- a/stable/insights-agent/templates/_cronjob.yaml
+++ b/stable/insights-agent/templates/_cronjob.yaml
@@ -8,11 +8,11 @@ spec:
   concurrencyPolicy: Forbid
   failedJobsHistoryLimit: {{ .Values.cronjobs.failedJobsHistoryLimit }}
   successfulJobsHistoryLimit: {{ .Values.cronjobs.successfulJobsHistoryLimit }}
-  {{- if .Values.cronjobs.dnsPolicy -}}
-  dnsPolicy: {{ .Values.cronjobs.dnsPolicy }}
-  {{- end -}}
   jobTemplate:
     spec:
+      {{- with .Values.cronjobs.dnsPolicy }}
+      dnsPolicy: {{ . }}
+      {{- end }}
       backoffLimit: {{ .Values.cronjobs.backoffLimit }}
       template:
         spec:

--- a/stable/insights-agent/templates/_cronjob.yaml
+++ b/stable/insights-agent/templates/_cronjob.yaml
@@ -8,8 +8,8 @@ spec:
   concurrencyPolicy: Forbid
   failedJobsHistoryLimit: {{ .Values.cronjobs.failedJobsHistoryLimit }}
   successfulJobsHistoryLimit: {{ .Values.cronjobs.successfulJobsHistoryLimit }}
-  {{- with .Values.cronjobs.dnsPolicy -}}
-  dnsPolicy: {{ . }}
+  {{- if .Values.cronjobs.dnsPolicy -}}
+  dnsPolicy: {{ .Values.cronjobs.dnsPolicy }}
   {{- end -}}
   jobTemplate:
     spec:

--- a/stable/insights-agent/templates/_cronjob.yaml
+++ b/stable/insights-agent/templates/_cronjob.yaml
@@ -8,6 +8,9 @@ spec:
   concurrencyPolicy: Forbid
   failedJobsHistoryLimit: {{ .Values.cronjobs.failedJobsHistoryLimit }}
   successfulJobsHistoryLimit: {{ .Values.cronjobs.successfulJobsHistoryLimit }}
+  {{- with .Values.cronjobs.dnsPolicy -}}
+  dnsPolicy: {{ . }}
+  {{- end -}}
   jobTemplate:
     spec:
       backoffLimit: {{ .Values.cronjobs.backoffLimit }}

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -23,7 +23,7 @@ cronjobs:
   successfulJobsHistoryLimit: 2
   nodeSelector: null
   runJobsImmediately: true
-  dnsPolicy:
+  # dnsPolicy:
 
 cronjobExecutor:
   image:

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -23,6 +23,7 @@ cronjobs:
   successfulJobsHistoryLimit: 2
   nodeSelector: null
   runJobsImmediately: true
+  dnsPolicy:
 
 cronjobExecutor:
   image:


### PR DESCRIPTION
**Why This PR?**
This PR adds a way for a user to specify DNS policy that should be used in a job.

Fixes #

**Changes**
Changes proposed in this pull request:

* Added DNS policy field in cronjobs values
* Added the documentation for it.

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
