### PR TITLE
Insights Agent Change kubectl image

### DIFF
--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 0.27.4
-appVersion: 1.9.4
+version: 0.27.5
+appVersion: 1.12.1
 maintainers:
   - name: rbren
   - name: makoscafee

--- a/stable/insights-agent/templates/cronjob-executor/job.yaml
+++ b/stable/insights-agent/templates/cronjob-executor/job.yaml
@@ -21,11 +21,9 @@ spec:
         args:
           - -c
           - |
-            curl -SsL -o /tmp/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.19.0-rc.2/bin/linux/amd64/kubectl
-            chmod +x /tmp/kubectl
             # Can't use -o name because it appends cronjob.batch to the beginning
-            /tmp/kubectl get cj --selector=app=insights-agent -o custom-columns=NAME:.metadata.name --no-headers | xargs -I~job~ sh -c "/tmp/kubectl delete job ~job~ || echo 'Does Not Exist'"
-            /tmp/kubectl get cj --selector=app=insights-agent -o custom-columns=NAME:.metadata.name --no-headers | xargs -I~job~ /tmp/kubectl create job ~job~ --from=CronJob/~job~
+            kubectl get cj --selector=app=insights-agent -o custom-columns=NAME:.metadata.name --no-headers | xargs -I~job~ sh -c "kubectl delete job ~job~ || echo 'Does Not Exist'"
+            kubectl get cj --selector=app=insights-agent -o custom-columns=NAME:.metadata.name --no-headers | xargs -I~job~ kubectl create job ~job~ --from=CronJob/~job~
         
         resources:
           {{- toYaml .Values.cronjobExecutor.resources | nindent 10 }}

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -29,7 +29,7 @@ cronjobs:
 cronjobExecutor:
   image:
     repository: quay.io/fairwinds/kubectl
-    tag: "1.19"
+    tag: "0.19"
   resources:
     limits:
       cpu: 100m

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -28,8 +28,8 @@ cronjobs:
 
 cronjobExecutor:
   image:
-    repository: boxboat/kubectl
-    tag: "1.16.6"
+    repository: quay.io/fairwinds/kubectl
+    tag: "1.19"
   resources:
     limits:
       cpu: 100m


### PR DESCRIPTION
**Why This PR?**
Replaces the temporary kubectl version with a Fairwinds image.

Fixes #

**Changes**
Changes proposed in this pull request:

* Changes the kubectl image used.
*

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
