### PR TITLE
[Insights Agent] add annotations to exempt Kube-bench permissions from Polaris.

### DIFF
--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 1.5.5
+version: 1.5.6
 appVersion: 2.3.0
 maintainers:
   - name: rbren

--- a/stable/insights-agent/ci/test-values.yaml
+++ b/stable/insights-agent/ci/test-values.yaml
@@ -13,6 +13,9 @@ opa:
 test:
   enabled: true
 
+kubebench:
+  enabled: true
+
 kubesec:
   enabled: true
 

--- a/stable/insights-agent/templates/_helpers.tpl
+++ b/stable/insights-agent/templates/_helpers.tpl
@@ -41,3 +41,16 @@ Create chart name and version as used by the chart label.
     sidecar.istio.io/inject: "false"
   {{- end }}
 {{- end }}
+{{/*
+Metadata for the cronjobs but always show annotations
+*/}}
+{{- define "annotation-metadata" }}
+  name: {{ .Label }}
+  labels:
+    app: insights-agent
+  annotations:
+  {{- if .Values.cronjobs.disableServiceMesh }}
+    linkerd.io/inject: disabled
+    sidecar.istio.io/inject: "false"
+  {{- end }}
+{{- end }}

--- a/stable/insights-agent/templates/kube-bench/cronjob.yaml
+++ b/stable/insights-agent/templates/kube-bench/cronjob.yaml
@@ -5,7 +5,9 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  {{- include "metadata" . }}
+  {{- include "annotation-metadata" . }}
+    polaris.fairwinds.com/hostPIDSet-exempt: true
+    polaris.fairwinds.com/runAsRootAllowed-exempt: true
 spec:
   {{ include "cronjob-spec" . | nindent 2 | trim }}
   jobTemplate:

--- a/stable/insights-agent/templates/kube-bench/cronjob.yaml
+++ b/stable/insights-agent/templates/kube-bench/cronjob.yaml
@@ -6,8 +6,8 @@ apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   {{- include "annotation-metadata" . }}
-    polaris.fairwinds.com/hostPIDSet-exempt: true
-    polaris.fairwinds.com/runAsRootAllowed-exempt: true
+    polaris.fairwinds.com/hostPIDSet-exempt: "true"
+    polaris.fairwinds.com/runAsRootAllowed-exempt: "true"
 spec:
   {{ include "cronjob-spec" . | nindent 2 | trim }}
   jobTemplate:


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_
Adds exemptions to Polaris so that it won't flag kube-bench.

Fixes #

**Changes**
Changes proposed in this pull request:

* Adds annotations to kube-bench for polaris exemptions
* Adds a new helper to ensure that Annotations is always the last chunk of metadata

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
