### PR TITLE
[Insights Agent] Disable reports by default

### DIFF
--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 0.27.8
-appVersion: 1.13.1
+version: 1.0.0
+appVersion: 2.0.0
 maintainers:
   - name: rbren
   - name: makoscafee

--- a/stable/insights-agent/ci/test-values.yaml
+++ b/stable/insights-agent/ci/test-values.yaml
@@ -13,5 +13,21 @@ opa:
 test:
   enabled: true
 
+kubesec:
+  enabled: true
+
+polaris:
+  enabled: true
+
+pluto:
+  enabled: true
+
+nova:
+  enabled: true
+
+kubehunter:
+  enabled: true
+
 trivy:
+  enabled: true
   maxScansPerRun: 2

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -39,7 +39,7 @@ cronjobExecutor:
       memory: 3Mi
 
 polaris:
-  enabled: true
+  enabled: false
   schedule: "rand * * * *"
   timeout: 300
   image:
@@ -54,7 +54,7 @@ polaris:
       memory: 64Mi
 
 kubehunter:
-  enabled: true
+  enabled: false
   schedule: "rand * * * *"
   timeout: 300
   logLevel: INFO
@@ -85,7 +85,7 @@ kubesec:
       memory: 64Mi
 
 goldilocks:
-  enabled: true
+  enabled: false
   installVPA: true
   schedule: "rand * * * *"
   timeout: 300
@@ -145,7 +145,7 @@ workloads:
       memory: 64Mi
 
 nova:
-  enabled: true
+  enabled: false
   schedule: "rand * * * *"
   timeout: 300
   image:
@@ -160,7 +160,7 @@ nova:
       memory: 128Mi
 
 rbacreporter:
-  enabled: true
+  enabled: false
   schedule: "rand * * * *"
   timeout: 300
   image:
@@ -175,7 +175,7 @@ rbacreporter:
       memory: 64Mi
 
 kubebench:
-  enabled: true
+  enabled: false
   schedule: "rand * * * *"
   mode: "cronjob"
   hourInterval: 2
@@ -203,7 +203,7 @@ kubebench:
       memory: 16Mi
 
 trivy:
-  enabled: true
+  enabled: false
   namespaceBlacklist: []
   schedule: "rand * * * *"
   privateImages:
@@ -223,7 +223,7 @@ trivy:
       memory: 64Mi
 
 pluto:
-  enabled: true
+  enabled: false
   schedule: "rand * * * *"
   timeout: 300
   image:


### PR DESCRIPTION
**Why This PR?**
Disables all reports except workloads in preparation for the Report Hub.

Fixes #

**Changes**
Changes proposed in this pull request:

* Marks all reports `enabled` to `false` except Workloads.

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
