### PR TITLE
[helm-release-pruner] use cluster-admin

### DIFF
--- a/stable/helm-release-pruner/Chart.yaml
+++ b/stable/helm-release-pruner/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v3.0.1
 description: This chart deploys a cronjob that purges stale Helm releases and associated namespaces. Releases are selected based on regex patterns for release name and namespace along with a Bash `date` command date string to define the stale cutoff date and time.
 name: helm-release-pruner
-version: 3.1.0
+version: 3.1.1
 maintainers:
   - name: coreypobrien
   - name: sudermanjr

--- a/stable/helm-release-pruner/templates/rbac.yml
+++ b/stable/helm-release-pruner/templates/rbac.yml
@@ -1,18 +1,3 @@
----
-{{- if .Values.job.listSecretsRole.create }}
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: {{ .Values.job.listSecretsRole.name }}
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - list
----
-{{- end }}
 {{- if .Values.rbac_manager.enabled }}
 apiVersion: rbacmanager.reactiveops.io/v1beta1
 kind: RBACDefinition
@@ -39,7 +24,7 @@ rbacBindings:
           matchLabels:
             environment: {{ .Values.rbac_manager.namespaceLabel }}
     clusterRoleBindings:
-      - clusterRole: {{ .Values.job.listSecretsRole.name }}
+      - clusterRole: cluster-admin
 {{- else }}
 {{- if .Values.job.serviceAccount.create }}
 apiVersion: v1
@@ -49,28 +34,13 @@ metadata:
 ---
 {{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: {{ template "helm-release-pruner.fullname" . }}
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - namespaces
-  - secrets
-  verbs:
-  - delete
-  - get
-  - list
----
-apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ template "helm-release-pruner.fullname" . }}
+  name: {{ template "helm-release-pruner.fullname" . }}-admin
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ template "helm-release-pruner.fullname" . }}
+  name: cluster-admin
 subjects:
 - kind: ServiceAccount
   {{- if .Values.job.serviceAccount.create }}

--- a/stable/helm-release-pruner/templates/rbac.yml
+++ b/stable/helm-release-pruner/templates/rbac.yml
@@ -36,7 +36,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ template "helm-release-pruner.fullname" . }}-admin
+  name: {{ template "helm-release-pruner.fullname" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
**Why This PR?**
HRP needs heavy-weight access to delete resources and view secrets

**Changes**
Changes proposed in this pull request:
* Change HRP to use the cluster-admin role

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
