### PR TITLE
[Polaris] update crb apiVersion

### DIFF
--- a/stable/polaris/Chart.yaml
+++ b/stable/polaris/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Validation of best practices in your Kubernetes clusters
 name: polaris
-version: 3.0.0
+version: 3.0.1
 appVersion: "3.0"
 icon: https://raw.githubusercontent.com/FairwindsOps/polaris/master/pkg/dashboard/assets/favicon-32x32.png
 maintainers:

--- a/stable/polaris/templates/rbac.yaml
+++ b/stable/polaris/templates/rbac.yaml
@@ -31,7 +31,7 @@ rules:
       - 'get'
       - 'list'
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "polaris.fullname" . }}


### PR DESCRIPTION
**Why This PR?**
Looks like, a ClusterRoleBinding was missed and still on the deprecated `v1beta1` apiVersion. This was causing issues when running a lint task on the chart.

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
