### PR TITLE
[insights-agent] fix polaris when no config is specified

### DIFF
--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 1.5.4
+version: 1.5.5
 appVersion: 2.3.0
 maintainers:
   - name: rbren

--- a/stable/insights-agent/templates/polaris/cronjob.yaml
+++ b/stable/insights-agent/templates/polaris/cronjob.yaml
@@ -13,14 +13,14 @@ spec:
       template:
         spec:
           {{ include "job-template-spec" . | indent 10 | trim }}
-          {{ if or .Values.polaris.config .Values.polaris.existingConfigmap }}
+          {{ if .Values.polaris.config }}
           - name: config
             configMap:
               name: {{ .Values.polaris.existingConfigmap | default "polaris" }}
           {{ end }}
           containers:
           - {{ include "container-spec" . | indent 12 | trim }}
-            {{ if or .Values.polaris.config .Values.polaris.existingConfigmap }}
+            {{ if .Values.polaris.config }}
             - name: config
               mountPath: /opt/app/config.yaml
               subPath: config.yaml
@@ -28,7 +28,7 @@ spec:
             {{ end }}
             command: [
               "polaris", "audit",
-              {{ if or .Values.polaris.config .Values.polaris.existingConfigmap }}
+              {{ if .Values.polaris.config }}
               "--config", "/opt/app/config.yaml",
               {{ end }}
               "--output-file", "/output/polaris.json",

--- a/stable/insights-agent/templates/polaris/cronjob.yaml
+++ b/stable/insights-agent/templates/polaris/cronjob.yaml
@@ -16,7 +16,7 @@ spec:
           {{ if .Values.polaris.config }}
           - name: config
             configMap:
-              name: {{ .Values.polaris.existingConfigmap | default "polaris" }}
+              name: polaris
           {{ end }}
           containers:
           - {{ include "container-spec" . | indent 12 | trim }}

--- a/stable/insights-agent/templates/polaris/cronjob.yaml
+++ b/stable/insights-agent/templates/polaris/cronjob.yaml
@@ -13,18 +13,24 @@ spec:
       template:
         spec:
           {{ include "job-template-spec" . | indent 10 | trim }}
+          {{ if or .Values.polaris.config .Values.polaris.existingConfigmap }}
           - name: config
             configMap:
-              name: polaris
+              name: {{ .Values.polaris.existingConfigmap | default "polaris" }}
+          {{ end }}
           containers:
           - {{ include "container-spec" . | indent 12 | trim }}
+            {{ if or .Values.polaris.config .Values.polaris.existingConfigmap }}
             - name: config
               mountPath: /opt/app/config.yaml
               subPath: config.yaml
               readOnly: true
+            {{ end }}
             command: [
               "polaris", "audit",
+              {{ if or .Values.polaris.config .Values.polaris.existingConfigmap }}
               "--config", "/opt/app/config.yaml",
+              {{ end }}
               "--output-file", "/output/polaris.json",
               "--format", "json",
               "--display-name", "{{ .Values.insights.cluster }}",


### PR DESCRIPTION
**Why This PR?**
🤦 

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
