### PR TITLE
[Insights Agent] Add ability to grant OPA additional access

### DIFF
--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 1.0.0
+version: 1.1.0
 appVersion: 2.0.0
 maintainers:
   - name: rbren

--- a/stable/insights-agent/README.md
+++ b/stable/insights-agent/README.md
@@ -71,6 +71,7 @@ Parameter | Description | Default
 `trivy.maxScansPerRun` | Maximum number of images to scan on a single run | 20
 `trivy.namespaceBlacklist` | Specifies which namespaces to not scan, takes an array of namespaces for example: `--set trivy.namespaceBlacklist="{kube-system,default}"` | nil
 `opa.role` | Specifies which ClusterRole to grant the OPA agent access to | view
+`opa.additionalAccess` | Specifies additional access to grant the OPA agent. This should contain an array of objects with each having an array of apiGroups, an array of resources, and an array of verbs. Just like a RoleBinding. | null
 `goldilocks.controller.flags.exclude-namespaces` | Namespaces to exclude from the goldilocks report | `kube-system`
 `goldilocks.installVPA` | Install the Vertical Pod Autoscaler as part of the Goldilocks installation | true
 `goldilocks.controller.flags.on-by-default` | Goldilocks will by default monitor all namespaces that aren't excluded | true

--- a/stable/insights-agent/templates/opa/rbac.yaml
+++ b/stable/insights-agent/templates/opa/rbac.yaml
@@ -23,6 +23,32 @@ rules:
   - 'get'
   - 'list'
 ---
+{{- with .Values.opa.additionalAccess }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: {{ include "insights-agent.fullname" $ }}-opa-additional
+  labels:
+    app: insights-agent
+rules:
+{{ . | toYaml }}
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "insights-agent.fullname" . }}-opa-additional
+  labels:
+    app: insights-agent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "insights-agent.fullname" $ }}-opa-additional
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "insights-agent.fullname" . }}-opa
+    namespace: {{ .Release.Namespace }}
+---
+{{- end }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:

--- a/stable/insights-agent/templates/opa/rbac.yaml
+++ b/stable/insights-agent/templates/opa/rbac.yaml
@@ -31,7 +31,7 @@ metadata:
   labels:
     app: insights-agent
 rules:
-{{ . | toYaml }}
+{{ toYaml . }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding

--- a/stable/insights-agent/templates/opa/rbac.yaml
+++ b/stable/insights-agent/templates/opa/rbac.yaml
@@ -36,7 +36,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "insights-agent.fullname" . }}-opa-additional
+  name: {{ include "insights-agent.fullname" $ }}-opa-additional
   labels:
     app: insights-agent
 roleRef:
@@ -45,8 +45,8 @@ roleRef:
   name: {{ include "insights-agent.fullname" $ }}-opa-additional
 subjects:
   - kind: ServiceAccount
-    name: {{ include "insights-agent.fullname" . }}-opa
-    namespace: {{ .Release.Namespace }}
+    name: {{ include "insights-agent.fullname" $ }}-opa
+    namespace: {{ $.Release.Namespace }}
 ---
 {{- end }}
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -121,6 +121,7 @@ opa:
   image:
     repository: quay.io/fairwinds/fw-opa
     tag: "0.2"
+  additionalAccess:
   resources:
     limits:
       cpu: 100m


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Adds additional values to let OPA have access to additional objects (like secrets)

Fixes #

**Changes**
Changes proposed in this pull request:

* Adds a new additionalAccess property to OPA.
*

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
