### PR TITLE
Adding certGen image to values that can be changed

### DIFF
--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 0.1.6
+version: 0.1.7
 appVersion: 0.8.0
 maintainers:
   - name: sudermanjr

--- a/stable/vpa/README.md
+++ b/stable/vpa/README.md
@@ -74,9 +74,9 @@ helm install vpa fairwinds-stable/vpa --namespace vpa --create-namespace
 | updater.affinity | object | `{}` |  |
 | admissionController.enabled | bool | `false` | If true, will install the admission-controller component of vpa |
 | admissionController.generateCertificate | bool | `true` | If true and admissionController is enabled, a pre-install hook will run to create the certificate for the webhook |
-| admissionController.certGen.repository | string | `"quay.io/reactiveops/ci-images"` |  |
-| admissionController.certGen.tag | string | `"v11-alpine"` |  |
-| admissionController.certGen.pullPolicy | string | `"Always"` |  |
+| admissionController.certGen.image.repository | string | `"quay.io/reactiveops/ci-images"` | An image that contains certgen for creating certificates. Only used if admissionController.generateCertificate is true |
+| admissionController.certGen.image.tag | string | `"v11-alpine"` | An image tag for the admissionController.certGen.image.repository image. Only used if admissionController.generateCertificate is true |
+| admissionController.certGen.image.pullPolicy | string | `"Always"` | The pull policy for the certgen image. Recommend not changing this |
 | admissionController.cleanupOnDelete | bool | `true` | If true, a post-delete job will remove the mutatingwebhookconfiguration and the tls secret for the admission controller |
 | admissionController.replicaCount | int | `1` |  |
 | admissionController.image.repository | string | `"us.gcr.io/k8s-artifacts-prod/autoscaling/vpa-admission-controller"` | The location of the vpa admission controller image |

--- a/stable/vpa/README.md
+++ b/stable/vpa/README.md
@@ -74,6 +74,9 @@ helm install vpa fairwinds-stable/vpa --namespace vpa --create-namespace
 | updater.affinity | object | `{}` |  |
 | admissionController.enabled | bool | `false` | If true, will install the admission-controller component of vpa |
 | admissionController.generateCertificate | bool | `true` | If true and admissionController is enabled, a pre-install hook will run to create the certificate for the webhook |
+| admissionController.certGen.repository | string | `"quay.io/reactiveops/ci-images"` |  |
+| admissionController.certGen.tag | string | `"v11-alpine"` |  |
+| admissionController.certGen.pullPolicy | string | `"Always"` |  |
 | admissionController.cleanupOnDelete | bool | `true` | If true, a post-delete job will remove the mutatingwebhookconfiguration and the tls secret for the admission controller |
 | admissionController.replicaCount | int | `1` |  |
 | admissionController.image.repository | string | `"us.gcr.io/k8s-artifacts-prod/autoscaling/vpa-admission-controller"` | The location of the vpa admission controller image |

--- a/stable/vpa/templates/admission-controller-certgen.yaml
+++ b/stable/vpa/templates/admission-controller-certgen.yaml
@@ -61,7 +61,7 @@ spec:
       serviceAccountName: {{ include "vpa.fullname" . }}-certgen
       containers:
       - name: certgen
-        image: quay.io/reactiveops/ci-images:v11-alpine
+        image: "{{ .Values.admissionController.certGen.image.repository }}:{{ .Values.admissionController.certGen.image.tag | default .Chart.AppVersion }}"
         command: ["bash"]
         args:
           - -c

--- a/stable/vpa/values.yaml
+++ b/stable/vpa/values.yaml
@@ -97,12 +97,13 @@ admissionController:
   # admissionController.generateCertificate -- If true and admissionController is enabled, a pre-install hook will run to create the certificate for the webhook
   generateCertificate: true
   certGen:
-    # admissionController.certGen.image.repository -- An image that contains certgen for creating certificates. Only used if admissionController.generateCertificate is true
-    repository: quay.io/reactiveops/ci-images
-    # admissionController.certGen.image.repository -- An image tag for the admissionController.certGen.image.repository image. Only used if admissionController.generateCertificate is true
-    tag: v11-alpine
-    # admissionController.certGen.image.pullPolicy -- The pull policy for the certgen image. Recommend not changing this
-    pullPolicy: Always
+    image:
+      # admissionController.certGen.image.repository -- An image that contains certgen for creating certificates. Only used if admissionController.generateCertificate is true
+      repository: quay.io/reactiveops/ci-images
+      # admissionController.certGen.image.tag -- An image tag for the admissionController.certGen.image.repository image. Only used if admissionController.generateCertificate is true
+      tag: v11-alpine
+      # admissionController.certGen.image.pullPolicy -- The pull policy for the certgen image. Recommend not changing this
+      pullPolicy: Always
   # admissionController.cleanupOnDelete -- If true, a post-delete job will remove the mutatingwebhookconfiguration and the tls secret for the admission controller
   cleanupOnDelete: true
   replicaCount: 1

--- a/stable/vpa/values.yaml
+++ b/stable/vpa/values.yaml
@@ -96,6 +96,13 @@ admissionController:
   enabled: false
   # admissionController.generateCertificate -- If true and admissionController is enabled, a pre-install hook will run to create the certificate for the webhook
   generateCertificate: true
+  certGen:
+    # admissionController.certGen.image.repository -- An image that contains certgen for creating certificates. Only used if admissionController.generateCertificate is true
+    repository: quay.io/reactiveops/ci-images
+    # admissionController.certGen.image.repository -- An image tag for the admissionController.certGen.image.repository image. Only used if admissionController.generateCertificate is true
+    tag: v11-alpine
+    # admissionController.certGen.image.pullPolicy -- The pull policy for the certgen image. Recommend not changing this
+    pullPolicy: Always
   # admissionController.cleanupOnDelete -- If true, a post-delete job will remove the mutatingwebhookconfiguration and the tls secret for the admission controller
   cleanupOnDelete: true
   replicaCount: 1


### PR DESCRIPTION
**Why This PR?**
The certGen image was hard-coded. This enables overriding it.

Fixes #390

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.