### PR TITLE
Send Insights failures

### DIFF
--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 0.21.1
+version: 0.22.0
 appVersion: 1.7.0
 maintainers:
   - name: rbren

--- a/stable/insights-agent/README.md
+++ b/stable/insights-agent/README.md
@@ -50,7 +50,7 @@ Parameter | Description | Default
 `uploader.resources` | CPU/memory requests and limits for the uploader script |
 `cronjobs.backoffLimit` | Backoff limit to use for each report CronJob | 1
 `cronjobs.failedJobsHistoryLimit` | Number of failed jobs to keep in history for each report | 2
-`cronjobs.successfulJobHistoryLimit` | Number of successful jobs to keep in history for each report | 2
+`cronjobs.successfulJobsHistoryLimit` | Number of successful jobs to keep in history for each report | 2
 `cronjobs.nodeSelector` | Node selector to use for cronjobs | null
 `cronjobs.runJobsImmediately` | Run each of the reports immediately upon install of the Insights Agent | true
 `cronjobs.dnsPolicy` | Adds pod DNS policy |

--- a/stable/insights-agent/README.md
+++ b/stable/insights-agent/README.md
@@ -46,7 +46,7 @@ Parameter | Description | Default
 `insights.tokenSecretName` | If you don't provide a `base64token`, you can specify the name of a secret to pull the token from | ""
 `insights.host` | The location of the Insights server | https://insights.fairwinds.com
 `uploader.image.repository`  | The repository to pull the uploader script from | quay.io/fairwinds/insights-uploader
-`uploader.image.tag` | The tag to use for the uploader script | 0.1
+`uploader.image.tag` | The tag to use for the uploader script | 0.2
 `uploader.resources` | CPU/memory requests and limits for the uploader script |
 `uploader.sendFailures` | Send logs of failure to Insights when a job fails. | true
 `cronjobs.backoffLimit` | Backoff limit to use for each report CronJob | 1

--- a/stable/insights-agent/README.md
+++ b/stable/insights-agent/README.md
@@ -48,6 +48,7 @@ Parameter | Description | Default
 `uploader.image.repository`  | The repository to pull the uploader script from | quay.io/fairwinds/insights-uploader
 `uploader.image.tag` | The tag to use for the uploader script | 0.1
 `uploader.resources` | CPU/memory requests and limits for the uploader script |
+`uploader.sendFailures` | Send logs of failure to Insights when a job fails. | true
 `cronjobs.backoffLimit` | Backoff limit to use for each report CronJob | 1
 `cronjobs.failedJobsHistoryLimit` | Number of failed jobs to keep in history for each report | 2
 `cronjobs.successfulJobsHistoryLimit` | Number of successful jobs to keep in history for each report | 2

--- a/stable/insights-agent/templates/_uploader.yaml
+++ b/stable/insights-agent/templates/_uploader.yaml
@@ -34,6 +34,10 @@
         key: token
   - name: FAIRWINDS_AGENT_CHART_VERSION
     value: {{ .Chart.Version }}
+  - name: POD_NAME
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.name
   volumeMounts:
   - name: output
     mountPath: /output

--- a/stable/insights-agent/templates/_uploader.yaml
+++ b/stable/insights-agent/templates/_uploader.yaml
@@ -35,7 +35,7 @@
   - name: FAIRWINDS_AGENT_CHART_VERSION
     value: {{ .Chart.Version }}
   - name: SEND_FAILURES
-    value: {{ .Values.uploader.sendFailures }} 
+    value: {{ .Values.uploader.sendFailures | quote }} 
   - name: POD_NAME
     valueFrom:
       fieldRef:

--- a/stable/insights-agent/templates/_uploader.yaml
+++ b/stable/insights-agent/templates/_uploader.yaml
@@ -34,6 +34,8 @@
         key: token
   - name: FAIRWINDS_AGENT_CHART_VERSION
     value: {{ .Chart.Version }}
+  - name: SEND_FAILURES
+    value: {{ .Values.uploader.sendFailures }} 
   - name: POD_NAME
     valueFrom:
       fieldRef:

--- a/stable/insights-agent/templates/rbac.yaml
+++ b/stable/insights-agent/templates/rbac.yaml
@@ -32,6 +32,11 @@ subjects:
   name: {{ include "insights-agent.fullname" . }}-goldilocks
   namespace: {{ .Release.Namespace }}
 {{- end }}
+{{- if .Values.pluto.enabled }}
+- kind: ServiceAccount
+  name: {{ include "insights-agent.fullname" . }}-pluto
+  namespace: {{ .Release.Namespace }}
+{{- end }}
 {{- if .Values.kubebench.enabled }}
 - kind: ServiceAccount
   name: {{ include "insights-agent.fullname" . }}-kube-bench

--- a/stable/insights-agent/templates/rbac.yaml
+++ b/stable/insights-agent/templates/rbac.yaml
@@ -1,0 +1,74 @@
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "insights-agent.fullname" . }}-get-logs
+  labels:
+    app: insights-agent
+rules:
+- apiGroups: [""]
+  resources: ["pods", "pods/logs"]
+  verbs: ["get"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: {{ include "insights-agent.fullname" . }}-get-logs
+  labels:
+    app: insights-agent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "insights-agent.fullname" . }}-get-logs
+subjects:
+{{- if .Values.cronjobs.runJobsImmediately }}
+- kind: ServiceAccount
+  name: {{ include "insights-agent.fullname" . }}-cronjob-executor
+  namespace: {{ .Release.Namespace }}
+{{- end }}
+{{- if .Values.goldilocks.enabled }}
+- kind: ServiceAccount
+  name: {{ include "insights-agent.fullname" . }}-goldilocks
+  namespace: {{ .Release.Namespace }}
+{{- end }}
+{{- if .Values.kubebench.enabled }}
+- kind: ServiceAccount
+  name: {{ include "insights-agent.fullname" . }}-kube-bench
+  namespace: {{ .Release.Namespace }}
+{{- end }}
+{{- if .Values.kubehunter.enabled }}
+- kind: ServiceAccount
+  name: {{ include "insights-agent.fullname" . }}-kube-hunter
+  namespace: {{ .Release.Namespace }}
+{{- end }}
+{{- if .Values.kubesec.enabled }}
+- kind: ServiceAccount
+  name: {{ include "insights-agent.fullname" . }}-kubesec
+  namespace: {{ .Release.Namespace }}
+{{- end }}
+{{- if .Values.polaris.enabled }}
+- kind: ServiceAccount
+  name: {{ include "insights-agent.fullname" . }}-polaris
+  namespace: {{ .Release.Namespace }}
+{{- end }}
+{{- if .Values.rbacreporter.enabled }}
+- kind: ServiceAccount
+  name: {{ include "insights-agent.fullname" . }}-rbac-reporter
+  namespace: {{ .Release.Namespace }}
+{{- end }}
+{{- if .Values.releasewatcher.enabled }}
+- kind: ServiceAccount
+  name: {{ include "insights-agent.fullname" . }}-release-watcher
+  namespace: {{ .Release.Namespace }}
+{{- end }}
+{{- if .Values.trivy.enabled }}
+- kind: ServiceAccount
+  name: {{ include "insights-agent.fullname" . }}-trivy
+  namespace: {{ .Release.Namespace }}
+{{- end }}
+{{- if .Values.workloads.enabled }}
+- kind: ServiceAccount
+  name: {{ include "insights-agent.fullname" . }}-workloads
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/stable/insights-agent/templates/rbac.yaml
+++ b/stable/insights-agent/templates/rbac.yaml
@@ -7,8 +7,13 @@ metadata:
     app: insights-agent
 rules:
 - apiGroups: [""]
-  resources: ["pods", "pods/logs"]
+  resources: ["pods"]
   verbs: ["get"]
+{{- if .Values.uploader.sendFailures }}
+- apiGroups: [""]
+  resources: ["pods/logs"]
+  verbs: ["get"]
+{{- end }}
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -8,7 +8,7 @@ insights:
 uploader:
   image:
     repository: quay.io/fairwinds/insights-uploader
-    tag: "0.1"
+    tag: "0.2"
   resources:
     limits:
       cpu: 100m

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -9,6 +9,7 @@ uploader:
   image:
     repository: quay.io/fairwinds/insights-uploader
     tag: "0.2"
+  sendFailures: true
   resources:
     limits:
       cpu: 100m


### PR DESCRIPTION
**Why This PR?**
To add the ability to send failure reports to Insights

Fixes #

**Changes**
Changes proposed in this pull request:

Send failure reports to Insights

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
