### PR TITLE
Add ClusterRole for getting secrets

### DIFF
--- a/stable/helm-release-pruner/Chart.yaml
+++ b/stable/helm-release-pruner/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v3.0.1
 description: This chart deploys a cronjob that purges stale Helm releases and associated namespaces. Releases are selected based on regex patterns for release name and namespace along with a Bash `date` command date string to define the stale cutoff date and time.
 name: helm-release-pruner
-version: 3.0.1
+version: 3.1.0
 maintainers:
   - name: coreypobrien
   - name: sudermanjr

--- a/stable/helm-release-pruner/README.md
+++ b/stable/helm-release-pruner/README.md
@@ -43,6 +43,8 @@ Chart version 1.0.0 introduced RBacDefinitions with rbac-manager to manage acces
 | job.backoffLimit | int | `3` | The backoff limit for the job |
 | job.debug | bool | `false` | If true, will enable debug logging |
 | job.dryRun | bool | `true` | If true, will only log candidates for removal and not remove them |
+| job.listSecretsRole.create | bool | `true` | If true, a cluster role will be created for the job to list helm releases |
+| job.listSecretsRole.name | string | `"helm-release-pruner-list-secrets"` | Name of a cluster role granting list secrets permission |
 | job.resources.limits.cpu | string | `"25m"` |  |
 | job.resources.limits.memory | string | `"32Mi"` |  |
 | job.resources.requests.cpu | string | `"25m"` |  |

--- a/stable/helm-release-pruner/templates/rbac.yml
+++ b/stable/helm-release-pruner/templates/rbac.yml
@@ -1,4 +1,18 @@
 ---
+{{- if .Values.job.listSecretsRole.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.job.listSecretsRole.name }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - list
+---
+{{- end }}
 {{- if .Values.rbac_manager.enabled }}
 apiVersion: rbacmanager.reactiveops.io/v1beta1
 kind: RBACDefinition
@@ -24,6 +38,8 @@ rbacBindings:
         namespaceSelector:
           matchLabels:
             environment: {{ .Values.rbac_manager.namespaceLabel }}
+    clusterRoleBindings:
+      - clusterRole: {{ .Values.job.listSecretsRole.name }}
 {{- else }}
 {{- if .Values.job.serviceAccount.create }}
 apiVersion: v1

--- a/stable/helm-release-pruner/values.yaml
+++ b/stable/helm-release-pruner/values.yaml
@@ -24,6 +24,11 @@ job:
     create: true
     # job.serviceAccount.name -- The name of a pre-existing service account to use if job.serviceAccount.create is false
     name: ExistingServiceAccountName
+  listSecretsRole:
+    # job.listSecretsRole.create -- If true, a cluster role will be created for the job to list helm releases
+    create: true
+    # job.listSecretsRole.name -- Name of a cluster role granting list secrets permission
+    name: helm-release-pruner-list-secrets
   # resources -- The resources block for the job pod
   resources:
     limits:


### PR DESCRIPTION

**Why This PR?**
Helm 3 tries to enumerate all the secrets in the cluster for `helm ls --all-namespaces`; add a ClusterRole for listing secrets so it doesn't fail.

**Changes**
Changes proposed in this pull request:

* add `ClusterRole` with `list` permission on `secrets`

***Current job output without the change***

```
helm-release-pruner-manual-1595434561-689kq helm-release-pruner Error: list: failed to list: secrets is forbidden: User "system:serviceaccount:infra:helm-release-pruner" cannot list resource "secrets" in API group "" at the cluster scope
helm-release-pruner-manual-1595434561-689kq helm-release-pruner No stale Helm charts found.
helm-release-pruner-manual-1595434561-689kq helm-release-pruner Error: list: failed to list: secrets is forbidden: User "system:serviceaccount:infra:helm-release-pruner" cannot list resource "secrets" in API group "" at the cluster scope
helm-release-pruner-manual-1595434561-689kq helm-release-pruner No stale Helm charts found.
```

***job output with the change***

```
helm-release-pruner-manual-1595434641-lj8c6 helm-release-pruner No stale Helm charts found.
helm-release-pruner-manual-1595434641-lj8c6 helm-release-pruner ephemeral-basic-demo     	ephemeral-testo      1       	2020-07-22 09:11:57.593219 -0700 -0700 	deployed	basic-demo-0.3.3            	1.0
helm-release-pruner-manual-1595434641-lj8c6 helm-release-pruner release "ephemeral-basic-demo" uninstalled
helm-release-pruner-manual-1595434641-lj8c6 helm-release-pruner ephemeral-solo-basic-demo	ephemeral-deleteme   	1       	2020-07-22 09:12:26.906471 -0700 -0700 	deployed	basic-demo-0.3.3            	1.0
helm-release-pruner-manual-1595434641-lj8c6 helm-release-pruner release "ephemeral-solo-basic-demo" uninstalled
helm-release-pruner-manual-1595434641-lj8c6 helm-release-pruner namespace "ephemeral-deleteme" deleted
```

The two releases and the `ephemeral-deleteme` namespace are the expected changes.

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
