### PR TITLE
Insights Agent - Fix api version for OPA

### DIFF
--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 0.27.4
+version: 0.27.5
 appVersion: 1.9.4
 maintainers:
   - name: rbren

--- a/stable/insights-agent/templates/opa/rbac.yaml
+++ b/stable/insights-agent/templates/opa/rbac.yaml
@@ -23,7 +23,7 @@ rules:
   - 'get'
   - 'list'
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "insights-agent.fullname" . }}-checks-edit


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Fixes #

Wrong API version for OPA Role
**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
