### PR TITLE
[Insights Agent] Disable Service Mesh

### DIFF
--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 1.1.0
-appVersion: 2.0.0
+version: 1.2.0
+appVersion: 2.2.0
 maintainers:
   - name: rbren
   - name: makoscafee

--- a/stable/insights-agent/README.md
+++ b/stable/insights-agent/README.md
@@ -41,6 +41,7 @@ See below for configuration details.
 ## Configuration
 Parameter | Description | Default
 --------- | ----------- | -------
+`disableServiceMesh` | Adds annotations to all CronJobs to not inject Linkerd or Istio | true
 `insights.organization` | The name of the organization to upload data to | ""
 `insights.cluster` | The name of the cluster the data is coming from | ""
 `insights.base64token` | Your cluster's base64-encoded auth token provided by Insights | ""

--- a/stable/insights-agent/README.md
+++ b/stable/insights-agent/README.md
@@ -41,7 +41,6 @@ See below for configuration details.
 ## Configuration
 Parameter | Description | Default
 --------- | ----------- | -------
-`disableServiceMesh` | Adds annotations to all CronJobs to not inject Linkerd or Istio | true
 `insights.organization` | The name of the organization to upload data to | ""
 `insights.cluster` | The name of the cluster the data is coming from | ""
 `insights.base64token` | Your cluster's base64-encoded auth token provided by Insights | ""
@@ -51,6 +50,7 @@ Parameter | Description | Default
 `uploader.image.tag` | The tag to use for the uploader script | 0.2
 `uploader.resources` | CPU/memory requests and limits for the uploader script |
 `uploader.sendFailures` | Send logs of failure to Insights when a job fails. | true
+`cronjobs.disableServiceMesh` | Adds annotations to all CronJobs to not inject Linkerd or Istio | true
 `cronjobs.backoffLimit` | Backoff limit to use for each report CronJob | 1
 `cronjobs.failedJobsHistoryLimit` | Number of failed jobs to keep in history for each report | 2
 `cronjobs.successfulJobsHistoryLimit` | Number of successful jobs to keep in history for each report | 2

--- a/stable/insights-agent/templates/_helpers.tpl
+++ b/stable/insights-agent/templates/_helpers.tpl
@@ -35,7 +35,7 @@ Create chart name and version as used by the chart label.
   name: {{ .Label }}
   labels:
     app: insights-agent
-  {{- if .Values.disableServiceMesh }}
+  {{- if .Values.cronjobs.disableServiceMesh }}
   annotations:
     linkerd.io/inject: disabled
     sidecar.istio.io/inject: "false"

--- a/stable/insights-agent/templates/_helpers.tpl
+++ b/stable/insights-agent/templates/_helpers.tpl
@@ -32,7 +32,12 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{- define "metadata" }}
-  name: {{ . }}
+  name: {{ .Label }}
   labels:
     app: insights-agent
+  {{- if .Values.disableServiceMesh }}
+  annotations:
+    linkerd.io/inject: disabled
+    sidecar.istio.io/inject: "false"
+  {{- end }}
 {{- end }}

--- a/stable/insights-agent/templates/cronjob-executor/job.yaml
+++ b/stable/insights-agent/templates/cronjob-executor/job.yaml
@@ -5,7 +5,6 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   {{- include "metadata" . }}
-  annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
 spec:

--- a/stable/insights-agent/templates/cronjob-executor/job.yaml
+++ b/stable/insights-agent/templates/cronjob-executor/job.yaml
@@ -1,8 +1,10 @@
 {{- if .Values.cronjobs.runJobsImmediately -}}
+{{- $_ := set . "Label" "cronjob-executor" }}
+{{- $_ := set . "Config" .Values.cronjobs }}
 apiVersion: batch/v1
 kind: Job
 metadata:
-  {{- include "metadata" "cronjob-executor" }}
+  {{- include "metadata" . }}
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation

--- a/stable/insights-agent/templates/cronjob-executor/rbac.yaml
+++ b/stable/insights-agent/templates/cronjob-executor/rbac.yaml
@@ -24,7 +24,7 @@ rules:
   verbs: ["create", "delete"]
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "insights-agent.fullname" . }}-cronjob-executor

--- a/stable/insights-agent/templates/goldilocks/cronjob.yaml
+++ b/stable/insights-agent/templates/goldilocks/cronjob.yaml
@@ -4,7 +4,7 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  {{- include "metadata" .Label }}
+  {{- include "metadata" . }}
 spec:
   {{ include "cronjob-spec" . | nindent 2 | trim }}
   jobTemplate:

--- a/stable/insights-agent/templates/goldilocks/rbac.yaml
+++ b/stable/insights-agent/templates/goldilocks/rbac.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: insights-agent
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "insights-agent.fullname" . }}-goldilocks
@@ -40,7 +40,7 @@ rules:
       - 'create'
       - 'delete'
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "insights-agent.fullname" . }}-goldilocks

--- a/stable/insights-agent/templates/kube-bench/cronjob.yaml
+++ b/stable/insights-agent/templates/kube-bench/cronjob.yaml
@@ -5,7 +5,7 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  {{- include "metadata" .Label }}
+  {{- include "metadata" . }}
 spec:
   {{ include "cronjob-spec" . | nindent 2 | trim }}
   jobTemplate:

--- a/stable/insights-agent/templates/kube-hunter/cronjob.yaml
+++ b/stable/insights-agent/templates/kube-hunter/cronjob.yaml
@@ -4,7 +4,7 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  {{- include "metadata" .Label }}
+  {{- include "metadata" . }}
 spec:
   {{ include "cronjob-spec" . | nindent 2 | trim }}
   jobTemplate:

--- a/stable/insights-agent/templates/kubesec/cronjob.yaml
+++ b/stable/insights-agent/templates/kubesec/cronjob.yaml
@@ -4,7 +4,7 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  {{- include "metadata" .Label }}
+  {{- include "metadata" . }}
 spec:
   {{ include "cronjob-spec" . | nindent 2 | trim }}
   jobTemplate:

--- a/stable/insights-agent/templates/kubesec/rbac.yaml
+++ b/stable/insights-agent/templates/kubesec/rbac.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: insights-agent
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "insights-agent.fullname" . }}-kubesec
@@ -31,7 +31,7 @@ rules:
       - 'get'
       - 'list'
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "insights-agent.fullname" . }}-kubesec

--- a/stable/insights-agent/templates/nova/cronjob.yaml
+++ b/stable/insights-agent/templates/nova/cronjob.yaml
@@ -4,7 +4,7 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  {{- include "metadata" .Label }}
+  {{- include "metadata" . }}
 spec:
   {{ include "cronjob-spec" . | nindent 2 | trim }}
   jobTemplate:

--- a/stable/insights-agent/templates/opa/cronjob.yaml
+++ b/stable/insights-agent/templates/opa/cronjob.yaml
@@ -4,7 +4,7 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  {{- include "metadata" .Label }}
+  {{- include "metadata" . }}
 spec:
   {{ include "cronjob-spec" . | nindent 2 | trim }}
   jobTemplate:

--- a/stable/insights-agent/templates/opa/rbac.yaml
+++ b/stable/insights-agent/templates/opa/rbac.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: insights-agent
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "insights-agent.fullname" . }}-checks-view
@@ -24,7 +24,7 @@ rules:
   - 'list'
 ---
 {{- with .Values.opa.additionalAccess }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "insights-agent.fullname" $ }}-opa-additional
@@ -33,7 +33,7 @@ metadata:
 rules:
 {{ toYaml . }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "insights-agent.fullname" $ }}-opa-additional
@@ -49,7 +49,7 @@ subjects:
     namespace: {{ $.Release.Namespace }}
 ---
 {{- end }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "insights-agent.fullname" . }}-checks-edit
@@ -67,7 +67,7 @@ rules:
   - 'patch'
   - 'update'  
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "insights-agent.fullname" . }}-opa-edit
@@ -82,7 +82,7 @@ subjects:
     name: {{ include "insights-agent.fullname" . }}-opa
     namespace: {{ .Release.Namespace }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "insights-agent.fullname" . }}-opa

--- a/stable/insights-agent/templates/pluto/cronjob.yaml
+++ b/stable/insights-agent/templates/pluto/cronjob.yaml
@@ -4,7 +4,7 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  {{- include "metadata" .Label }}
+  {{- include "metadata" . }}
 spec:
   {{ include "cronjob-spec" . | nindent 2 | trim }}
   jobTemplate:

--- a/stable/insights-agent/templates/polaris/cronjob.yaml
+++ b/stable/insights-agent/templates/polaris/cronjob.yaml
@@ -4,7 +4,7 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  {{- include "metadata" .Label }}
+  {{- include "metadata" . }}
 spec:
   {{ include "cronjob-spec" . | nindent 2 | trim }}
   jobTemplate:

--- a/stable/insights-agent/templates/polaris/rbac.yaml
+++ b/stable/insights-agent/templates/polaris/rbac.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: insights-agent
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "insights-agent.fullname" . }}-polaris
@@ -21,7 +21,7 @@ rules:
       - 'get'
       - 'list'
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "insights-agent.fullname" . }}-polaris
@@ -36,7 +36,7 @@ subjects:
     name: {{ include "insights-agent.fullname" . }}-polaris
     namespace: {{ .Release.Namespace }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "insights-agent.fullname" . }}-polaris-view

--- a/stable/insights-agent/templates/rbac-reporter/cronjob.yaml
+++ b/stable/insights-agent/templates/rbac-reporter/cronjob.yaml
@@ -4,7 +4,7 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  {{- include "metadata" .Label }}
+  {{- include "metadata" . }}
 spec:
   {{ include "cronjob-spec" . | nindent 2 | trim }}
   jobTemplate:

--- a/stable/insights-agent/templates/rbac-reporter/rbac.yaml
+++ b/stable/insights-agent/templates/rbac-reporter/rbac.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: insights-agent
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "insights-agent.fullname" . }}-rbac-reporter

--- a/stable/insights-agent/templates/rbac.yaml
+++ b/stable/insights-agent/templates/rbac.yaml
@@ -21,7 +21,7 @@ rules:
 {{- end }}
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "insights-agent.fullname" . }}-get-logs

--- a/stable/insights-agent/templates/trivy/cronjob.yaml
+++ b/stable/insights-agent/templates/trivy/cronjob.yaml
@@ -4,7 +4,7 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  {{- include "metadata" .Label }}
+  {{- include "metadata" . }}
 spec:
   {{ include "cronjob-spec" . | nindent 2 | trim }}
   jobTemplate:

--- a/stable/insights-agent/templates/trivy/rbac.yaml
+++ b/stable/insights-agent/templates/trivy/rbac.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: insights-agent
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "insights-agent.fullname" . }}-trivy

--- a/stable/insights-agent/templates/workloads/cronjob.yaml
+++ b/stable/insights-agent/templates/workloads/cronjob.yaml
@@ -4,7 +4,7 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  {{- include "metadata" .Label }}
+  {{- include "metadata" . }}
 spec:
   {{ include "cronjob-spec" . | nindent 2 | trim }}
   jobTemplate:

--- a/stable/insights-agent/templates/workloads/rbac.yaml
+++ b/stable/insights-agent/templates/workloads/rbac.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: insights-agent
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "insights-agent.fullname" . }}-workloads
@@ -43,7 +43,7 @@ rules:
       - 'get'
       - 'list'
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "insights-agent.fullname" . }}-workloads

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -1,4 +1,3 @@
-disableServiceMesh: true
 
 insights:
   host: https://insights.fairwinds.com
@@ -21,6 +20,7 @@ uploader:
       memory: 64Mi
 
 cronjobs:
+  disableServiceMesh: true
   backoffLimit: 1
   failedJobsHistoryLimit: 2
   successfulJobsHistoryLimit: 2

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -1,4 +1,3 @@
-
 insights:
   host: https://insights.fairwinds.com
   organization: ""

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -1,3 +1,5 @@
+disableServiceMesh: true
+
 insights:
   host: https://insights.fairwinds.com
   organization: ""


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Updates RBAC API versions to be consistent. Adds an option to disable injection of Service Mesh sidecars because those don't work with CronJobs.

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
