### PR TITLE
update helm-docs to 1.3.0, sort based on file order

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,14 +37,14 @@ jobs:
           name: Install helm-docs
           command: |
             cd /tmp
-            curl -LO https://github.com/norwoodj/helm-docs/releases/download/v0.15.0/helm-docs_0.15.0_Linux_x86_64.tar.gz
-            tar -zxvf helm-docs_0.15.0_Linux_x86_64.tar.gz
+            curl -LO https://github.com/norwoodj/helm-docs/releases/download/v1.3.0/helm-docs_1.3.0_Linux_x86_64.tar.gz
+            tar -zxvf helm-docs_1.3.0_Linux_x86_64.tar.gz
             mv helm-docs /usr/local/bin/helm-docs
             chmod +x /usr/local/bin/helm-docs
       - run:
           name: Check Docs for Changes
           command: |
-            helm-docs
+            helm-docs --sort-values-order=file
             git diff --exit-code
   lint-scripts:
     docker:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,6 +34,8 @@ repos:
     hooks:
       - id: helmlint
   - repo: https://github.com/norwoodj/helm-docs
-    rev: v0.8.0
+    rev: v1.3.0
     hooks:
       - id: helm-docs
+        args:
+          - --sort-values-order=file

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -333,8 +333,8 @@ to autogenerate your README.md, you'll need to do the following:
 
 * In `values.yaml`, add comments with descriptions
 * Add a `README.md.gotmpl`
-* Install helm-docs (`brew install norwoodj/tap/helm-docs`)
-* Run `helm-docs` in your chart's directory
+* Install helm-docs (`brew install norwoodj/tap/helm-docs@1.3.0`)
+* Run `helm-docs --sort-values-order=file` in your chart's directory
 
 See the Goldilocks chart for a good example.
 

--- a/incubator/clamav/Chart.yaml
+++ b/incubator/clamav/Chart.yaml
@@ -5,7 +5,7 @@ description: |
     as the clamd server with a configurable number of replicas. Then, a daemonset that
     mounts the host file system scans using clamdscan and the remote server.
 type: application
-version: 0.0.2
+version: 0.0.3
 appVersion: v0.0.3
 maintainers:
   - name: sudermanjr

--- a/incubator/clamav/README.md
+++ b/incubator/clamav/README.md
@@ -8,27 +8,27 @@ mounts the host file system scans using clamdscan and the remote server.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| fullnameOverride | string | `""` |  |
 | imagePullSecrets | list | `[]` | A list of image pull secrets to use in both the server and scanner |
 | nameOverride | string | `""` |  |
-| scanner.image.pullPolicy | string | `"Always"` |  |
-| scanner.image.repository | string | `"quay.io/fairwinds/clamav"` |  |
-| scanner.resources | object | `{"limits":{"cpu":"100m","memory":"50Mi"},"requests":{"cpu":"100m","memory":"50Mi"}}` | The resources block for the scanner daemonset pods |
-| scanner.serviceAccount.annotations | object | `{}` | Annotations to add to the service account if it is created |
-| scanner.serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
-| scanner.serviceAccount.name | string | `nil` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
-| scanner.tolerations | list | `[{"effect":"NoSchedule","key":"node-role.kubernetes.io/master"}]` | A list of tolerations for the scanner daemonset pods. |
-| server.affinity | object | `{}` |  |
-| server.image.pullPolicy | string | `"Always"` | The imagePullPolicy for the server image |
-| server.image.repository | string | `"quay.io/fairwinds/clamav"` | The image repository to use for the server deployment. Version will be the application version in Chart.yaml |
-| server.nodeSelector | object | `{}` | A nodeSelector block for the server pods. |
-| server.podSecurityContext | object | `{}` |  |
+| fullnameOverride | string | `""` |  |
 | server.replicaCount | int | `2` | The number of replicas to run in the server deployment |
-| server.resources | object | `{"limits":{"cpu":"1000m","memory":"2Gi"},"requests":{"cpu":"1000m","memory":"2Gi"}}` | The resources block for the server deployment pods |
-| server.securityContext | object | `{}` |  |
-| server.service.port | int | `3310` | The port number to expose the service on |
-| server.service.type | string | `"ClusterIP"` | The type of service to run for the deployment |
-| server.serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
+| server.image.repository | string | `"quay.io/fairwinds/clamav"` | The image repository to use for the server deployment. Version will be the application version in Chart.yaml |
+| server.image.pullPolicy | string | `"Always"` | The imagePullPolicy for the server image |
 | server.serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
+| server.serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | server.serviceAccount.name | string | `nil` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
+| server.podSecurityContext | object | `{}` |  |
+| server.securityContext | object | `{}` |  |
+| server.service.type | string | `"ClusterIP"` | The type of service to run for the deployment |
+| server.service.port | int | `3310` | The port number to expose the service on |
+| server.resources | object | `{"limits":{"cpu":"1000m","memory":"2Gi"},"requests":{"cpu":"1000m","memory":"2Gi"}}` | The resources block for the server deployment pods |
+| server.nodeSelector | object | `{}` | A nodeSelector block for the server pods. |
 | server.tolerations | list | `[]` |  |
+| server.affinity | object | `{}` |  |
+| scanner.tolerations | list | `[{"effect":"NoSchedule","key":"node-role.kubernetes.io/master"}]` | A list of tolerations for the scanner daemonset pods. |
+| scanner.resources | object | `{"limits":{"cpu":"100m","memory":"50Mi"},"requests":{"cpu":"100m","memory":"50Mi"}}` | The resources block for the scanner daemonset pods |
+| scanner.image.repository | string | `"quay.io/fairwinds/clamav"` |  |
+| scanner.image.pullPolicy | string | `"Always"` |  |
+| scanner.serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
+| scanner.serviceAccount.annotations | object | `{}` | Annotations to add to the service account if it is created |
+| scanner.serviceAccount.name | string | `nil` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |

--- a/incubator/github-prometheus-exporter/Chart.yaml
+++ b/incubator/github-prometheus-exporter/Chart.yaml
@@ -1,26 +1,8 @@
 apiVersion: v2
 name: github-prometheus-exporter
 description: A Helm chart for Kubernetes
-
-# A chart can be either an 'application' or a 'library' chart.
-#
-# Application charts are a collection of templates that can be packaged into versioned archives
-# to be deployed.
-#
-# Library charts provide useful utilities or functions for the chart developer. They're included as
-# a dependency of application charts to inject those utilities and functions into the rendering
-# pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
-
-# This is the chart version. This version number should be incremented each time you make changes
-# to the chart and its templates, including the app version.
-# Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
-
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application. Versions are not expected to
-# follow Semantic Versioning. They should reflect the version the application is using.
+version: 0.1.2
 appVersion: release-1.0.1
-
 maintainers:
   - name: sudermanjr

--- a/incubator/github-prometheus-exporter/README.md
+++ b/incubator/github-prometheus-exporter/README.md
@@ -6,37 +6,37 @@ A chart for https://github.com/infinityworks/github-exporter
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| affinity | object | `{}` |  |
-| autoscaling.enabled | bool | `false` |  |
-| autoscaling.maxReplicas | int | `100` |  |
-| autoscaling.minReplicas | int | `1` |  |
-| autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
-| config.apiURL | string | `"https://api.github.com"` | Github API URL, shouldn't need to change this. |
+| replicaCount | int | `1` |  |
 | config.githubToken | string | `""` | A github token to be kept in environment |
-| config.logLevel | string | `"debug"` | The level of logging the exporter will run with |
-| config.orgs | string | `""` | Env ORGS. If supplied, the exporter will enumerate all repositories for that organization. Expected in the format "org1, org2". |
 | config.repos | string | `""` | Env REPOS. If supplied, The repos you wish to monitor, expected in the format "user/repo1, user/repo2". Can be across different Github users/orgs. |
 | config.users | string | `""` | Env USERS. If supplied, the exporter will enumerate all repositories for that users. Expected in the format "user1, user2" |
-| fullnameOverride | string | `""` |  |
-| image.pullPolicy | string | `"Always"` | The image pull policy. Strongly recommend not changing this |
+| config.orgs | string | `""` | Env ORGS. If supplied, the exporter will enumerate all repositories for that organization. Expected in the format "org1, org2". |
+| config.apiURL | string | `"https://api.github.com"` | Github API URL, shouldn't need to change this. |
+| config.logLevel | string | `"debug"` | The level of logging the exporter will run with |
 | image.repository | string | `"infinityworks/github-exporter"` | Where to find the docker image |
+| image.pullPolicy | string | `"Always"` | The image pull policy. Strongly recommend not changing this |
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion |
 | imagePullSecrets | list | `[]` |  |
-| ingress.annotations | object | `{}` |  |
+| nameOverride | string | `""` |  |
+| fullnameOverride | string | `""` |  |
+| serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
+| serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
+| serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
+| podAnnotations | object | `{}` | A map of annotations to add to the pod |
+| podSecurityContext | object | `{}` | A pod security context to add |
+| securityContext | object | `{}` |  |
+| service.type | string | `"ClusterIP"` | The type of service to expose |
+| service.port | int | `9171` | The port that the service will listen on |
 | ingress.enabled | bool | `false` |  |
+| ingress.annotations | object | `{}` |  |
 | ingress.hosts[0].host | string | `"chart-example.local"` |  |
 | ingress.hosts[0].paths | list | `[]` |  |
 | ingress.tls | list | `[]` |  |
-| nameOverride | string | `""` |  |
-| nodeSelector | object | `{}` |  |
-| podAnnotations | object | `{}` | A map of annotations to add to the pod |
-| podSecurityContext | object | `{}` | A pod security context to add |
-| replicaCount | int | `1` |  |
 | resources | object | `{}` |  |
-| securityContext | object | `{}` |  |
-| service.port | int | `9171` | The port that the service will listen on |
-| service.type | string | `"ClusterIP"` | The type of service to expose |
-| serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
-| serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
-| serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
+| autoscaling.enabled | bool | `false` |  |
+| autoscaling.minReplicas | int | `1` |  |
+| autoscaling.maxReplicas | int | `100` |  |
+| autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
+| nodeSelector | object | `{}` |  |
 | tolerations | list | `[]` |  |
+| affinity | object | `{}` |  |

--- a/stable/gemini/Chart.yaml
+++ b/stable/gemini/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Automated backup and restore of PersistentVolumes using the  VolumeSnapshot API
 name: gemini
-version: 0.0.3
+version: 0.0.4
 appVersion: 0.1.0
 maintainers:
   - name: rbren

--- a/stable/gemini/README.md
+++ b/stable/gemini/README.md
@@ -31,5 +31,5 @@ Your cluster must support the [VolumeSnapshot API](https://kubernetes.io/docs/co
 | image.tag | string | `"0.1"` | The gemini image tag to use |
 | rbac.create | bool | `true` | If true, create a new ServiceAccount and attach permissions |
 | rbac.serviceAccountName | string | `nil` |  |
-| resources | object | `{"limits":{"cpu":"200m","memory":"512Mi"},"requests":{"cpu":"25m","memory":"64Mi"}}` | The resources block for the controller pods |
 | verbosity | int | `5` |  |
+| resources | object | `{"limits":{"cpu":"200m","memory":"512Mi"},"requests":{"cpu":"25m","memory":"64Mi"}}` | The resources block for the controller pods |

--- a/stable/gemini/README.md
+++ b/stable/gemini/README.md
@@ -31,5 +31,5 @@ Your cluster must support the [VolumeSnapshot API](https://kubernetes.io/docs/co
 | image.tag | string | `"0.1"` | The gemini image tag to use |
 | rbac.create | bool | `true` | If true, create a new ServiceAccount and attach permissions |
 | rbac.serviceAccountName | string | `nil` |  |
-| verbosity | int | `5` |  |
+| verbosity | int | `5` | How verbose the controller logs should be |
 | resources | object | `{"limits":{"cpu":"200m","memory":"512Mi"},"requests":{"cpu":"25m","memory":"64Mi"}}` | The resources block for the controller pods |

--- a/stable/gemini/values.yaml
+++ b/stable/gemini/values.yaml
@@ -12,6 +12,7 @@ rbac:
   # If rbac.create is false, the name of an existing ServiceAccount to use
   serviceAccountName:
 
+# verbosity -- How verbose the controller logs should be
 verbosity: 5
 
 # resources -- The resources block for the controller pods

--- a/stable/gke-node-termination-handler/Chart.yaml
+++ b/stable/gke-node-termination-handler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: This helm chart provides an adapter for translating GCE node termination events to graceful pod terminations in Kubernetes.
 name: gke-node-termination-handler
-version: 1.0.1
+version: 1.0.2
 maintainers:
   - name: bbensky
   - name: hopson

--- a/stable/gke-node-termination-handler/README.md
+++ b/stable/gke-node-termination-handler/README.md
@@ -10,10 +10,10 @@ We recommend installing gke-node-termination-handler in its own namespace.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| daemonset.updateStrategy.type | string | `"RollingUpdate"` | The daemonset update strategy |
-| fullnameOverride | string | `""` | A template override for fullname |
-| image.pullPolicy | string | `"Always"` | The image pull policy. We recommend not changing this |
 | image.repository | string | `"k8s.gcr.io/gke-node-termination-handler@sha256"` | The image repository to pull from |
 | image.tag | string | `"aca12d17b222dfed755e28a44d92721e477915fb73211d0a0f8925a1fa847cca"` | The image tag to use |
+| image.pullPolicy | string | `"Always"` | The image pull policy. We recommend not changing this |
 | nameOverride | string | `""` | A template override for name |
+| fullnameOverride | string | `""` | A template override for fullname |
+| daemonset.updateStrategy.type | string | `"RollingUpdate"` | The daemonset update strategy |
 | resources | object | `{"limits":{"cpu":"150m","memory":"30Mi"},"requests":{"cpu":"150m","memory":"30Mi"}}` | A resource limit and requess block for the daemonset |

--- a/stable/goldilocks/Chart.yaml
+++ b/stable/goldilocks/Chart.yaml
@@ -4,7 +4,7 @@ description: |
   A Helm chart for running Fairwinds Goldilocks. See https://github.com/FairwindsOps/goldilocks
 name: goldilocks
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/goldilocks/icon.png
-version: 3.0.2
+version: 3.0.3
 maintainers:
   - name: sudermanjr
   - name: lucasreed

--- a/stable/goldilocks/README.md
+++ b/stable/goldilocks/README.md
@@ -45,41 +45,41 @@ This will completely remove the VPA and then re-install it using the new method.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| controller.affinity | object | `{}` | Affinity for the controller pods |
+| uninstallVPA | bool | `false` | Enabling this flag will remove a vpa installation that was previously managed with this chart. It is considered deprecated and will be removed in a later release. |
+| vpa.enabled | bool | `false` | If true, the vpa will be installed as a sub-chart |
+| metrics-server.enabled | bool | `false` | If true, the metrics-server will be installed as a sub-chart |
+| metrics-server.apiService.create | bool | `true` |  |
+| image.repository | string | `"quay.io/fairwinds/goldilocks"` | Repository for the goldilocks image |
+| image.tag | string | `"v3.0.0"` | The goldilocks image tag to use |
+| image.pullPolicy | string | `"Always"` | imagePullPolicy - Highly recommended to leave this as `Always` |
+| nameOverride | string | `""` |  |
+| fullnameOverride | string | `""` |  |
 | controller.enabled | bool | `true` | Whether or not to install the controller deployment |
+| controller.rbac.create | bool | `true` | If set to true, rbac resources will be created for the controller |
+| controller.serviceAccount.create | bool | `true` | If true, a service account will be created for the controller. If set to false, you must set `controller.serviceAccount.name` |
+| controller.serviceAccount.name | string | `nil` | The name of an existing service account to use for the controller. Combined with `controller.serviceAccount.create` |
 | controller.flags | object | `{}` | A map of additional flags to pass to the controller |
 | controller.logVerbosity | string | `"2"` | Controller log verbosity. Can be set from 1-10 with 10 being extremely verbose |
 | controller.nodeSelector | object | `{}` | Node selector for the controller pod |
-| controller.rbac.create | bool | `true` | If set to true, rbac resources will be created for the controller |
-| controller.resources | object | `{"limits":{"cpu":"25m","memory":"32Mi"},"requests":{"cpu":"25m","memory":"32Mi"}}` | The resources block for the controller pods |
-| controller.serviceAccount.create | bool | `true` | If true, a service account will be created for the controller. If set to false, you must set `controller.serviceAccount.name` |
-| controller.serviceAccount.name | string | `nil` | The name of an existing service account to use for the controller. Combined with `controller.serviceAccount.create` |
 | controller.tolerations | list | `[]` | Tolerations for the controller pod |
-| dashboard.affinity | object | `{}` |  |
-| dashboard.basePath | string | `nil` | Sets the web app's basePath/base href |
+| controller.affinity | object | `{}` | Affinity for the controller pods |
+| controller.resources | object | `{"limits":{"cpu":"25m","memory":"32Mi"},"requests":{"cpu":"25m","memory":"32Mi"}}` | The resources block for the controller pods |
 | dashboard.enabled | bool | `true` | If true, the dashboard component will be installed |
+| dashboard.replicaCount | int | `2` | Number of dashboard pods to run |
+| dashboard.service.type | string | `"ClusterIP"` | The type of the dashboard service |
+| dashboard.service.port | int | `80` | The port to run the dashboard service on |
+| dashboard.logVerbosity | string | `"2"` | Dashboard log verbosity. Can be set from 1-10 with 10 being extremely verbose |
 | dashboard.excludeContainers | string | `"linkerd-proxy,istio-proxy"` | Container names to exclude from displaying in the Goldilocks dashboard |
-| dashboard.ingress.annotations | object | `{}` |  |
+| dashboard.rbac.create | bool | `true` | If set to true, rbac resources will be created for the dashboard |
+| dashboard.serviceAccount.create | bool | `true` | If true, a service account will be created for the dashboard. If set to false, you must set `dashboard.serviceAccount.name` |
+| dashboard.serviceAccount.name | string | `nil` | The name of an existing service account to use for the controller. Combined with `dashboard.serviceAccount.create` |
+| dashboard.basePath | string | `nil` | Sets the web app's basePath/base href |
 | dashboard.ingress.enabled | bool | `false` | Enables an ingress object for the dashboard. |
+| dashboard.ingress.annotations | object | `{}` |  |
 | dashboard.ingress.hosts[0].host | string | `"chart-example.local"` |  |
 | dashboard.ingress.hosts[0].paths | list | `[]` |  |
 | dashboard.ingress.tls | list | `[]` |  |
-| dashboard.logVerbosity | string | `"2"` | Dashboard log verbosity. Can be set from 1-10 with 10 being extremely verbose |
-| dashboard.nodeSelector | object | `{}` |  |
-| dashboard.rbac.create | bool | `true` | If set to true, rbac resources will be created for the dashboard |
-| dashboard.replicaCount | int | `2` | Number of dashboard pods to run |
 | dashboard.resources | object | `{"limits":{"cpu":"25m","memory":"32Mi"},"requests":{"cpu":"25m","memory":"32Mi"}}` | A resources block for the dashboard. |
-| dashboard.service.port | int | `80` | The port to run the dashboard service on |
-| dashboard.service.type | string | `"ClusterIP"` | The type of the dashboard service |
-| dashboard.serviceAccount.create | bool | `true` | If true, a service account will be created for the dashboard. If set to false, you must set `dashboard.serviceAccount.name` |
-| dashboard.serviceAccount.name | string | `nil` | The name of an existing service account to use for the controller. Combined with `dashboard.serviceAccount.create` |
+| dashboard.nodeSelector | object | `{}` |  |
 | dashboard.tolerations | list | `[]` |  |
-| fullnameOverride | string | `""` |  |
-| image.pullPolicy | string | `"Always"` | imagePullPolicy - Highly recommended to leave this as `Always` |
-| image.repository | string | `"quay.io/fairwinds/goldilocks"` | Repository for the goldilocks image |
-| image.tag | string | `"v3.0.0"` | The goldilocks image tag to use |
-| metrics-server.apiService.create | bool | `true` |  |
-| metrics-server.enabled | bool | `false` | If true, the metrics-server will be installed as a sub-chart |
-| nameOverride | string | `""` |  |
-| uninstallVPA | bool | `false` | Enabling this flag will remove a vpa installation that was previously managed with this chart. It is considered deprecated and will be removed in a later release. |
-| vpa.enabled | bool | `false` | If true, the vpa will be installed as a sub-chart |
+| dashboard.affinity | object | `{}` |  |

--- a/stable/helm-release-pruner/Chart.yaml
+++ b/stable/helm-release-pruner/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v3.0.1
 description: This chart deploys a cronjob that purges stale Helm releases and associated namespaces. Releases are selected based on regex patterns for release name and namespace along with a Bash `date` command date string to define the stale cutoff date and time.
 name: helm-release-pruner
-version: 3.1.2
+version: 3.1.3
 maintainers:
   - name: coreypobrien
   - name: sudermanjr

--- a/stable/helm-release-pruner/README.md
+++ b/stable/helm-release-pruner/README.md
@@ -35,24 +35,24 @@ Chart version 1.0.0 introduced RBacDefinitions with rbac-manager to manage acces
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| fullnameOverride | string | `""` | A template override for fullname |
-| image.pullPolicy | string | `"Always"` | The image pull policy. We do not recommend changing this |
 | image.repository | string | `"quay.io/fairwinds/helm-release-pruner"` | Repo for image that the job runs on |
 | image.tag | string | `"v3.0.1"` | The image tag to use |
+| image.pullPolicy | string | `"Always"` | The image pull policy. We do not recommend changing this |
 | job.backoffLimit | int | `3` | The backoff limit for the job |
-| job.debug | bool | `false` | If true, will enable debug logging |
+| job.restartPolicy | string | `"Never"` |  |
+| job.schedule | string | `"0 */4 * * *"` | The schedule for the cronjob to run on |
 | job.dryRun | bool | `true` | If true, will only log candidates for removal and not remove them |
+| job.debug | bool | `false` | If true, will enable debug logging |
+| job.serviceAccount.create | bool | `true` | If true, a service account will be created for the job to use |
+| job.serviceAccount.name | string | `"ExistingServiceAccountName"` | The name of a pre-existing service account to use if job.serviceAccount.create is false |
 | job.listSecretsRole.create | bool | `true` | If true, a cluster role will be created for the job to list helm releases |
 | job.listSecretsRole.name | string | `"helm-release-pruner-list-secrets"` | Name of a cluster role granting list secrets permission |
 | job.resources.limits.cpu | string | `"25m"` |  |
 | job.resources.limits.memory | string | `"32Mi"` |  |
 | job.resources.requests.cpu | string | `"25m"` |  |
 | job.resources.requests.memory | string | `"32M"` |  |
-| job.restartPolicy | string | `"Never"` |  |
-| job.schedule | string | `"0 */4 * * *"` | The schedule for the cronjob to run on |
-| job.serviceAccount.create | bool | `true` | If true, a service account will be created for the job to use |
-| job.serviceAccount.name | string | `"ExistingServiceAccountName"` | The name of a pre-existing service account to use if job.serviceAccount.create is false |
-| nameOverride | string | `""` | A template override for name |
 | pruneProfiles | list | `[]` | Filters to use to find purge candidates. See example usage above for details |
 | rbac_manager.enabled | bool | `false` | If true, creates an RbacDefinition to manage access |
 | rbac_manager.namespaceLabel | string | `""` | Label to match namespaces to grant access to |
+| fullnameOverride | string | `""` | A template override for fullname |
+| nameOverride | string | `""` | A template override for name |

--- a/stable/insights-admission/Chart.yaml
+++ b/stable/insights-admission/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: insights-admission
 description: A Validating Webhook Admission Controller that utilizes Fairwinds Insights.
 type: application
-version: 0.2.1
+version: 0.2.2
 appVersion: "0.1"
 maintainers:
 - name: rbren

--- a/stable/insights-admission/README.md
+++ b/stable/insights-admission/README.md
@@ -37,21 +37,27 @@ rules:
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| replicaCount | int | `2` | The number of pods to run for the admission contrller. |
+| insights.organization | string | `""` | The name of your Organization from Fairwinds Insights |
+| insights.cluster | string | `""` | The name of your cluster from Fairwinds Insights |
+| insights.host | string | `"https://insights.fairwinds.com"` | Override the hostname for Fairwinds Insights |
+| insights.base64token | string | `""` | The token for your cluster from the Cluster Settings page in Fairwinds Insights. This should already be base64 encoded. |
 | webhookConfig.failurePolicy | string | `"Fail"` | failurePolicy for the ValidatingWebhookConfiguration |
 | webhookConfig.matchPolicy | string | `"Exact"` | matchPolicy for the ValidatingWebhookConfiguration |
 | webhookConfig.namespaceSelector | object | `{"matchExpressions":[{"key":"control-plane","operator":"DoesNotExist"}]}` | namespaceSelector for the ValidatingWebhookConfiguration |
 | webhookConfig.objectSelector | object | `{}` | objectSelector for the ValidatingWebhookConfiguration |
 | webhookConfig.rules | list | `[]` | An array of additional for the ValidatingWebhookConfiguration. Each requires a set of apiGroups, apiVersions, operations, resources, and a scope. |
 | webhookConfig.defaultRules | list | `[{"apiGroups":["apps"],"apiVersions":["v1","v1beta1","v1beta2"],"operations":["CREATE","UPDATE"],"resources":["daemonsets","deployments","statefulsets"],"scope":"Namespaced"},{"apiGroups":["batch"],"apiVersions":["v1","v1beta1"],"operations":["CREATE","UPDATE"],"resources":["jobs","cronjobs"],"scope":"Namespaced"},{"apiGroups":[""],"apiVersions":["v1"],"operations":["CREATE","UPDATE"],"resources":["pods","replicationcontrollers"],"scope":"Namespaced"}]` | An array of rules for commons types for the ValidatingWebhookConfiguration |
-| insights.organization | string | `""` | The name of your Organization from Fairwinds Insights |
-| insights.cluster | string | `""` | The name of your cluster from Fairwinds Insights |
-| insights.host | string | `"https://insights.fairwinds.com"` | Override the hostname for Fairwinds Insights |
-| insights.base64token | string | `""` | The token for your cluster from the Cluster Settings page in Fairwinds Insights. This should already be base64 encoded. |
+| resources | object | `{"limits":{"cpu":1,"memory":"2Gi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | A resources block for the controller. |
 | image.repository | string | `"quay.io/fairwinds/insights-admission-controller"` | Repository for the Insights Admission Controller image |
 | image.pullPolicy | string | `"Always"` | imagePullPolicy - Highly recommended to leave this as 'Always' |
 | image.tag | string | `""` | The Insights admission controller tag to use. Defaults to the Chart's AppVersion |
 | imagePullSecrets | list | `[]` | Secrets to use when pulling this image. |
+| replicaCount | int | `2` | The number of pods to run for the admission contrller. |
+| autoscaling.enabled | bool | `false` | Autoscale instead of a static number of pods running. |
+| autoscaling.minReplicas | int | `2` | Minimum number of pods to run. |
+| autoscaling.maxReplicas | int | `5` | Maximum number of pods to run. |
+| autoscaling.targetCPUUtilizationPercentage | int | `80` | Target CPU to scale towards. |
+| autoscaling.targetMemoryUtilizationPercentage | string | `nil` | Target memory to scale towards. |
 | nameOverride | string | `""` | Overrides the name of the release. |
 | fullnameOverride | string | `""` | Long name of the release to override. |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
@@ -62,12 +68,6 @@ rules:
 | securityContext | object | `{"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":15000}` | Security Context for the container. |
 | service.type | string | `"ClusterIP"` | Type of service to create. |
 | service.port | int | `443` | Port to use for the service. |
-| resources | object | `{"limits":{"cpu":1,"memory":"2Gi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | A resources block for the controller. |
-| autoscaling.enabled | bool | `false` | Autoscale instead of a static number of pods running. |
-| autoscaling.minReplicas | int | `2` | Minimum number of pods to run. |
-| autoscaling.maxReplicas | int | `5` | Maximum number of pods to run. |
-| autoscaling.targetCPUUtilizationPercentage | int | `80` | Target CPU to scale towards. |
-| autoscaling.targetMemoryUtilizationPercentage | string | `nil` | Target memory to scale towards. |
 | nodeSelector | object | `{}` | nodSelector to add to the controller. |
 | tolerations | list | `[]` | Toleratations to add to the controller. |
 | affinity | object | `{}` | Pod affinity/anti-affinity rules |

--- a/stable/insights-admission/README.md
+++ b/stable/insights-admission/README.md
@@ -37,41 +37,41 @@ rules:
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| affinity | object | `{}` | Pod affinity/anti-affinity rules |
-| autoscaling.enabled | bool | `false` | Autoscale instead of a static number of pods running. |
-| autoscaling.maxReplicas | int | `5` | Maximum number of pods to run. |
-| autoscaling.minReplicas | int | `2` | Minimum number of pods to run. |
-| autoscaling.targetCPUUtilizationPercentage | int | `80` | Target CPU to scale towards. |
-| autoscaling.targetMemoryUtilizationPercentage | string | `nil` | Target memory to scale towards. |
-| caBundle | string | `""` | If you are providing your own certificate then this is the Certificate Authority for that certificate |
-| clusterDomain | string | `"cluster.local"` | The base domain to use for cluster DNS |
-| fullnameOverride | string | `""` | Long name of the release to override. |
-| image.pullPolicy | string | `"Always"` | imagePullPolicy - Highly recommended to leave this as 'Always' |
-| image.repository | string | `"quay.io/fairwinds/insights-admission-controller"` | Repository for the Insights Admission Controller image |
-| image.tag | string | `""` | The Insights admission controller tag to use. Defaults to the Chart's AppVersion |
-| imagePullSecrets | list | `[]` | Secrets to use when pulling this image. |
-| insights.base64token | string | `""` | The token for your cluster from the Cluster Settings page in Fairwinds Insights. This should already be base64 encoded. |
-| insights.cluster | string | `""` | The name of your cluster from Fairwinds Insights |
-| insights.host | string | `"https://insights.fairwinds.com"` | Override the hostname for Fairwinds Insights |
-| insights.organization | string | `""` | The name of your Organization from Fairwinds Insights |
-| nameOverride | string | `""` | Overrides the name of the release. |
-| nodeSelector | object | `{}` | nodSelector to add to the controller. |
-| podAnnotations | object | `{}` | Annotations to add to each pod. |
-| podSecurityContext | object | `{}` | Security Context for the entire pod. |
 | replicaCount | int | `2` | The number of pods to run for the admission contrller. |
-| resources | object | `{"limits":{"cpu":1,"memory":"2Gi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | A resources block for the controller. |
-| secretName | string | `""` | If you are providing your own certificate then this is the name of the secret holding the certificate. |
-| securityContext | object | `{"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":15000}` | Security Context for the container. |
-| service.port | int | `443` | Port to use for the service. |
-| service.type | string | `"ClusterIP"` | Type of service to create. |
-| serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
-| serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
-| serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
-| test | object | `{"enabled":false,"image":{"repository":"python","tag":"3.8-alpine"}}` | Used for chart CI only - deploys a test deployment |
-| tolerations | list | `[]` | Toleratations to add to the controller. |
-| webhookConfig.defaultRules | list | `[{"apiGroups":["apps"],"apiVersions":["v1","v1beta1","v1beta2"],"operations":["CREATE","UPDATE"],"resources":["daemonsets","deployments","statefulsets"],"scope":"Namespaced"},{"apiGroups":["batch"],"apiVersions":["v1","v1beta1"],"operations":["CREATE","UPDATE"],"resources":["jobs","cronjobs"],"scope":"Namespaced"},{"apiGroups":[""],"apiVersions":["v1"],"operations":["CREATE","UPDATE"],"resources":["pods","replicationcontrollers"],"scope":"Namespaced"}]` | An array of rules for commons types for the ValidatingWebhookConfiguration |
 | webhookConfig.failurePolicy | string | `"Fail"` | failurePolicy for the ValidatingWebhookConfiguration |
 | webhookConfig.matchPolicy | string | `"Exact"` | matchPolicy for the ValidatingWebhookConfiguration |
 | webhookConfig.namespaceSelector | object | `{"matchExpressions":[{"key":"control-plane","operator":"DoesNotExist"}]}` | namespaceSelector for the ValidatingWebhookConfiguration |
 | webhookConfig.objectSelector | object | `{}` | objectSelector for the ValidatingWebhookConfiguration |
 | webhookConfig.rules | list | `[]` | An array of additional for the ValidatingWebhookConfiguration. Each requires a set of apiGroups, apiVersions, operations, resources, and a scope. |
+| webhookConfig.defaultRules | list | `[{"apiGroups":["apps"],"apiVersions":["v1","v1beta1","v1beta2"],"operations":["CREATE","UPDATE"],"resources":["daemonsets","deployments","statefulsets"],"scope":"Namespaced"},{"apiGroups":["batch"],"apiVersions":["v1","v1beta1"],"operations":["CREATE","UPDATE"],"resources":["jobs","cronjobs"],"scope":"Namespaced"},{"apiGroups":[""],"apiVersions":["v1"],"operations":["CREATE","UPDATE"],"resources":["pods","replicationcontrollers"],"scope":"Namespaced"}]` | An array of rules for commons types for the ValidatingWebhookConfiguration |
+| insights.organization | string | `""` | The name of your Organization from Fairwinds Insights |
+| insights.cluster | string | `""` | The name of your cluster from Fairwinds Insights |
+| insights.host | string | `"https://insights.fairwinds.com"` | Override the hostname for Fairwinds Insights |
+| insights.base64token | string | `""` | The token for your cluster from the Cluster Settings page in Fairwinds Insights. This should already be base64 encoded. |
+| image.repository | string | `"quay.io/fairwinds/insights-admission-controller"` | Repository for the Insights Admission Controller image |
+| image.pullPolicy | string | `"Always"` | imagePullPolicy - Highly recommended to leave this as 'Always' |
+| image.tag | string | `""` | The Insights admission controller tag to use. Defaults to the Chart's AppVersion |
+| imagePullSecrets | list | `[]` | Secrets to use when pulling this image. |
+| nameOverride | string | `""` | Overrides the name of the release. |
+| fullnameOverride | string | `""` | Long name of the release to override. |
+| serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
+| serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
+| serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
+| podAnnotations | object | `{}` | Annotations to add to each pod. |
+| podSecurityContext | object | `{}` | Security Context for the entire pod. |
+| securityContext | object | `{"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":15000}` | Security Context for the container. |
+| service.type | string | `"ClusterIP"` | Type of service to create. |
+| service.port | int | `443` | Port to use for the service. |
+| resources | object | `{"limits":{"cpu":1,"memory":"2Gi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | A resources block for the controller. |
+| autoscaling.enabled | bool | `false` | Autoscale instead of a static number of pods running. |
+| autoscaling.minReplicas | int | `2` | Minimum number of pods to run. |
+| autoscaling.maxReplicas | int | `5` | Maximum number of pods to run. |
+| autoscaling.targetCPUUtilizationPercentage | int | `80` | Target CPU to scale towards. |
+| autoscaling.targetMemoryUtilizationPercentage | string | `nil` | Target memory to scale towards. |
+| nodeSelector | object | `{}` | nodSelector to add to the controller. |
+| tolerations | list | `[]` | Toleratations to add to the controller. |
+| affinity | object | `{}` | Pod affinity/anti-affinity rules |
+| caBundle | string | `""` | If you are providing your own certificate then this is the Certificate Authority for that certificate |
+| secretName | string | `""` | If you are providing your own certificate then this is the name of the secret holding the certificate. |
+| clusterDomain | string | `"cluster.local"` | The base domain to use for cluster DNS |
+| test | object | `{"enabled":false,"image":{"repository":"python","tag":"3.8-alpine"}}` | Used for chart CI only - deploys a test deployment |

--- a/stable/insights-admission/values.yaml
+++ b/stable/insights-admission/values.yaml
@@ -1,9 +1,12 @@
-# Default values for insights-admission.
-# This is a YAML-formatted file.
-# Declare variables to be passed into your templates.
-
-# replicaCount -- The number of pods to run for the admission contrller.
-replicaCount: 2
+insights:
+  # insights.organization -- The name of your Organization from Fairwinds Insights
+  organization: ""
+  # insights.cluster -- The name of your cluster from Fairwinds Insights
+  cluster: ""
+  # insights.host -- Override the hostname for Fairwinds Insights
+  host: https://insights.fairwinds.com
+  # insights.base64token -- The token for your cluster from the Cluster Settings page in Fairwinds Insights. This should already be base64 encoded.
+  base64token: ""
 
 webhookConfig:
   # webhookConfig.failurePolicy -- failurePolicy for the ValidatingWebhookConfiguration
@@ -59,15 +62,14 @@ webhookConfig:
     - replicationcontrollers
     scope: Namespaced
 
-insights:
-  # insights.organization -- The name of your Organization from Fairwinds Insights
-  organization: ""
-  # insights.cluster -- The name of your cluster from Fairwinds Insights
-  cluster: ""
-  # insights.host -- Override the hostname for Fairwinds Insights
-  host: https://insights.fairwinds.com
-  # insights.base64token -- The token for your cluster from the Cluster Settings page in Fairwinds Insights. This should already be base64 encoded.
-  base64token: ""
+# resources -- A resources block for the controller.
+resources:
+  limits:
+    cpu: 1
+    memory: 2Gi
+  requests:
+    cpu: 100m
+    memory: 128Mi
 
 image:
   # image.repository -- Repository for the Insights Admission Controller image
@@ -79,6 +81,21 @@ image:
 
 # imagePullSecrets -- Secrets to use when pulling this image.
 imagePullSecrets: []
+
+# replicaCount -- The number of pods to run for the admission contrller.
+replicaCount: 2
+
+autoscaling:
+  # autoscaling.enabled -- Autoscale instead of a static number of pods running.
+  enabled: false
+  # autoscaling.minReplicas -- Minimum number of pods to run.
+  minReplicas: 2
+  # autoscaling.maxReplicas -- Maximum number of pods to run.
+  maxReplicas: 5
+  # autoscaling.targetCPUUtilizationPercentage -- Target CPU to scale towards.
+  targetCPUUtilizationPercentage: 80
+  # autoscaling.targetMemoryUtilizationPercentage -- Target memory to scale towards.
+  targetMemoryUtilizationPercentage: null
 
 # nameOverride -- Overrides the name of the release.
 nameOverride: ""
@@ -114,27 +131,6 @@ service:
   type: ClusterIP
   # service.port -- Port to use for the service.
   port: 443
-
-# resources -- A resources block for the controller.
-resources:
-  limits:
-    cpu: 1
-    memory: 2Gi
-  requests:
-    cpu: 100m
-    memory: 128Mi
-
-autoscaling:
-  # autoscaling.enabled -- Autoscale instead of a static number of pods running.
-  enabled: false
-  # autoscaling.minReplicas -- Minimum number of pods to run.
-  minReplicas: 2
-  # autoscaling.maxReplicas -- Maximum number of pods to run.
-  maxReplicas: 5
-  # autoscaling.targetCPUUtilizationPercentage -- Target CPU to scale towards.
-  targetCPUUtilizationPercentage: 80
-  # autoscaling.targetMemoryUtilizationPercentage -- Target memory to scale towards.
-  targetMemoryUtilizationPercentage: null
 
 # nodeSelector -- nodSelector to add to the controller.
 nodeSelector: {}

--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 0.1.5
+version: 0.1.6
 appVersion: 0.8.0
 maintainers:
   - name: sudermanjr

--- a/stable/vpa/README.md
+++ b/stable/vpa/README.md
@@ -36,54 +36,54 @@ helm install vpa fairwinds-stable/vpa --namespace vpa --create-namespace
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| admissionController.affinity | object | `{}` |  |
-| admissionController.cleanupOnDelete | bool | `true` | If true, a post-delete job will remove the mutatingwebhookconfiguration and the tls secret for the admission controller |
-| admissionController.enabled | bool | `false` | If true, will install the admission-controller component of vpa |
-| admissionController.generateCertificate | bool | `true` | If true and admissionController is enabled, a pre-install hook will run to create the certificate for the webhook |
-| admissionController.image.pullPolicy | string | `"Always"` | The pull policy for the admission controller image. Recommend not changing this |
-| admissionController.image.repository | string | `"us.gcr.io/k8s-artifacts-prod/autoscaling/vpa-admission-controller"` | The location of the vpa admission controller image |
-| admissionController.image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion |
-| admissionController.nodeSelector | object | `{}` |  |
-| admissionController.podAnnotations | object | `{}` | Annotations to add to the admission controller pod |
-| admissionController.podSecurityContext.runAsNonRoot | bool | `true` |  |
-| admissionController.podSecurityContext.runAsUser | int | `65534` |  |
-| admissionController.replicaCount | int | `1` |  |
-| admissionController.resources | object | `{"limits":{"cpu":"200m","memory":"500Mi"},"requests":{"cpu":"50m","memory":"200Mi"}}` | The resources block for the admission controller pod |
-| admissionController.securityContext | object | `{}` | The security context for the containers inside the admission controller pod |
-| admissionController.tolerations | list | `[]` |  |
-| fullnameOverride | string | `""` | A template override for the fullname |
 | imagePullSecrets | list | `[]` | A list of image pull secrets to be used for all pods |
-| nameOverride | string | `""` | A template override for the name |
 | priorityClassName | string | `""` | To set the priorityclass for all pods |
+| nameOverride | string | `""` | A template override for the name |
+| fullnameOverride | string | `""` | A template override for the fullname |
 | rbac.create | bool | `true` | If true, then rbac resources (clusterroles and clusterrolebindings) will be created for the selected components. |
-| recommender.affinity | object | `{}` |  |
+| serviceAccount.create | bool | `true` | Specifies whether a service account should be created for each component |
+| serviceAccount.annotations | object | `{}` | Annotations to add to the service accounts for each component |
+| serviceAccount.name | string | `""` | The base name of the service account to use (appended with the component). If not set and create is true, a name is generated using the fullname template and appended for each component |
 | recommender.enabled | bool | `true` | If true, the vpa recommender component will be installed. |
 | recommender.extraArgs | object | `{"pod-recommendation-min-cpu-millicores":15,"pod-recommendation-min-memory-mb":100,"v":"4"}` | A set of key-value flags to be passed to the recommender |
-| recommender.image.pullPolicy | string | `"Always"` | The pull policy for the recommender image. Recommend not changing this |
+| recommender.replicaCount | int | `1` |  |
 | recommender.image.repository | string | `"us.gcr.io/k8s-artifacts-prod/autoscaling/vpa-recommender"` | The location of the recommender image |
+| recommender.image.pullPolicy | string | `"Always"` | The pull policy for the recommender image. Recommend not changing this |
 | recommender.image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion |
-| recommender.nodeSelector | object | `{}` |  |
 | recommender.podAnnotations | object | `{}` | Annotations to add to the recommender pod |
 | recommender.podSecurityContext.runAsNonRoot | bool | `true` |  |
 | recommender.podSecurityContext.runAsUser | int | `65534` |  |
-| recommender.replicaCount | int | `1` |  |
-| recommender.resources | object | `{"limits":{"cpu":"200m","memory":"1000Mi"},"requests":{"cpu":"50m","memory":"500Mi"}}` | The resources block for the recommender pod |
 | recommender.securityContext | object | `{}` | The security context for the containers inside the recommender pod |
+| recommender.resources | object | `{"limits":{"cpu":"200m","memory":"1000Mi"},"requests":{"cpu":"50m","memory":"500Mi"}}` | The resources block for the recommender pod |
+| recommender.nodeSelector | object | `{}` |  |
 | recommender.tolerations | list | `[]` |  |
-| serviceAccount.annotations | object | `{}` | Annotations to add to the service accounts for each component |
-| serviceAccount.create | bool | `true` | Specifies whether a service account should be created for each component |
-| serviceAccount.name | string | `""` | The base name of the service account to use (appended with the component). If not set and create is true, a name is generated using the fullname template and appended for each component |
-| updater.affinity | object | `{}` |  |
+| recommender.affinity | object | `{}` |  |
 | updater.enabled | bool | `true` | If true, the updater component will be deployed |
 | updater.extraArgs | object | `{}` | A key-value map of flags to pass to the updater |
-| updater.image.pullPolicy | string | `"Always"` | The pull policy for the updater image. Recommend not changing this |
+| updater.replicaCount | int | `1` |  |
 | updater.image.repository | string | `"us.gcr.io/k8s-artifacts-prod/autoscaling/vpa-updater"` | The location of the updater image |
+| updater.image.pullPolicy | string | `"Always"` | The pull policy for the updater image. Recommend not changing this |
 | updater.image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion |
-| updater.nodeSelector | object | `{}` |  |
 | updater.podAnnotations | object | `{}` | Annotations to add to the updater pod |
 | updater.podSecurityContext.runAsNonRoot | bool | `true` |  |
 | updater.podSecurityContext.runAsUser | int | `65534` |  |
-| updater.replicaCount | int | `1` |  |
-| updater.resources | object | `{"limits":{"cpu":"200m","memory":"1000Mi"},"requests":{"cpu":"50m","memory":"500Mi"}}` | The resources block for the updater pod |
 | updater.securityContext | object | `{}` | The security context for the containers inside the updater pod |
+| updater.resources | object | `{"limits":{"cpu":"200m","memory":"1000Mi"},"requests":{"cpu":"50m","memory":"500Mi"}}` | The resources block for the updater pod |
+| updater.nodeSelector | object | `{}` |  |
 | updater.tolerations | list | `[]` |  |
+| updater.affinity | object | `{}` |  |
+| admissionController.enabled | bool | `false` | If true, will install the admission-controller component of vpa |
+| admissionController.generateCertificate | bool | `true` | If true and admissionController is enabled, a pre-install hook will run to create the certificate for the webhook |
+| admissionController.cleanupOnDelete | bool | `true` | If true, a post-delete job will remove the mutatingwebhookconfiguration and the tls secret for the admission controller |
+| admissionController.replicaCount | int | `1` |  |
+| admissionController.image.repository | string | `"us.gcr.io/k8s-artifacts-prod/autoscaling/vpa-admission-controller"` | The location of the vpa admission controller image |
+| admissionController.image.pullPolicy | string | `"Always"` | The pull policy for the admission controller image. Recommend not changing this |
+| admissionController.image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion |
+| admissionController.podAnnotations | object | `{}` | Annotations to add to the admission controller pod |
+| admissionController.podSecurityContext.runAsNonRoot | bool | `true` |  |
+| admissionController.podSecurityContext.runAsUser | int | `65534` |  |
+| admissionController.securityContext | object | `{}` | The security context for the containers inside the admission controller pod |
+| admissionController.resources | object | `{"limits":{"cpu":"200m","memory":"500Mi"},"requests":{"cpu":"50m","memory":"200Mi"}}` | The resources block for the admission controller pod |
+| admissionController.nodeSelector | object | `{}` |  |
+| admissionController.tolerations | list | `[]` |  |
+| admissionController.affinity | object | `{}` |  |


### PR DESCRIPTION
**Why This PR?**
Updates `helm-docs` to latest, and uses the `--sort-values-order=file` argument to sort the value docs based on the order they appear in values.yaml

This gives us more control over how the values appear in the README.

I also updated the values order for Gemini and insights-admission - happy to rearrange others.

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
