### PR TITLE
[Insights Agent] Add blocklist/allowlist to CRD

### DIFF
--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 1.1.0
+version: 1.2.0
 appVersion: 2.0.0
 maintainers:
   - name: rbren

--- a/stable/insights-agent/templates/opa/instance.yaml
+++ b/stable/insights-agent/templates/opa/instance.yaml
@@ -22,6 +22,14 @@ properties:
               type: array
               items: 
                 type: string
+      namespaceBlocklist:
+        type: array
+        item:
+          type: string
+      namespaceAllowlist:
+        type: array
+        item:
+          type: string
       parameters:
         type: object
         x-kubernetes-preserve-unknown-fields: true


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Adds a couple fields to the OPA CRDs to have an allowlist and blocklist for Namespaces. After it's in the CRD then we can start moving up the stack to add it into the Agent, Insights, CI/CD, admission controller, and the CLI.
Fixes #

**Changes**
Changes proposed in this pull request:

* Adding two new fields to the Intance CRD. `namespaceAllowlist` and `namespaceBlocklist` I'm open to suggestionss on naming.
*

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
