### PR TITLE
[astro] updates to the configmap should roll the deployment

### DIFF
--- a/stable/astro/Chart.yaml
+++ b/stable/astro/Chart.yaml
@@ -1,5 +1,5 @@
 name: astro
-version: 1.0.5
+version: 1.0.6
 apiVersion: v1
 appVersion: "1.5.3"
 description: Emit datadog monitors based on kubernetes state.
@@ -11,7 +11,7 @@ sources:
   - https://github.com/FairwindsOps/astro
 maintainers:
   - name: mjhuber
-    email: micah@fairwinds.com
+    email: micah@fastmail.us
   - name: lucasreed
     email: luke@fairwinds.com
 engine: gotpl

--- a/stable/astro/Chart.yaml
+++ b/stable/astro/Chart.yaml
@@ -14,4 +14,6 @@ maintainers:
     email: micah@fastmail.us
   - name: lucasreed
     email: luke@fairwinds.com
+  - name: baderbuddy
+    email: bader@fairwinds.com
 engine: gotpl

--- a/stable/astro/templates/deployment.yaml
+++ b/stable/astro/templates/deployment.yaml
@@ -18,6 +18,10 @@ spec:
       labels:
         app.kubernetes.io/name: {{ include "astro.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- if .Values.custom_config.enabled }}
+      annotations:
+        checksum/configmap: {{ include (print $.Template.BasePath "/configmap-data.yaml") . | sha256sum }}
+      {{- end }}
     spec:
       {{- if .Values.deployment.serviceAccount.create }}
       serviceAccountName: {{ include "astro.fullname" . }}


### PR DESCRIPTION
**Why This PR?**
Currently if a change to the custom-config occurs, it will not trigger a
relaunch of the pods. This fixes that issue.

Fixes https://github.com/FairwindsOps/astro/issues/119

**Changes**
Changes proposed in this pull request:

* an annotation that is a sha of the configmap will cause the deployment
to roll

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.