### PR TITLE
[insights-agent] disable goldilocks in CI

### DIFF
--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 0.25.1
+version: 0.25.2
 appVersion: 1.9.0
 maintainers:
   - name: rbren

--- a/stable/insights-agent/ci/test-values.yaml
+++ b/stable/insights-agent/ci/test-values.yaml
@@ -3,3 +3,6 @@ insights:
   organization: acme-co
   cluster: us-east-1
   base64token: Zm9vCg==
+
+goldilocks:
+  enabled: false


### PR DESCRIPTION
**Why This PR?**
Goldilocks takes a long time to install with the insights-agent

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
