### PR TITLE
Add prometheus community to list of chart repos

### DIFF
--- a/scripts/repo-sync-fw.sh
+++ b/scripts/repo-sync-fw.sh
@@ -23,6 +23,7 @@ readonly HELM_TARBALL=helm-v3.2.0-linux-amd64.tar.gz
 readonly STABLE_REPO_URL=https://charts.fairwinds.com/stable/
 readonly INCUBATOR_REPO_URL=https://charts.fairwinds.com/incubator/
 readonly JETSTACK_REPO_URL=https://charts.jetstack.io
+readonly PROMETHEUS_REPO_URL=https://prometheus-community.github.io/helm-charts
 readonly S3_BUCKET_STABLE=s3://charts.fairwinds.com/stable
 readonly S3_BUCKET_INCUBATOR=s3://charts.fairwinds.com/incubator
 
@@ -49,6 +50,7 @@ setup_helm_client() {
     helm repo add fairwinds-stable "$STABLE_REPO_URL"
     helm repo add fairwinds-incubator "$INCUBATOR_REPO_URL"
     helm repo add jetstack "$JETSTACK_REPO_URL"
+    helm repo add prometheus-community "$PROMETHEUS_REPO_URL"
 }
 
 authenticate() {

--- a/scripts/repo-sync.sh
+++ b/scripts/repo-sync.sh
@@ -23,6 +23,7 @@ readonly HELM_TARBALL=helm-v3.2.0-linux-amd64.tar.gz
 readonly STABLE_REPO_URL=https://charts.reactiveops.com/stable/
 readonly INCUBATOR_REPO_URL=https://charts.reactiveops.com/incubator/
 readonly JETSTACK_REPO_URL=https://charts.jetstack.io
+readonly PROMETHEUS_REPO_URL=https://prometheus-community.github.io/helm-charts
 readonly S3_BUCKET_STABLE=s3://charts.reactiveops.com/stable
 readonly S3_BUCKET_INCUBATOR=s3://charts.reactiveops.com/incubator
 
@@ -49,6 +50,7 @@ setup_helm_client() {
     helm repo add reactiveops-stable "$STABLE_REPO_URL"
     helm repo add reactiveops-incubator "$INCUBATOR_REPO_URL"
     helm repo add jetstack "$JETSTACK_REPO_URL"
+    helm repo add prometheus-community "$PROMETHEUS_REPO_URL"
 }
 
 authenticate() {


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Insights-Agent added a dependency on Prometheus and the Prometheus Community repo wasn't in the list of repos so the latest version wasn't able to be deployed.

Fixes #

**Changes**
Changes proposed in this pull request:

* Adds prometheus-community to the sync scripts.
*

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
