### PR TITLE
Fix imagePullSecrets

### DIFF
--- a/stable/rbac-manager/Chart.yaml
+++ b/stable/rbac-manager/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rbac-manager
-version: 1.5.6
+version: 1.5.7
 appVersion: 0.9.4
 description: A Kubernetes operator that simplifies the management of Role Bindings and Service Accounts.
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/rbac-manager/icon.png

--- a/stable/rbac-manager/templates/deployment.yaml
+++ b/stable/rbac-manager/templates/deployment.yaml
@@ -27,6 +27,12 @@ spec:
     {{- end }}
     spec:
       serviceAccountName: {{ template "rbac-manager.fullname" . }}
+      {{- if .Values.image.imagePullSecrets }}
+      imagePullSecrets:
+        {{- range .Values.image.imagePullSecrets }}
+        - name: {{ . }}
+        {{- end}}
+      {{- end}}
 {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
 {{- end }}
@@ -34,10 +40,6 @@ spec:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-{{- if .Values.image.imagePullSecrets }}
-        imagePullSecrets:
-        {{ toYaml .Values.image.imagePullSecrets }}
-{{- end }}
         readinessProbe:
           httpGet:
             scheme: HTTP

--- a/stable/rbac-manager/values.yaml
+++ b/stable/rbac-manager/values.yaml
@@ -3,6 +3,7 @@ image:
   tag: v0.9.4
   pullPolicy: Always
   imagePullSecrets: []
+#   - myRegistryKeySecretName
 
 resources:
   requests:


### PR DESCRIPTION
**Why This PR?**
This enables rbac-manager helm chart to work with private docker registries.

Fixes #346 

**Changes**
Changes proposed in this pull request:

* Bugfix: Move imagePullSecrets to Pod spec. See https://kubernetes.io/docs/concepts/containers/images/#referring-to-an-imagepullsecrets-on-a-pod 

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
