### PR TITLE
Issue-391 - Create ServiceMonitor for prometheus scraping

### DIFF
--- a/stable/rbac-manager/Chart.yaml
+++ b/stable/rbac-manager/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rbac-manager
-version: 1.6.1
+version: 1.6.2
 appVersion: 0.9.4
 description: A Kubernetes operator that simplifies the management of Role Bindings and Service Accounts.
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/rbac-manager/icon.png

--- a/stable/rbac-manager/README.md
+++ b/stable/rbac-manager/README.md
@@ -27,22 +27,26 @@ Helm 3 will be made mandatory in the future.
 
 ## Configuration
 
-| Parameter                   | Description                                 | Default                            |
-| --------------------------- | --------------------------------------------| ---------------------------------- |
-| `image.repository`          | Docker image repo                           | `quay.io/reactiveops/rbac-manager` |
-| `image.tag`                 | Docker image tag                            | `0.7.0`                            |
-| `image.pullPolicy`          | Docker image pull policy                    | `Always`                           |
-| `image.imagePullSecrets`    | Docker registry credentials                 | `[]`                               |
-| `resources.requests.cpu`    | CPU resource request                        | `100m`                             |
-| `resources.requests.memory` | Memory resource request                     | `128Mi`                            |
-| `resources.limits.cpu`      | CPU resource limit                          | `100m`                             |
-| `resources.limits.memory`   | Memory resource limit                       | `128Mi`                            |
-| `nodeSelector`              | Deployment nodeSelector                     | `{}`                               |
-| `tolerations`               | Deployment tolerations                      | `[]`                               |
-| `affinity`                  | Deployment affinity                         | `{}`                               |
-| `priorityClassName`         | Priority Class of the pod                   | `""`                               |
-| `podAnnotations`            | Annotations to add to the Deployment's pods | `{}`            |
-| `podLabels`                 | Labels to add to the Deployment's pods      | `{}`                 |
+| Parameter                    | Description                                              | Default                            |
+| ---------------------------- | -------------------------------------------------------- | ---------------------------------- |
+| `image.repository`           | Docker image repo                                        | `quay.io/reactiveops/rbac-manager` |
+| `image.tag`                  | Docker image tag                                         | `0.7.0`                            |
+| `image.pullPolicy`           | Docker image pull policy                                 | `Always`                           |
+| `image.imagePullSecrets`     | Docker registry credentials                              | `[]`                               |
+| `resources.requests.cpu`     | CPU resource request                                     | `100m`                             |
+| `resources.requests.memory`  | Memory resource request                                  | `128Mi`                            |
+| `resources.limits.cpu`       | CPU resource limit                                       | `100m`                             |
+| `resources.limits.memory`    | Memory resource limit                                    | `128Mi`                            |
+| `nodeSelector`               | Deployment nodeSelector                                  | `{}`                               |
+| `tolerations`                | Deployment tolerations                                   | `[]`                               |
+| `affinity`                   | Deployment affinity                                      | `{}`                               |
+| `priorityClassName`          | Priority Class of the pod                                | `""`                               |
+| `podAnnotations`             | Annotations to add to the Deployment's pods              | `{}`            |
+| `podLabels`                  | Labels to add to the Deployment's pods                   | `{}`                 |
+| `serviceMonitor.enabled`     | Create a ServiceMonitor for prometheus scraping          | `false` |
+| `serviceMonitor.annotations` | annotations for the serviceMonitor and headless service  | `""` |
+| `serviceMonitor.namespace`   | The namespace to deploy the ServiceMonitor into          | `""` |
+| `serviceMonitor.interval`    | How often to scrape the metrics endpoint                 | `60s` |
 
 ## Upgrading to Chart Version 1.0.0
 

--- a/stable/rbac-manager/templates/headless-service.yaml
+++ b/stable/rbac-manager/templates/headless-service.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.serviceMonitor.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "rbac-manager.fullname" . }}-headless
+  labels:
+    app: {{ template "rbac-manager.name" . }}
+    chart: {{ template "rbac-manager.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- with .Values.serviceMonitor.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+  clusterIP: None
+  selector:
+    app: {{ template "rbac-manager.name" . }}
+    release: {{ .Release.Name }}
+  type: ClusterIP
+{{- end }}

--- a/stable/rbac-manager/templates/headless-service.yaml
+++ b/stable/rbac-manager/templates/headless-service.yaml
@@ -18,4 +18,9 @@ spec:
     app: {{ template "rbac-manager.name" . }}
     release: {{ .Release.Name }}
   type: ClusterIP
+  ports:
+  - name: metrics
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
 {{- end }}

--- a/stable/rbac-manager/templates/servicemonitor.yaml
+++ b/stable/rbac-manager/templates/servicemonitor.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.serviceMonitor.enabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "rbac-manager.fullname" . }}
+  {{- if .Values.serviceMonitor.namespace }}
+  namespace: {{ .Values.serviceMonitor.namespace }}
+  {{- end }}
+  labels:
+    app: {{ template "rbac-manager.name" . }}
+    chart: {{ template "rbac-manager.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  endpoints:
+  - interval: {{ .Values.serviceMonitor.interval }}
+    port: 8080
+    path: /metrics
+    scheme: http
+  jobLabel: "{{ .Release.Name }}"
+  selector:
+    matchLabels:
+      app: {{ template "rbac-manager.name" . }}
+      release: {{ .Release.Name }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+{{- end }}

--- a/stable/rbac-manager/templates/servicemonitor.yaml
+++ b/stable/rbac-manager/templates/servicemonitor.yaml
@@ -12,6 +12,10 @@ metadata:
     chart: {{ template "rbac-manager.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- with .Values.serviceMonitor.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
 spec:
   endpoints:
   - interval: {{ .Values.serviceMonitor.interval }}

--- a/stable/rbac-manager/templates/servicemonitor.yaml
+++ b/stable/rbac-manager/templates/servicemonitor.yaml
@@ -15,9 +15,8 @@ metadata:
 spec:
   endpoints:
   - interval: {{ .Values.serviceMonitor.interval }}
-    port: 8080
+    port: metrics
     path: /metrics
-    scheme: http
   jobLabel: "{{ .Release.Name }}"
   selector:
     matchLabels:

--- a/stable/rbac-manager/templates/servicemonitor.yaml
+++ b/stable/rbac-manager/templates/servicemonitor.yaml
@@ -17,7 +17,6 @@ spec:
   - interval: {{ .Values.serviceMonitor.interval }}
     port: metrics
     path: /metrics
-  jobLabel: "{{ .Release.Name }}"
   selector:
     matchLabels:
       app: {{ template "rbac-manager.name" . }}

--- a/stable/rbac-manager/values.yaml
+++ b/stable/rbac-manager/values.yaml
@@ -24,12 +24,8 @@ affinity: {}
 podAnnotations: {}
 podLabels: {}
 
-service:
-  enabled: false
-  annotations: {}
-
 serviceMonitor:
   enabled: false
-  annotations: ""
+  annotations: {}
   namespace: ""
   interval: 60s

--- a/stable/rbac-manager/values.yaml
+++ b/stable/rbac-manager/values.yaml
@@ -23,3 +23,13 @@ affinity: {}
 
 podAnnotations: {}
 podLabels: {}
+
+service:
+  enabled: false
+  annotations: {}
+
+serviceMonitor:
+  enabled: false
+  annotations: ""
+  namespace: ""
+  interval: 60s


### PR DESCRIPTION
**Why This PR?**
Adds servicemonitor and headless service to allow for prometheus scraping
Fixes #391 

**Changes**
Changes proposed in this pull request:
* New headless service and servicemonitor configurable through the .Values.serviceMonitor fields

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
