### PR TITLE
[vpa] Removed empty 'required' field from CRD

### DIFF
--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: 0.8.0
 maintainers:
   - name: sudermanjr

--- a/stable/vpa/crds/vpa-v1-crd.yaml
+++ b/stable/vpa/crds/vpa-v1-crd.yaml
@@ -32,7 +32,6 @@ spec:
       properties:
         spec:
           type: object
-          required: []
           properties:
             targetRef:
               type: object


### PR DESCRIPTION
**Why This PR?**

When installing the vpa using this chart, the `required: []` field from the `verticalpodautoscalers` is removed by Kubernetes before persisting the CRD. This causes issues when using GitOps tools such as ArgoCD because the CRD manifest in git still contains the `required: []` but the live manifest does not. Thereby making the chart appear out-of-sync.

**Changes**
Changes proposed in this pull request:

* delete the `required: []` line

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
