### PR TITLE
[stable/vpa] Add probes and metrics ports

### DIFF
--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 0.1.8
+version: 0.2.0
 appVersion: 0.8.0
 maintainers:
   - name: sudermanjr

--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 0.1.7
+version: 0.1.8
 appVersion: 0.8.0
 maintainers:
   - name: sudermanjr

--- a/stable/vpa/templates/admission-controller-deployment.yaml
+++ b/stable/vpa/templates/admission-controller-deployment.yaml
@@ -42,9 +42,30 @@ spec:
             - name: tls-certs
               mountPath: "/etc/tls-certs"
               readOnly: true
+          livenessProbe:
+            failureThreshold: 6
+            httpGet:
+              path: /health-check
+              port: metrics
+              scheme: HTTP
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 3
+          readinessProbe:
+            failureThreshold: 120
+            httpGet:
+              path: /health-check
+              port: metrics
+              scheme: HTTP
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 3
           ports:
             - name: http
               containerPort: 8000
+              protocol: TCP
+            - name: metrics
+              containerPort: 8944
               protocol: TCP
           env:
             - name: NAMESPACE

--- a/stable/vpa/templates/recommender-deployment.yaml
+++ b/stable/vpa/templates/recommender-deployment.yaml
@@ -44,9 +44,27 @@ spec:
             - --{{ $key }}={{ $value }}
           {{- end }}
           {{- end }}
+          livenessProbe:
+            failureThreshold: 6
+            httpGet:
+              path: /health-check
+              port: metrics
+              scheme: HTTP
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 3
+          readinessProbe:
+            failureThreshold: 120
+            httpGet:
+              path: /health-check
+              port: metrics
+              scheme: HTTP
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 3
           ports:
-            - name: http
-              containerPort: 8080
+            - name: metrics
+              containerPort: 8942
               protocol: TCP
           resources:
             {{- toYaml .Values.recommender.resources | nindent 12 }}

--- a/stable/vpa/templates/updater-deployment.yaml
+++ b/stable/vpa/templates/updater-deployment.yaml
@@ -44,9 +44,27 @@ spec:
             - --{{ $key }}={{ $value }}
           {{- end }}
           {{- end }}
+          livenessProbe:
+            failureThreshold: 6
+            httpGet:
+              path: /health-check
+              port: metrics
+              scheme: HTTP
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 3
+          readinessProbe:
+            failureThreshold: 120
+            httpGet:
+              path: /health-check
+              port: metrics
+              scheme: HTTP
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 3
           ports:
-            - name: http
-              containerPort: 8080
+            - name: metrics
+              containerPort: 8943
               protocol: TCP
           resources:
             {{- toYaml .Values.updater.resources | nindent 12 }}


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

This PR describes how to configure probes for the vpa chart as finding the correct port and paths needs users of the chart to dig into the vertical pod autoscaler pod

Fixes #

**Changes**
Changes proposed in this pull request:

* This PR adds probes to vpa components as well as describe the metrics port to allow scraping of the vpa component metrics

**Checklist:**

* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
