### PR TITLE
Fix webhook

### DIFF
--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: 0.8.0
 maintainers:
   - name: sudermanjr

--- a/stable/vpa/templates/admission-controller-service.yaml
+++ b/stable/vpa/templates/admission-controller-service.yaml
@@ -2,18 +2,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "vpa.fullname" . }}-admission-controller
-spec:
-  ports:
-    - port: 443
-      targetPort: 8000
-  selector:
-    app.kubernetes.io/component: admission-controller
-    {{- include "vpa.selectorLabels" . | nindent 4 }}
----
-apiVersion: v1
-kind: Service
-metadata:
   name: vpa-webhook
 spec:
   ports:

--- a/stable/vpa/templates/admission-controller-service.yaml
+++ b/stable/vpa/templates/admission-controller-service.yaml
@@ -9,5 +9,17 @@ spec:
       targetPort: 8000
   selector:
     app.kubernetes.io/component: admission-controller
-    {{- include "vpa.labels" . | nindent 4 }}
+    {{- include "vpa.selectorLabels" . | nindent 4 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vpa-webhook
+spec:
+  ports:
+    - port: 443
+      targetPort: 8000
+  selector:
+    app.kubernetes.io/component: admission-controller
+    {{- include "vpa.selectorLabels" . | nindent 4 }}
 {{- end }}


### PR DESCRIPTION
Signed-off-by: Daan Potter <dhapotter@gmail.com>

**Why This PR?**
- The current implementation is broken. It include helm labels.
- There is no service for the webhook included

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [x ] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x ] Any new values are backwards compatible and/or have sensible default.
* [x ] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
