### PR TITLE
Update codeowners for fluentd and gemini

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,7 +5,7 @@
 /incubator/capsize/ @sudermanjr
 /incubator/custom-iptables/ @sudermanjr
 /incubator/fairwinds-metrics/ @sudermanjr
-/incubator/fluentd/ @dosullivan @crmejia
+/incubator/fluentd/ @coreypobrien @crmejia
 /incubator/imagepullsecret-deploy/ @crmejia
 /incubator/load-generator/ @sudermanjr
 /incubator/node-problem-detector/ @crmejia
@@ -18,7 +18,7 @@
 /stable/ecr-cleanup/ @sudermanjr
 /stable/rbac-manager/ @robscott @sudermanjr @lucasreed
 /stable/polaris/ @rbren @makoscafee @jordandoig @baderbuddy
-/stable/gemini/ @rbren @dosullivan
+/stable/gemini/ @rbren
 /stable/gke-node-termination-handler/ @hopson
 /stable/goldilocks/ @sudermanjr @dosullivan
 /stable/insights-admission/ @rbren @makoscafee @baderbuddy

--- a/incubator/fluentd/Chart.yaml
+++ b/incubator/fluentd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.12.43"
 description: Fluentd for multiple endpoints
 name: fluentd
-version: 4.1.2
+version: 4.1.3
 maintainers:
-  - name: dosullivan
   - name: coreypobrien
+  - name: crmejia


### PR DESCRIPTION
**Why This PR?**
Updates codeowners

Fixes #

**Changes**
Changes proposed in this pull request:

* Remove dosullivan from gemini and fluentd
* Add myself to fluentd

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
