### PR TITLE
[polaris] Allow to disable rbac and serviceAccount.

### DIFF
--- a/stable/polaris/Chart.yaml
+++ b/stable/polaris/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Validation of best practices in your Kubernetes clusters
 name: polaris
-version: 1.2.4
+version: 1.3.0
 appVersion: "1.2"
 icon: https://raw.githubusercontent.com/FairwindsOps/polaris/master/pkg/dashboard/assets/favicon-32x32.png
 maintainers:

--- a/stable/polaris/README.md
+++ b/stable/polaris/README.md
@@ -31,6 +31,9 @@ Parameter | Description | Default
 `image.tag` | Image tag | 1.2
 `image.pullPolicy` | Image pull policy | Always
 `image.pullSecrets` | Image pull secrets | []
+`rbac.enabled` | Whether RBAC resources (ClusterRole, ClusterRolebinding) should be created | true
+`serviceAccount.create` | Specifies whether a service account should be created | true
+`serviceAccount.name` | The name of the service account to use | polaris.fullname
 `templateOnly` | | false
 `dashboard.basePath` | Path on which the dashboard is served. | /
 `dashboard.enable` | Whether to run the dashboard | true

--- a/stable/polaris/templates/_helpers.tpl
+++ b/stable/polaris/templates/_helpers.tpl
@@ -54,3 +54,14 @@ app.kubernetes.io/name: {{ include "polaris.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Name of the service account to use
+*/}}
+{{- define "polaris.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "polaris.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/stable/polaris/templates/dashboard.deployment.yaml
+++ b/stable/polaris/templates/dashboard.deployment.yaml
@@ -77,7 +77,7 @@ spec:
           subPath: config.yaml
           readOnly: true
         {{- end }}
-      serviceAccountName: {{ include "polaris.fullname" . }}
+      serviceAccountName: {{ template "polaris.serviceAccountName" . }}
       nodeSelector:
       {{- with .Values.dashboard.nodeSelector }}
 {{ toYaml . | indent 8 }}

--- a/stable/polaris/templates/rbac.yaml
+++ b/stable/polaris/templates/rbac.yaml
@@ -1,20 +1,5 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: {{ include "polaris.fullname" . }}
-  {{- if .Values.templateOnly }}
-  namespace: {{ .Release.Namespace }}
-  {{- end }}
-  labels:
-    {{- include "polaris.labels" . | nindent 4 }}
-{{- if .Values.image.pullSecrets }}
-imagePullSecrets:
-{{- range .Values.image.pullSecrets }}
-  - name: {{ . }}
-{{- end }}
-{{- end }}
----
-apiVersion: rbac.authorization.k8s.io/v1beta1
+{{- if .Values.rbac.enabled -}}
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "polaris.fullname" . }}-view
@@ -29,7 +14,7 @@ subjects:
     name: {{ include "polaris.fullname" . }}
     namespace: {{ .Release.Namespace }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "polaris.fullname" . }}
@@ -60,3 +45,4 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "polaris.fullname" . }}
     namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/stable/polaris/templates/serviceaccount.yaml
+++ b/stable/polaris/templates/serviceaccount.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "polaris.fullname" . }}
+  {{- if .Values.templateOnly }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
+  labels:
+    {{- include "polaris.labels" . | nindent 4 }}
+{{- if .Values.image.pullSecrets }}
+imagePullSecrets:
+{{- range .Values.image.pullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/stable/polaris/values.yaml
+++ b/stable/polaris/values.yaml
@@ -6,6 +6,17 @@ image:
 
 templateOnly: false
 
+rbac:
+  # Specifies whether RBAC resources (ClusterRole, ClusterRolebinding) should be created
+  enabled: true
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+
 dashboard:
   enable: true
   replicas: 1


### PR DESCRIPTION
Allow to disable rbac and serviceAccount.

Some may want to setup by other means so that deploying this chart does not requires extended cluster-wide privileges.

Also update ClusterRole and ClusterRolesBinding to api v1.

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
