### PR TITLE
[insights-admission] configuration updates

### DIFF
--- a/stable/insights-admission/Chart.yaml
+++ b/stable/insights-admission/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: insights-admission
 description: A Validating Webhook Admission Controller that utilizes Fairwinds Insights.
 type: application
-version: 0.1.1
-appVersion: "0.1"
+version: 0.2.0
+appVersion: "1.13.0"
 maintainers:
 - name: rbren
 - name: makoscafee

--- a/stable/insights-admission/Chart.yaml
+++ b/stable/insights-admission/Chart.yaml
@@ -3,7 +3,7 @@ name: insights-admission
 description: A Validating Webhook Admission Controller that utilizes Fairwinds Insights.
 type: application
 version: 0.2.0
-appVersion: "1.13.0"
+appVersion: "0.1"
 maintainers:
 - name: rbren
 - name: makoscafee

--- a/stable/insights-admission/README.md
+++ b/stable/insights-admission/README.md
@@ -45,6 +45,7 @@ rules:
 | autoscaling.targetMemoryUtilizationPercentage | string | `nil` | Target memory to scale towards. |
 | caBundle | string | `""` | If you are providing your own certificate then this is the Certificate Authority for that certificate |
 | defaultRules | list | `[{"apiGroups":["apps"],"apiVersions":["v1","v1beta1","v1beta2"],"operations":["CREATE","UPDATE"],"resources":["daemonsets","deployments","statefulsets"],"scope":"Namespaced"},{"apiGroups":["batch"],"apiVersions":["v1","v1beta1"],"operations":["CREATE","UPDATE"],"resources":["jobs","cronjobs"],"scope":"Namespaced"},{"apiGroups":[""],"apiVersions":["v1"],"operations":["CREATE","UPDATE"],"resources":["pods","replicationcontrollers"],"scope":"Namespaced"}]` | An array of rules for commons types for the ValidatingWebhookConfiguration |
+| failurePolicy | string | `"Fail"` |  |
 | fullnameOverride | string | `""` | Long name of the release to override. |
 | image.pullPolicy | string | `"Always"` | imagePullPolicy - Highly recommended to leave this as 'Always' |
 | image.repository | string | `"quay.io/fairwinds/insights-admission-controller"` | Repository for the Insights Admission Controller image |

--- a/stable/insights-admission/README.md
+++ b/stable/insights-admission/README.md
@@ -39,13 +39,11 @@ rules:
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Pod affinity/anti-affinity rules |
 | autoscaling.enabled | bool | `false` | Autoscale instead of a static number of pods running. |
-| autoscaling.maxReplicas | int | `20` | Maximum number of pods to run. |
+| autoscaling.maxReplicas | int | `5` | Maximum number of pods to run. |
 | autoscaling.minReplicas | int | `2` | Minimum number of pods to run. |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` | Target CPU to scale towards. |
 | autoscaling.targetMemoryUtilizationPercentage | string | `nil` | Target memory to scale towards. |
 | caBundle | string | `""` | If you are providing your own certificate then this is the Certificate Authority for that certificate |
-| defaultRules | list | `[{"apiGroups":["apps"],"apiVersions":["v1","v1beta1","v1beta2"],"operations":["CREATE","UPDATE"],"resources":["daemonsets","deployments","statefulsets"],"scope":"Namespaced"},{"apiGroups":["batch"],"apiVersions":["v1","v1beta1"],"operations":["CREATE","UPDATE"],"resources":["jobs","cronjobs"],"scope":"Namespaced"},{"apiGroups":[""],"apiVersions":["v1"],"operations":["CREATE","UPDATE"],"resources":["pods","replicationcontrollers"],"scope":"Namespaced"}]` | An array of rules for commons types for the ValidatingWebhookConfiguration |
-| failurePolicy | string | `"Fail"` |  |
 | fullnameOverride | string | `""` | Long name of the release to override. |
 | image.pullPolicy | string | `"Always"` | imagePullPolicy - Highly recommended to leave this as 'Always' |
 | image.repository | string | `"quay.io/fairwinds/insights-admission-controller"` | Repository for the Insights Admission Controller image |
@@ -61,7 +59,6 @@ rules:
 | podSecurityContext | object | `{}` | Security Context for the entire pod. |
 | replicaCount | int | `2` | The number of pods to run for the admission contrller. |
 | resources | object | `{"limits":{"cpu":1,"memory":"2Gi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | A resources block for the controller. |
-| rules | list | `[]` | An array of additional for the ValidatingWebhookConfiguration. Each requires a set of apiGroups, apiVersions, operations, resources, and a scope. |
 | secretName | string | `""` | If you are providing your own certificate then this is the name of the secret holding the certificate. |
 | securityContext | object | `{"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":15000}` | Security Context for the container. |
 | service.port | int | `443` | Port to use for the service. |
@@ -71,3 +68,9 @@ rules:
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
 | test | object | `{"enabled":false,"image":{"repository":"python","tag":"3.6"}}` | Used for chart CI only - deploys a test deployment |
 | tolerations | list | `[]` | Toleratations to add to the controller. |
+| webhookConfig.defaultRules | list | `[{"apiGroups":["apps"],"apiVersions":["v1","v1beta1","v1beta2"],"operations":["CREATE","UPDATE"],"resources":["daemonsets","deployments","statefulsets"],"scope":"Namespaced"},{"apiGroups":["batch"],"apiVersions":["v1","v1beta1"],"operations":["CREATE","UPDATE"],"resources":["jobs","cronjobs"],"scope":"Namespaced"},{"apiGroups":[""],"apiVersions":["v1"],"operations":["CREATE","UPDATE"],"resources":["pods","replicationcontrollers"],"scope":"Namespaced"}]` | An array of rules for commons types for the ValidatingWebhookConfiguration |
+| webhookConfig.failurePolicy | string | `"Fail"` | failurePolicy for the ValidatingWebhookConfiguration |
+| webhookConfig.matchPolicy | string | `"Exact"` | matchPolicy for the ValidatingWebhookConfiguration |
+| webhookConfig.namespaceSelector | object | `{"matchExpressions":[{"key":"control-plane","operator":"DoesNotExist"}]}` | namespaceSelector for the ValidatingWebhookConfiguration |
+| webhookConfig.objectSelector | object | `{}` | objectSelector for the ValidatingWebhookConfiguration |
+| webhookConfig.rules | list | `[]` | An array of additional for the ValidatingWebhookConfiguration. Each requires a set of apiGroups, apiVersions, operations, resources, and a scope. |

--- a/stable/insights-admission/README.md
+++ b/stable/insights-admission/README.md
@@ -44,6 +44,7 @@ rules:
 | autoscaling.targetCPUUtilizationPercentage | int | `80` | Target CPU to scale towards. |
 | autoscaling.targetMemoryUtilizationPercentage | string | `nil` | Target memory to scale towards. |
 | caBundle | string | `""` | If you are providing your own certificate then this is the Certificate Authority for that certificate |
+| clusterDomain | string | `"cluster.local"` | The base domain to use for cluster DNS |
 | fullnameOverride | string | `""` | Long name of the release to override. |
 | image.pullPolicy | string | `"Always"` | imagePullPolicy - Highly recommended to leave this as 'Always' |
 | image.repository | string | `"quay.io/fairwinds/insights-admission-controller"` | Repository for the Insights Admission Controller image |

--- a/stable/insights-admission/ci/test-values.yaml
+++ b/stable/insights-admission/ci/test-values.yaml
@@ -1,3 +1,4 @@
+replicas: 1
 insights:
   host: http://insights-admission-test:8080
   organization: acme-co

--- a/stable/insights-admission/templates/cert.yaml
+++ b/stable/insights-admission/templates/cert.yaml
@@ -6,9 +6,8 @@ metadata:
 spec:
   commonName: {{ include "insights-admission.fullname" .}}.{{ .Release.Namespace}}.svc
   dnsNames:
-  - {{ include "insights-admission.fullname" . }}.{{ .Release.Namespace }}
   - {{ include "insights-admission.fullname" . }}.{{ .Release.Namespace }}.svc
-  - {{ include "insights-admission.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+  - {{ include "insights-admission.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}
   issuerRef:
     kind: Issuer
     name: {{ include "insights-admission.fullname" . }}-selfsigned

--- a/stable/insights-admission/templates/cert.yaml
+++ b/stable/insights-admission/templates/cert.yaml
@@ -6,11 +6,12 @@ metadata:
 spec:
   commonName: {{ include "insights-admission.fullname" .}}.{{ .Release.Namespace}}.svc
   dnsNames:
+  - {{ include "insights-admission.fullname" . }}.{{ .Release.Namespace }}
   - {{ include "insights-admission.fullname" . }}.{{ .Release.Namespace }}.svc
   - {{ include "insights-admission.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
   issuerRef:
     kind: Issuer
-    name: {{ include "insights-admission.fullname" . }}-ca
+    name: {{ include "insights-admission.fullname" . }}-selfsigned
   secretName: {{ include "insights-admission.fullname" . }}
 ---
 apiVersion: cert-manager.io/v1alpha2

--- a/stable/insights-admission/templates/cert.yaml
+++ b/stable/insights-admission/templates/cert.yaml
@@ -3,9 +3,6 @@ apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
   name: {{ include "insights-admission.fullname" . }}-cert
-  annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "6"
 spec:
   commonName: {{ include "insights-admission.fullname" .}}.{{ .Release.Namespace}}.svc
   dnsNames:
@@ -20,9 +17,6 @@ apiVersion: cert-manager.io/v1alpha2
 kind: Issuer
 metadata:
   name: {{ include "insights-admission.fullname" . }}-selfsigned
-  annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "0"
 spec:
   selfSigned: {}
 ---
@@ -30,9 +24,6 @@ apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
   name: {{ include "insights-admission.fullname" . }}-ca-cert
-  annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "4"
 spec:
   commonName: {{ include "insights-admission.fullname" .}}-ca
   isCA: true
@@ -45,9 +36,6 @@ apiVersion: cert-manager.io/v1alpha2
 kind: Issuer
 metadata:
   name: {{ include "insights-admission.fullname" . }}-ca
-  annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "5"
 spec:
   ca:
     secretName: {{ include "insights-admission.fullname" . }}-ca

--- a/stable/insights-admission/templates/cert.yaml
+++ b/stable/insights-admission/templates/cert.yaml
@@ -19,24 +19,4 @@ metadata:
   name: {{ include "insights-admission.fullname" . }}-selfsigned
 spec:
   selfSigned: {}
----
-apiVersion: cert-manager.io/v1alpha2
-kind: Certificate
-metadata:
-  name: {{ include "insights-admission.fullname" . }}-ca-cert
-spec:
-  commonName: {{ include "insights-admission.fullname" .}}-ca
-  isCA: true
-  issuerRef:
-    kind: Issuer
-    name: {{ include "insights-admission.fullname" . }}-selfsigned
-  secretName: {{ include "insights-admission.fullname" . }}-ca
----
-apiVersion: cert-manager.io/v1alpha2
-kind: Issuer
-metadata:
-  name: {{ include "insights-admission.fullname" . }}-ca
-spec:
-  ca:
-    secretName: {{ include "insights-admission.fullname" . }}-ca
 {{- end -}}

--- a/stable/insights-admission/templates/certificate-rbac.yaml
+++ b/stable/insights-admission/templates/certificate-rbac.yaml
@@ -3,7 +3,5 @@ kind: ServiceAccount
 metadata:
   name: {{ include "insights-admission.fullname" . }}-certificates
   namespace: {{ .Release.Namespace }}
-  annotations:
-    helm.sh/hook: pre-install
   labels:
     {{- include "insights-admission.labels" . | nindent 4 }}

--- a/stable/insights-admission/templates/configuration.yaml
+++ b/stable/insights-admission/templates/configuration.yaml
@@ -19,7 +19,7 @@ webhooks:
       namespace: {{ .Release.Namespace }}
       path: /validate
       port: 443
-  failurePolicy: Ignore
+  failurePolicy: {{ .Values.failurePolicy }}
   matchPolicy: Exact
   name: insights.fairwinds.com
   namespaceSelector:

--- a/stable/insights-admission/templates/configuration.yaml
+++ b/stable/insights-admission/templates/configuration.yaml
@@ -3,8 +3,6 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: {{ include "insights-admission.fullname" . }}
   annotations:
-    helm.sh/hook: pre-install
-    "helm.sh/hook-weight": "10"
     {{- if not .Values.secretName }}
     cert-manager.io/inject-apiserver-ca: "true"
     cert-manager.io/inject-ca-from: "{{ .Release.Namespace }}/{{ include "insights-admission.fullname" . }}-cert"

--- a/stable/insights-admission/templates/configuration.yaml
+++ b/stable/insights-admission/templates/configuration.yaml
@@ -4,7 +4,6 @@ metadata:
   name: {{ include "insights-admission.fullname" . }}
   annotations:
     {{- if not .Values.secretName }}
-    cert-manager.io/inject-apiserver-ca: "true"
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "insights-admission.fullname" . }}-cert
     {{- end }}
 webhooks:

--- a/stable/insights-admission/templates/configuration.yaml
+++ b/stable/insights-admission/templates/configuration.yaml
@@ -5,13 +5,13 @@ metadata:
   annotations:
     {{- if not .Values.secretName }}
     cert-manager.io/inject-apiserver-ca: "true"
-    cert-manager.io/inject-ca-from: "{{ .Release.Namespace }}/{{ include "insights-admission.fullname" . }}-cert"
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "insights-admission.fullname" . }}-cert
     {{- end }}
 webhooks:
 - admissionReviewVersions:
   - v1beta1
   clientConfig:
-    caBundle: {{ .Values.caBundle | quote }} 
+    caBundle: {{ .Values.caBundle | quote }}
     service:
       name: {{ include "insights-admission.fullname" . }}
       namespace: {{ .Release.Namespace }}

--- a/stable/insights-admission/templates/configuration.yaml
+++ b/stable/insights-admission/templates/configuration.yaml
@@ -11,21 +11,22 @@ webhooks:
 - admissionReviewVersions:
   - v1beta1
   clientConfig:
+    {{- if .Values.caBundle }}
     caBundle: {{ .Values.caBundle | quote }}
+    {{- end }}
     service:
       name: {{ include "insights-admission.fullname" . }}
       namespace: {{ .Release.Namespace }}
       path: /validate
       port: 443
-  failurePolicy: {{ .Values.failurePolicy }}
-  matchPolicy: Exact
+  failurePolicy: {{ .Values.webhookConfig.failurePolicy }}
+  matchPolicy: {{ .Values.webhookConfig.matchPolicy }}
   name: insights.fairwinds.com
   namespaceSelector:
-    matchExpressions:
-    - key: control-plane
-      operator: DoesNotExist
-  objectSelector: {}
+    {{ .Values.webhookConfig.namespaceSelector | toYaml | nindent 4 }}
+  objectSelector:
+    {{ .Values.webhookConfig.objectSelector | toYaml | nindent 4 }}
   rules:
-  {{- concat .Values.rules .Values.defaultRules | toYaml | nindent 2 }}
+  {{- concat .Values.webhookConfig.rules .Values.webhookConfig.defaultRules | toYaml | nindent 2 }}
   sideEffects: None
   timeoutSeconds: 10

--- a/stable/insights-admission/templates/test-deployment.yaml
+++ b/stable/insights-admission/templates/test-deployment.yaml
@@ -44,7 +44,7 @@ spec:
                 self.wfile.write(content)
                 return
               def do_POST(self):
-                content = "{}".encode(encoding="utf-8")
+                content = '{"Success": true}'.encode(encoding="utf-8")
                 self.send_response(200, "success")
                 self.send_header("Content-type", "application/json")
                 self.send_header("Content-length", len(content))

--- a/stable/insights-admission/values.yaml
+++ b/stable/insights-admission/values.yaml
@@ -5,7 +5,59 @@
 # replicaCount -- The number of pods to run for the admission contrller.
 replicaCount: 2
 
-failurePolicy: Fail
+webhookConfig:
+  # webhookConfig.failurePolicy -- failurePolicy for the ValidatingWebhookConfiguration
+  failurePolicy: Fail
+  # webhookConfig.matchPolicy -- matchPolicy for the ValidatingWebhookConfiguration
+  matchPolicy: Exact
+  # webhookConfig.namespaceSelector -- namespaceSelector for the ValidatingWebhookConfiguration
+  namespaceSelector:
+    matchExpressions:
+    - key: control-plane
+      operator: DoesNotExist
+  # webhookConfig.objectSelector -- objectSelector for the ValidatingWebhookConfiguration
+  objectSelector: {}
+  # webhookConfig.rules -- An array of additional for the ValidatingWebhookConfiguration. Each requires a set of apiGroups, apiVersions, operations, resources, and a scope.
+  rules: []
+  # webhookConfig.defaultRules -- An array of rules for commons types for the ValidatingWebhookConfiguration
+  defaultRules:
+  - apiGroups:
+    - apps
+    apiVersions:
+    - v1
+    - v1beta1
+    - v1beta2
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - daemonsets
+    - deployments
+    - statefulsets
+    scope: Namespaced
+  - apiGroups:
+    - batch
+    apiVersions:
+    - v1
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - jobs
+    - cronjobs
+    scope: Namespaced
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - pods
+    - replicationcontrollers
+    scope: Namespaced
 
 insights:
   # insights.organization -- The name of your Organization from Fairwinds Insights
@@ -78,7 +130,7 @@ autoscaling:
   # autoscaling.minReplicas -- Minimum number of pods to run.
   minReplicas: 2
   # autoscaling.maxReplicas -- Maximum number of pods to run.
-  maxReplicas: 20
+  maxReplicas: 5
   # autoscaling.targetCPUUtilizationPercentage -- Target CPU to scale towards.
   targetCPUUtilizationPercentage: 80
   # autoscaling.targetMemoryUtilizationPercentage -- Target memory to scale towards.
@@ -92,49 +144,6 @@ tolerations: []
 
 # affinity -- Pod affinity/anti-affinity rules
 affinity: {}
-
-# rules -- An array of additional for the ValidatingWebhookConfiguration. Each requires a set of apiGroups, apiVersions, operations, resources, and a scope.
-rules: []
-
-# defaultRules -- An array of rules for commons types for the ValidatingWebhookConfiguration
-defaultRules:
-- apiGroups:
-  - apps
-  apiVersions:
-  - v1
-  - v1beta1
-  - v1beta2
-  operations:
-  - CREATE
-  - UPDATE
-  resources:
-  - daemonsets
-  - deployments
-  - statefulsets
-  scope: Namespaced
-- apiGroups:
-  - batch
-  apiVersions:
-  - v1
-  - v1beta1
-  operations:
-  - CREATE
-  - UPDATE
-  resources:
-  - jobs
-  - cronjobs
-  scope: Namespaced
-- apiGroups:
-  - ""
-  apiVersions:
-  - v1
-  operations:
-  - CREATE
-  - UPDATE
-  resources:
-  - pods
-  - replicationcontrollers
-  scope: Namespaced
 
 # caBundle -- If you are providing your own certificate then this is the Certificate Authority for that certificate
 caBundle: ""

--- a/stable/insights-admission/values.yaml
+++ b/stable/insights-admission/values.yaml
@@ -149,6 +149,8 @@ affinity: {}
 caBundle: ""
 # secretName -- If you are providing your own certificate then this is the name of the secret holding the certificate.
 secretName: ""
+# clusterDomain -- The base domain to use for cluster DNS
+clusterDomain: cluster.local
 
 # test -- Used for chart CI only - deploys a test deployment
 test:

--- a/stable/insights-admission/values.yaml
+++ b/stable/insights-admission/values.yaml
@@ -5,6 +5,8 @@
 # replicaCount -- The number of pods to run for the admission contrller.
 replicaCount: 2
 
+failurePolicy: Fail
+
 insights:
   # insights.organization -- The name of your Organization from Fairwinds Insights
   organization: ""


### PR DESCRIPTION
**Why This PR?**
Various changes after playing with the admission controller for a bit

Major fix for flakiness in the CA provider by removing `cert-manager.io/inject-apiserver-ca: "true"` - about 50% of requests were failing due to certs.

Fixes #

**Changes**
Changes proposed in this pull request:
* helm hooks were messing with the uninstall, and seem to be unnecessary
* templates out some of the more important pieces of the config
* removes an (unnecessary?) CA provider
* sets default failurePolicy to Fail

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
