### PR TITLE
Add back permissions to view nodes

### DIFF
--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 0.23.2
+version: 0.23.3
 appVersion: 1.8.0
 maintainers:
   - name: rbren

--- a/stable/insights-agent/templates/polaris/rbac.yaml
+++ b/stable/insights-agent/templates/polaris/rbac.yaml
@@ -7,9 +7,40 @@ metadata:
     app: insights-agent
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: {{ include "insights-agent.fullname" . }}-polaris
+  labels:
+    app: insights-agent
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - 'nodes'
+      - 'namespaces'
+    verbs:
+      - 'get'
+      - 'list'
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "insights-agent.fullname" . }}-polaris
+  labels:
+    app: insights-agent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "insights-agent.fullname" . }}-polaris
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "insights-agent.fullname" . }}-polaris
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "insights-agent.fullname" . }}-polaris-view
   labels:
     app: insights-agent
 roleRef:

--- a/stable/insights-agent/templates/polaris/rbac.yaml
+++ b/stable/insights-agent/templates/polaris/rbac.yaml
@@ -17,7 +17,6 @@ rules:
       - ''
     resources:
       - 'nodes'
-      - 'namespaces'
     verbs:
       - 'get'
       - 'list'


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Fixes #
Missing permission to view nodes

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
