### PR TITLE
[gke-node-termination-handler] add .Values.extraArgs

### DIFF
--- a/stable/gke-node-termination-handler/Chart.yaml
+++ b/stable/gke-node-termination-handler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: This helm chart provides an adapter for translating GCE node termination events to graceful pod terminations in Kubernetes.
 name: gke-node-termination-handler
-version: 1.0.3
+version: 1.1.0
 maintainers:
   - name: bbensky
   - name: hopson

--- a/stable/gke-node-termination-handler/Chart.yaml
+++ b/stable/gke-node-termination-handler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: This helm chart provides an adapter for translating GCE node termination events to graceful pod terminations in Kubernetes.
 name: gke-node-termination-handler
-version: 1.0.2
+version: 1.0.3
 maintainers:
   - name: bbensky
   - name: hopson

--- a/stable/gke-node-termination-handler/README.md
+++ b/stable/gke-node-termination-handler/README.md
@@ -17,3 +17,4 @@ We recommend installing gke-node-termination-handler in its own namespace.
 | fullnameOverride | string | `""` | A template override for fullname |
 | daemonset.updateStrategy.type | string | `"RollingUpdate"` | The daemonset update strategy |
 | resources | object | `{"limits":{"cpu":"150m","memory":"30Mi"},"requests":{"cpu":"150m","memory":"30Mi"}}` | A resource limit and requess block for the daemonset |
+| systemPodGracePeriod | string | `"0s"` | A period to wait for regular pods to terminate. Recommended values: 0s-14s for preemptible VMs, 0s-(regular-vm-timeout/2) for regular VMs. |

--- a/stable/gke-node-termination-handler/README.md
+++ b/stable/gke-node-termination-handler/README.md
@@ -17,4 +17,5 @@ We recommend installing gke-node-termination-handler in its own namespace.
 | fullnameOverride | string | `""` | A template override for fullname |
 | daemonset.updateStrategy.type | string | `"RollingUpdate"` | The daemonset update strategy |
 | resources | object | `{"limits":{"cpu":"150m","memory":"30Mi"},"requests":{"cpu":"150m","memory":"30Mi"}}` | A resource limit and requess block for the daemonset |
-| systemPodGracePeriod | string | `"0s"` | A period to wait for regular pods to terminate. Recommended values: 0s-14s for preemptible VMs, 0s-(regular-vm-timeout/2) for regular VMs. |
+| args | list | `["-v=10","--logtostderr","--exclude-pods=$(POD_NAME):$(POD_NAMESPACE)","--taint=cloud.google.com/impending-node-termination::NoSchedule"]` | Command arguments. Usually you don't need to override them. |
+| extraArgs | list | `[]` | Extra arguments for command. For example, "--system-pod-grace-period=14s" to wait for 14s for regular pods to terminate. |

--- a/stable/gke-node-termination-handler/templates/daemonset.yaml
+++ b/stable/gke-node-termination-handler/templates/daemonset.yaml
@@ -35,7 +35,12 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         name: {{ .Chart.Name }}
         command: ["./node-termination-handler"]
-        args: ["--logtostderr", "--exclude-pods=$(POD_NAME):$(POD_NAMESPACE)", "-v=10", "--taint=cloud.google.com/impending-node-termination::NoSchedule"]
+        args:
+          - "-v=10"
+          - "--logtostderr"
+          - "--exclude-pods=$(POD_NAME):$(POD_NAMESPACE)"
+          - "--taint=cloud.google.com/impending-node-termination::NoSchedule"
+          - "--system-pod-grace-period={{ .Values.systemPodGracePeriod }}"
         securityContext:
           capabilities:
             # Necessary to reboot node

--- a/stable/gke-node-termination-handler/templates/daemonset.yaml
+++ b/stable/gke-node-termination-handler/templates/daemonset.yaml
@@ -36,11 +36,7 @@ spec:
         name: {{ .Chart.Name }}
         command: ["./node-termination-handler"]
         args:
-          - "-v=10"
-          - "--logtostderr"
-          - "--exclude-pods=$(POD_NAME):$(POD_NAMESPACE)"
-          - "--taint=cloud.google.com/impending-node-termination::NoSchedule"
-          - "--system-pod-grace-period={{ .Values.systemPodGracePeriod }}"
+          {{- concat .Values.args .Values.extraArgs | toYaml | nindent 12 }}
         securityContext:
           capabilities:
             # Necessary to reboot node

--- a/stable/gke-node-termination-handler/values.yaml
+++ b/stable/gke-node-termination-handler/values.yaml
@@ -24,3 +24,6 @@ resources:
   requests:
     cpu: 150m
     memory: 30Mi
+
+# systemPodGracePeriod -- A period to wait for regular pods to terminate. Recommended values: 0s-14s for preemptible VMs, 0s-(regular-vm-timeout/2) for regular VMs.
+systemPodGracePeriod: 0s

--- a/stable/gke-node-termination-handler/values.yaml
+++ b/stable/gke-node-termination-handler/values.yaml
@@ -25,5 +25,12 @@ resources:
     cpu: 150m
     memory: 30Mi
 
-# systemPodGracePeriod -- A period to wait for regular pods to terminate. Recommended values: 0s-14s for preemptible VMs, 0s-(regular-vm-timeout/2) for regular VMs.
-systemPodGracePeriod: 0s
+# args -- Command arguments. Usually you don't need to override them.
+args:
+  - "-v=10"
+  - "--logtostderr"
+  - "--exclude-pods=$(POD_NAME):$(POD_NAMESPACE)"
+  - "--taint=cloud.google.com/impending-node-termination::NoSchedule"
+
+# extraArgs -- Extra arguments for command. For example, "--system-pod-grace-period=14s" to wait for 14s for regular pods to terminate.
+extraArgs: []


### PR DESCRIPTION
**Why This PR?**
_It should be possible to configure grace period for regular pods, as documented [here](https://github.com/GoogleCloudPlatform/k8s-node-termination-handler#graceful-terminations-for-regular-pods-non-system-pods)_

**Changes**
Changes proposed in this pull request:

* Adds `systemPodGracePeriod` option to chart values.

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
