### PR TITLE
[goldilocks] Updated vpa chart dependency to latest

### DIFF
--- a/stable/goldilocks/Chart.yaml
+++ b/stable/goldilocks/Chart.yaml
@@ -4,7 +4,7 @@ description: |
   A Helm chart for running Fairwinds Goldilocks. See https://github.com/FairwindsOps/goldilocks
 name: goldilocks
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/goldilocks/icon.png
-version: 3.0.0
+version: 3.0.1
 maintainers:
   - name: sudermanjr
   - name: lucasreed
@@ -16,7 +16,7 @@ keywords:
   - kubernetes
 dependencies:
 - name: vpa
-  version: 0.1.0
+  version: 0.1.1
   repository: https://charts.fairwinds.com/stable
   condition: vpa.enabled
 - name: metrics-server


### PR DESCRIPTION
**Why This PR?**

This chart uses the VPA chart as a dependency which was recently updated (see https://github.com/FairwindsOps/charts/pull/360)

**Changes**
Changes proposed in this pull request:

* updated vpa subchart to latest version 0.1.1

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
