### PR TITLE
Convert rbac-manager to use helm-docs

### DIFF
--- a/.helmdocsignore
+++ b/.helmdocsignore
@@ -17,4 +17,3 @@ stable/aws-iam-authenticator
 stable/ecr-cleanup
 stable/insights-agent
 stable/polaris
-stable/rbac-manager

--- a/stable/rbac-manager/Chart.yaml
+++ b/stable/rbac-manager/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rbac-manager
-version: 1.6.2
+version: 1.6.3
 appVersion: 0.9.4
 description: A Kubernetes operator that simplifies the management of Role Bindings and Service Accounts.
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/rbac-manager/icon.png

--- a/stable/rbac-manager/README.md.gotmpl
+++ b/stable/rbac-manager/README.md.gotmpl
@@ -48,22 +48,4 @@ The following process has worked repeatedly for us to upgrade from an older vers
 
 In the above workflow, an RBAC Definition installed between revision 1 and 2 should persist through to revision 5. This process is admittedly quite strange, and in our testing the second rollback (step 5) is indeed required for this process to work.
 
-## Values
-
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| image.repository | string | `"quay.io/reactiveops/rbac-manager"` | The image to run for rbac manager |
-| image.tag | string | `"v0.9.4"` | The tag of the image to run |
-| image.pullPolicy | string | `"Always"` | The image pullPolicy. Recommend not changing this |
-| image.imagePullSecrets | list | `[]` |  |
-| resources | object | `{"limits":{"cpu":"100m","memory":"128Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | A resources block for the rbac-manager pods |
-| priorityClassName | string | `""` | The name of a priorityClass to use |
-| nodeSelector | object | `{}` | Deployment nodeSelector |
-| tolerations | list | `[]` | Deployment tolerations |
-| affinity | object | `{}` | Deployment affinity |
-| podAnnotations | object | `{}` | Annotations to apply to the pods |
-| podLabels | object | `{}` | Labels to apply to the pod |
-| serviceMonitor.enabled | bool | `false` | If true, a ServiceMonitor will be created for Prometheus |
-| serviceMonitor.annotations | object | `{}` | Annotations to apply to the serviceMonitor and headless service |
-| serviceMonitor.namespace | string | `""` | The namespace to deploy the serviceMonitor into |
-| serviceMonitor.interval | string | `"60s"` | How often to scrape the metrics endpoint |
+{{ template "chart.valuesSection" . }}

--- a/stable/rbac-manager/values.yaml
+++ b/stable/rbac-manager/values.yaml
@@ -1,10 +1,14 @@
 image:
+  # image.repository -- The image to run for rbac manager
   repository: quay.io/reactiveops/rbac-manager
+  # image.tag -- The tag of the image to run
   tag: v0.9.4
+  # image.pullPolicy -- The image pullPolicy. Recommend not changing this
   pullPolicy: Always
+  # imagePullSecrets -- A list of imagePullSecrets to reference for pulling the image
   imagePullSecrets: []
-#   - myRegistryKeySecretName
 
+# resources -- A resources block for the rbac-manager pods
 resources:
   requests:
     cpu: 100m
@@ -13,19 +17,29 @@ resources:
     cpu: 100m
     memory: 128Mi
 
+# priorityClassName -- The name of a priorityClass to use
 priorityClassName: ""
 
+# nodeSelector -- Deployment nodeSelector
 nodeSelector: {}
 
+# tolerations -- Deployment tolerations
 tolerations: []
 
+# affinity -- Deployment affinity
 affinity: {}
 
+# podAnnotations -- Annotations to apply to the pods
 podAnnotations: {}
+# podLabels -- Labels to apply to the pod
 podLabels: {}
 
 serviceMonitor:
+  # serviceMonitor.enabled -- If true, a ServiceMonitor will be created for Prometheus
   enabled: false
+  # serviceMonitor.annotations -- Annotations to apply to the serviceMonitor and headless service
   annotations: {}
+  # serviceMonitor.namespace -- The namespace to deploy the serviceMonitor into
   namespace: ""
+  # serviceMonitor.interval -- How often to scrape the metrics endpoint
   interval: 60s


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_
rbac-manager chart now uses helm-docs for auto-generation of the values in the README.md


**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.