### PR TITLE
updating rbac-manager to v0.10.0

### DIFF
--- a/stable/rbac-manager/Chart.yaml
+++ b/stable/rbac-manager/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: rbac-manager
-version: 1.6.3
-appVersion: 0.9.4
+version: 1.7.0
+appVersion: 0.10.0
 description: A Kubernetes operator that simplifies the management of Role Bindings and Service Accounts.
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/rbac-manager/icon.png
 keywords:

--- a/stable/rbac-manager/README.md
+++ b/stable/rbac-manager/README.md
@@ -53,7 +53,7 @@ In the above workflow, an RBAC Definition installed between revision 1 and 2 sho
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | image.repository | string | `"quay.io/reactiveops/rbac-manager"` | The image to run for rbac manager |
-| image.tag | string | `"v0.9.4"` | The tag of the image to run |
+| image.tag | string | `"v0.10.0"` | The tag of the image to run |
 | image.pullPolicy | string | `"Always"` | The image pullPolicy. Recommend not changing this |
 | image.imagePullSecrets | list | `[]` |  |
 | resources | object | `{"limits":{"cpu":"100m","memory":"128Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | A resources block for the rbac-manager pods |

--- a/stable/rbac-manager/templates/deployment.yaml
+++ b/stable/rbac-manager/templates/deployment.yaml
@@ -44,7 +44,7 @@ spec:
           httpGet:
             scheme: HTTP
             path: /metrics
-            port: 8080
+            port: 8042
           initialDelaySeconds: 5
           timeoutSeconds: 3
           periodSeconds: 3
@@ -53,7 +53,7 @@ spec:
           httpGet:
             scheme: HTTP
             path: /metrics
-            port: 8080
+            port: 8042
         securityContext:
           allowPrivilegeEscalation: false
           privileged: false
@@ -65,7 +65,7 @@ spec:
         ports:
           # metrics port
           - name: http-metrics
-            containerPort: 8080
+            containerPort: 8042
             protocol: TCP
         resources:
 {{ toYaml .Values.resources | indent 10 }}

--- a/stable/rbac-manager/templates/headless-service.yaml
+++ b/stable/rbac-manager/templates/headless-service.yaml
@@ -20,7 +20,7 @@ spec:
   type: ClusterIP
   ports:
   - name: metrics
-    port: 8080
+    port: 8042
     protocol: TCP
-    targetPort: 8080
+    targetPort: 8042
 {{- end }}

--- a/stable/rbac-manager/values.yaml
+++ b/stable/rbac-manager/values.yaml
@@ -2,7 +2,7 @@ image:
   # image.repository -- The image to run for rbac manager
   repository: quay.io/reactiveops/rbac-manager
   # image.tag -- The tag of the image to run
-  tag: v0.9.4
+  tag: v0.10.0
   # image.pullPolicy -- The image pullPolicy. Recommend not changing this
   pullPolicy: Always
   # imagePullSecrets -- A list of imagePullSecrets to reference for pulling the image


### PR DESCRIPTION
**Why This PR?**
Lots of changes in rbac-manager to release

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.