### PR TITLE
[insights-agent] fix opa

### DIFF
--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 0.27.3
+version: 0.27.4
 appVersion: 1.9.4
 maintainers:
   - name: rbren

--- a/stable/insights-agent/ci/test-values.yaml
+++ b/stable/insights-agent/ci/test-values.yaml
@@ -6,3 +6,6 @@ insights:
 
 goldilocks:
   enabled: false
+
+opa:
+  enabled: true

--- a/stable/insights-agent/ci/test-values.yaml
+++ b/stable/insights-agent/ci/test-values.yaml
@@ -8,4 +8,4 @@ goldilocks:
   enabled: false
 
 opa:
-  enabled: false
+  enabled: true

--- a/stable/insights-agent/ci/test-values.yaml
+++ b/stable/insights-agent/ci/test-values.yaml
@@ -8,4 +8,4 @@ goldilocks:
   enabled: false
 
 opa:
-  enabled: true
+  enabled: false

--- a/stable/insights-agent/templates/opa/check.yaml
+++ b/stable/insights-agent/templates/opa/check.yaml
@@ -1,54 +1,69 @@
+{{- define "customCheckSchema" }}
+type: object
+required:
+- spec
+properties:
+  spec:
+    type: object
+    required:
+    - rego
+    properties:
+      output:
+        type: object
+        properties:
+          severity:
+            type: number
+            maximum: 1
+            minimum: 0
+          title:
+            type: string
+          remediation:
+            type: string
+          category:
+            type: string
+      additionalKubernetesData:
+        type: array
+        items:
+          type: object
+          properties:
+            apiGroups:
+              type: array
+              items:
+                type: string
+            kinds:
+              type: array
+              items:
+                type: string
+      rego:
+        type: string
+{{- end }}
+
 {{- if .Values.opa.enabled -}}
-apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   # name must match the spec fields below, and be in the form: <plural>.<group>
   name: customchecks.insights.fairwinds.com
+{{- if .Capabilities.APIVersions.Has "apiextensions.k8s.io/v1/CustomResourceDefinition" }}
+apiVersion: apiextensions.k8s.io/v1
 spec:
-  group: insights.fairwinds.com
   versions:
     - name: v1beta1
       served: true
       storage: true
       schema:
         openAPIV3Schema:
-          type: object
-          required:
-          - spec
-          properties:
-            spec:
-              type: object
-              required:
-              - rego
-              properties:
-                output:
-                  type: object
-                  properties:
-                    severity:
-                      type: number
-                      maximum: 1
-                      minimum: 0
-                    title:
-                      type: string
-                    remediation:
-                      type: string
-                    category:
-                      type: string
-                additionalKubernetesData:
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      apiGroups:
-                        type: array
-                        items:
-                          type: string
-                      kinds:
-                        type: array
-                        items:
-                          type: string
-                rego:
-                  type: string
+          {{ include "customCheckSchema" . | nindent 10 | trim }}
+{{- else }}
+apiVersion: apiextensions.k8s.io/v1beta1
+spec:
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+  validation:
+    openAPIV3Schema:
+      {{ include "customCheckSchema" . | nindent 6 | trim }}
+{{- end }}
   scope: Namespaced
   names:
     # plural name to be used in the URL: /apis/<group>/<version>/<plural>

--- a/stable/insights-agent/templates/opa/check.yaml
+++ b/stable/insights-agent/templates/opa/check.yaml
@@ -64,6 +64,7 @@ spec:
     openAPIV3Schema:
       {{ include "customCheckSchema" . | nindent 6 | trim }}
 {{- end }}
+  group: insights.fairwinds.com
   scope: Namespaced
   names:
     # plural name to be used in the URL: /apis/<group>/<version>/<plural>

--- a/stable/insights-agent/templates/opa/cronjob.yaml
+++ b/stable/insights-agent/templates/opa/cronjob.yaml
@@ -29,9 +29,9 @@ spec:
             - name: FAIRWINDS_INSIGHTS_HOST
               value: {{ .Values.insights.host }}
             - name: FAIRWINDS_ORG
-              value: {{ .Values.insights.organization }}
+              value: {{ .Values.insights.organization | quote  }}
             - name: FAIRWINDS_CLUSTER
-              value: {{ .Values.insights.cluster }}
+              value: {{ .Values.insights.cluster | quote }}
             {{ include "security-context" . | indent 12 | trim }}
           {{ include "uploaderContainer" . | indent 10 | trim }}
 {{- end -}}

--- a/stable/insights-agent/templates/opa/instance.yaml
+++ b/stable/insights-agent/templates/opa/instance.yaml
@@ -47,7 +47,7 @@ properties:
 kind: CustomResourceDefinition
 metadata:
   # name must match the spec fields below, and be in the form: <plural>.<group>
-  name: customchecks.insights.fairwinds.com
+  name: customcheckinstances.insights.fairwinds.com
 {{- if .Capabilities.APIVersions.Has "apiextensions.k8s.io/v1/CustomResourceDefinition" }}
 apiVersion: apiextensions.k8s.io/v1
 spec:
@@ -70,12 +70,6 @@ spec:
       {{ include "customCheckInstanceSchema" . | nindent 6 | trim }}
 {{- end }}
   group: insights.fairwinds.com
-  versions:
-    - name: v1beta1
-      served: true
-      storage: true
-      schema:
-        openAPIV3Schema:
   scope: Namespaced
   names:
     # plural name to be used in the URL: /apis/<group>/<version>/<plural>

--- a/stable/insights-agent/templates/opa/instance.yaml
+++ b/stable/insights-agent/templates/opa/instance.yaml
@@ -1,10 +1,74 @@
+{{- define "customCheckInstanceSchema" }}
+type: object
+required:
+- spec
+properties:
+  spec:
+    type: object
+    required:
+    - targets
+    - customCheckName
+    properties:
+      targets:
+        type: array
+        items:
+          type: object
+          properties:
+            apiGroups:
+              type: array
+              items: 
+                type: string
+            kinds:
+              type: array
+              items: 
+                type: string
+      parameters:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+      customCheckName:
+        type: string
+      output:
+        type: object
+        properties:
+          severity:
+            type: number
+            maximum: 1
+            minimum: 0
+          title:
+            type: string
+          remediation:
+            type: string
+          category:
+            type: string
+{{- end }}
 {{- if .Values.opa.enabled -}}
-apiVersion: apiextensions.k8s.io/v1
+
+
 kind: CustomResourceDefinition
 metadata:
   # name must match the spec fields below, and be in the form: <plural>.<group>
-  name: customcheckinstances.insights.fairwinds.com
+  name: customchecks.insights.fairwinds.com
+{{- if .Capabilities.APIVersions.Has "apiextensions.k8s.io/v1/CustomResourceDefinition" }}
+apiVersion: apiextensions.k8s.io/v1
 spec:
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          {{ include "customCheckInstanceSchema" . | nindent 10 | trim }}
+{{- else }}
+apiVersion: apiextensions.k8s.io/v1beta1
+spec:
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+  validation:
+    openAPIV3Schema:
+      {{ include "customCheckInstanceSchema" . | nindent 6 | trim }}
+{{- end }}
   group: insights.fairwinds.com
   versions:
     - name: v1beta1
@@ -12,47 +76,6 @@ spec:
       storage: true
       schema:
         openAPIV3Schema:
-          type: object
-          required:
-          - spec
-          properties:
-            spec:
-              type: object
-              required:
-              - targets
-              - customCheckName
-              properties:
-                targets:
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      apiGroups:
-                        type: array
-                        items: 
-                          type: string
-                      kinds:
-                        type: array
-                        items: 
-                          type: string
-                parameters:
-                  type: object
-                  x-kubernetes-preserve-unknown-fields: true
-                customCheckName:
-                  type: string
-                output:
-                  type: object
-                  properties:
-                    severity:
-                      type: number
-                      maximum: 1
-                      minimum: 0
-                    title:
-                      type: string
-                    remediation:
-                      type: string
-                    category:
-                      type: string
   scope: Namespaced
   names:
     # plural name to be used in the URL: /apis/<group>/<version>/<plural>

--- a/stable/insights-agent/templates/opa/rbac.yaml
+++ b/stable/insights-agent/templates/opa/rbac.yaml
@@ -23,7 +23,7 @@ rules:
   - 'get'
   - 'list'
 ---
-apiVersion: rbac.authorizations.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
   name: {{ include "insights-agent.fullname" . }}-checks-edit


### PR DESCRIPTION
**Why This PR?**
Turns out OPA wasn't enabled in our tests

Fixes #

**Changes**
Changes proposed in this pull request:
* fix RBAC
* quote some strings
* add OPA to tests

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
