### PR TITLE
[Insights Admission Controller] Add configmap/secrets to admission controller

### DIFF
--- a/stable/insights-admission/Chart.yaml
+++ b/stable/insights-admission/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: insights-admission
 description: A Validating Webhook Admission Controller that utilizes Fairwinds Insights.
 type: application
-version: 0.3.0
+version: 0.3.1
 appVersion: "0.1"
 maintainers:
 - name: rbren

--- a/stable/insights-admission/README.md
+++ b/stable/insights-admission/README.md
@@ -41,6 +41,12 @@ rules:
 | insights.cluster | string | `""` | The name of your cluster from Fairwinds Insights |
 | insights.host | string | `"https://insights.fairwinds.com"` | Override the hostname for Fairwinds Insights |
 | insights.base64token | string | `""` | The token for your cluster from the Cluster Settings page in Fairwinds Insights. This should already be base64 encoded. |
+| insights.secret.create | bool | `true` | Create a secret containing the base64 encoded token. |
+| insights.secret.name | string | `nil` | The name of the secret to use. |
+| insights.secret.suffix | string | `"-token"` | The suffix to add onto the relase name to get the secret that contains the base64 token |
+| insights.configmap.create | bool | `true` | Create a config map with Insights configuration |
+| insights.configmap.suffix | string | `nil` | The suffix to add onto the release name to get the configmap that contains the host/organization/cluster |
+| insights.configmap.name | string | `"-configmap"` | The name of the configmap to use. |
 | webhookConfig.failurePolicy | string | `"Fail"` | failurePolicy for the ValidatingWebhookConfiguration |
 | webhookConfig.matchPolicy | string | `"Exact"` | matchPolicy for the ValidatingWebhookConfiguration |
 | webhookConfig.namespaceSelector | object | `{"matchExpressions":[{"key":"control-plane","operator":"DoesNotExist"}]}` | namespaceSelector for the ValidatingWebhookConfiguration |

--- a/stable/insights-admission/README.md
+++ b/stable/insights-admission/README.md
@@ -42,11 +42,11 @@ rules:
 | insights.host | string | `"https://insights.fairwinds.com"` | Override the hostname for Fairwinds Insights |
 | insights.base64token | string | `""` | The token for your cluster from the Cluster Settings page in Fairwinds Insights. This should already be base64 encoded. |
 | insights.secret.create | bool | `true` | Create a secret containing the base64 encoded token. |
-| insights.secret.name | string | `nil` | The name of the secret to use. |
+| insights.secret.nameOverride | string | `nil` | The name of the secret to use. |
 | insights.secret.suffix | string | `"-token"` | The suffix to add onto the relase name to get the secret that contains the base64 token |
 | insights.configmap.create | bool | `true` | Create a config map with Insights configuration |
+| insights.configmap.nameOverride | string | `"-configmap"` | The name of the configmap to use. |
 | insights.configmap.suffix | string | `nil` | The suffix to add onto the release name to get the configmap that contains the host/organization/cluster |
-| insights.configmap.name | string | `"-configmap"` | The name of the configmap to use. |
 | webhookConfig.failurePolicy | string | `"Fail"` | failurePolicy for the ValidatingWebhookConfiguration |
 | webhookConfig.matchPolicy | string | `"Exact"` | matchPolicy for the ValidatingWebhookConfiguration |
 | webhookConfig.namespaceSelector | object | `{"matchExpressions":[{"key":"control-plane","operator":"DoesNotExist"}]}` | namespaceSelector for the ValidatingWebhookConfiguration |

--- a/stable/insights-admission/templates/_helpers.tpl
+++ b/stable/insights-admission/templates/_helpers.tpl
@@ -61,3 +61,25 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Create the name of the Secret to use
+*/}}
+{{- define "insights-admission.secretName" -}}
+{{- if .Values.insights.secret.name }}
+{{- .Values.insights.secret.name }}
+{{- else }}
+{{- printf "%s-%s" (include "insights-admission.fullname" .) (default "-token" .Values.insights.secret.suffix) }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the name of the ConfigMap to use
+*/}}
+{{- define "insights-admission.configmapName" -}}
+{{- if .Values.insights.configmap.name }}
+{{- .Values.insights.configmap.name }}
+{{- else }}
+{{- printf "%s-%s" (include "insights-admission.fullname" .) (default "-configmap" .Values.insights.configmap.suffix) }}
+{{- end }}
+{{- end }}

--- a/stable/insights-admission/templates/configmap.yaml
+++ b/stable/insights-admission/templates/configmap.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.insights.configmap.create -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "insights-admission.configmapName" . }}
+data:
+  host: {{ required "You must set insights.host" .Values.insights.host | quote }}
+  cluster: {{ required "You must set insights.cluster" .Values.insights.cluster  | quote }}
+  organization: {{ required "You must set insights.organization" .Values.insights.organization | quote }}
+{{- end }}

--- a/stable/insights-admission/templates/deployment.yaml
+++ b/stable/insights-admission/templates/deployment.yaml
@@ -58,14 +58,23 @@ spec:
           - name: FAIRWINDS_TOKEN
             valueFrom:
               secretKeyRef:
-                name: {{ include "insights-admission.fullname" . }}-token
+                name: {{ include "insights-admission.secretName" . }}
                 key: token
           - name: FAIRWINDS_ORGANIZATION
-            value: {{ .Values.insights.organization | quote }}
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "insights-admission.configmapName" . }}
+                key: organization
           - name: FAIRWINDS_CLUSTER
-            value: {{ .Values.insights.cluster | quote }}
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "insights-admission.configmapName" . }}
+                key: cluster
           - name: FAIRWINDS_HOSTNAME
-            value: {{ .Values.insights.host }}
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "insights-admission.configmapName" . }}
+                key: host
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/stable/insights-admission/templates/token.yaml
+++ b/stable/insights-admission/templates/token.yaml
@@ -1,7 +1,8 @@
+{{- if .Values.insights.secret.create -}}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "insights-admission.fullname" . }}-token
+  name: {{ include "insights-admission.secretName" . }}
 data:
   token: {{ required "You must set base64token" .Values.insights.base64token | quote }}
-
+{{- end }}

--- a/stable/insights-admission/values.yaml
+++ b/stable/insights-admission/values.yaml
@@ -11,16 +11,16 @@ insights:
     # -- Create a secret containing the base64 encoded token.
     create: true
     # -- The name of the secret to use.
-    name:
+    nameOverride:
     # -- The suffix to add onto the relase name to get the secret that contains the base64 token
     suffix: "-token"
   configmap:
     # -- Create a config map with Insights configuration
     create: true
+    # -- The name of the configmap to use.
+    nameOverride: "-configmap"
     # -- The suffix to add onto the release name to get the configmap that contains the host/organization/cluster
     suffix:
-    # -- The name of the configmap to use.
-    name: "-configmap"
 
 webhookConfig:
   # webhookConfig.failurePolicy -- failurePolicy for the ValidatingWebhookConfiguration

--- a/stable/insights-admission/values.yaml
+++ b/stable/insights-admission/values.yaml
@@ -7,6 +7,20 @@ insights:
   host: https://insights.fairwinds.com
   # insights.base64token -- The token for your cluster from the Cluster Settings page in Fairwinds Insights. This should already be base64 encoded.
   base64token: ""
+  secret:
+    # -- Create a secret containing the base64 encoded token.
+    create: true
+    # -- The name of the secret to use.
+    name:
+    # -- The suffix to add onto the relase name to get the secret that contains the base64 token
+    suffix: "-token"
+  configmap:
+    # -- Create a config map with Insights configuration
+    create: true
+    # -- The suffix to add onto the release name to get the configmap that contains the host/organization/cluster
+    suffix:
+    # -- The name of the configmap to use.
+    name: "-configmap"
 
 webhookConfig:
   # webhookConfig.failurePolicy -- failurePolicy for the ValidatingWebhookConfiguration


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Adds configmap to make it easier to pass settings between Insights Agent and Admission Controller.

Fixes #

**Changes**
Changes proposed in this pull request:

* Moves config into a configmap. Provides settings to override secret name and not create secret.
*

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
