### PR TITLE
[rbac-manager] updating apiversions for kube 1.19

### DIFF
--- a/stable/rbac-manager/Chart.yaml
+++ b/stable/rbac-manager/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rbac-manager
-version: 1.5.7
+version: 1.6.0
 appVersion: 0.9.4
 description: A Kubernetes operator that simplifies the management of Role Bindings and Service Accounts.
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/rbac-manager/icon.png
@@ -17,5 +17,6 @@ maintainers:
   - name: robscott
   - name: sudermanjr
     email: andy@fairwinds.com
-  - name: mjhuber
+  - name: lucasreed
+    email: luke@fairwinds.com
 engine: gotpl

--- a/stable/rbac-manager/README.md
+++ b/stable/rbac-manager/README.md
@@ -21,7 +21,9 @@ helm install rbac-manager fairwinds-stable/rbac-manager --namespace rbac-manager
 
 ## Prerequisites
 
-Kubernetes 1.8+, Helm 2.10+
+As of chart version 1.6.0 Kubernetes 1.16+, Helm 2.10+
+
+Helm 3 will be made mandatory in the future.
 
 ## Configuration
 

--- a/stable/rbac-manager/templates/clusterrole.yaml
+++ b/stable/rbac-manager/templates/clusterrole.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ template "rbac-manager.fullname" . }}

--- a/stable/rbac-manager/templates/clusterrolebinding.yaml
+++ b/stable/rbac-manager/templates/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "rbac-manager.fullname" . }}

--- a/stable/rbac-manager/templates/customresourcedefinition.yaml
+++ b/stable/rbac-manager/templates/customresourcedefinition.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: rbacdefinitions.rbacmanager.reactiveops.io
@@ -12,61 +12,101 @@ spec:
   names:
     kind: RBACDefinition
     plural: rbacdefinitions
+    singular: rbacdefinition
+    shortNames:
+      - rbd
+      - rbacdef
   scope: Cluster
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          type: string
-        kind:
-          type: string
-        metadata:
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          required:
+            - rbacBindings
           type: object
-        rbacBindings:
-          items:
-            properties:
-              clusterRoleBindings:
-                items:
-                  properties:
-                    clusterRole:
-                      type: string
-                  required:
-                  - clusterRole
-                  type: object
-                type: array
-              name:
-                type: string
-              roleBindings:
-                items:
-                  properties:
-                    clusterRole:
-                      type: string
-                    namespace:
-                      type: string
-                    namespaceSelector:
+          properties:
+            rbacBindings:
+              items:
+                properties:
+                  clusterRoleBindings:
+                    items:
+                      properties:
+                        clusterRole:
+                          type: string
+                      required:
+                        - clusterRole
+                      type: object
+                    type: array
+                  name:
+                    type: string
+                  roleBindings:
+                    items:
+                      properties:
+                        clusterRole:
+                          type: string
+                        namespace:
+                          type: string
+                        namespaceSelector:
+                          type: object
+                          properties:
+                            matchLabels:
+                              type: object
+                              additionalProperties:
+                                type: string
+                            matchExpressions:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  key:
+                                    type: string
+                                  operator:
+                                    type:
+                                      string
+                                    enum:
+                                      - Exists
+                                      - DoesNotExist
+                                      - In
+                                      - NotIn
+                                  values:
+                                    type: array
+                                    items:
+                                      type: string
+                                required:
+                                  - key
+                                  - operator
+                        role:
+                          type: string
+                      type: object
+                    type: array
+                  subjects:
+                    items:
                       type: object
                       properties:
-                        matchLabels:
-                          type: object
-                        matchExpressions:
+                        imagePullSecrets:
                           type: array
-                    role:
-                      type: string
-                  type: object
-                type: array
-              subjects:
-                items:
-                  type: object
-                type: array
-            required:
-            - name
-            - subjects
-            type: object
-          type: array
-        status:
-          type: object
-      required:
-      - metadata
-      - rbacBindings
-      type: object
-  version: v1beta1
+                          items:
+                            type: string
+                        kind:
+                          type: string
+                          enum:
+                            - Group
+                            - ServiceAccount
+                            - User
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                      required:
+                        - name
+                        - kind
+                    type: array
+                required:
+                  - name
+                  - subjects
+                type: object
+              type: array
+            status:
+              type: object


### PR DESCRIPTION
**Why This PR?**
In kubernetes 1.19, some apiversions will be removed

Fixes #
This change will allow rbac-manager to work in kubernetes 1.19

**Changes**
Changes proposed in this pull request:

* change clusterrole, clusterrolebinding to use rbac.authorization.k8s.io/v1
* change crd to apiVersion apiextensions.k8s.io/v1
* update crd definition to align with openApiSpec v3 and the kubernetes
implementation of it
* added shortnames and singular name for the crd
	* allows the use of `kubectl get rbacdef` or `kubectl get rbd`
* removed Micah as chart owner
* added myself as chart owner


**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.