### PR TITLE
[VPA] Add environment variable values to certGen container

### DIFF
--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 0.2.1
+version: 0.2.2
 appVersion: 0.8.0
 maintainers:
   - name: sudermanjr

--- a/stable/vpa/README.md
+++ b/stable/vpa/README.md
@@ -89,6 +89,7 @@ recommender:
 | admissionController.certGen.image.repository | string | `"quay.io/reactiveops/ci-images"` | An image that contains certgen for creating certificates. Only used if admissionController.generateCertificate is true |
 | admissionController.certGen.image.tag | string | `"v11-alpine"` | An image tag for the admissionController.certGen.image.repository image. Only used if admissionController.generateCertificate is true |
 | admissionController.certGen.image.pullPolicy | string | `"Always"` | The pull policy for the certgen image. Recommend not changing this |
+| admissionController.certGen.env | object | `{}` | Additional environment variables to be added to the certgen container. Format is KEY: Value format |
 | admissionController.cleanupOnDelete | bool | `true` | If true, a post-delete job will remove the mutatingwebhookconfiguration and the tls secret for the admission controller |
 | admissionController.replicaCount | int | `1` |  |
 | admissionController.image.repository | string | `"us.gcr.io/k8s-artifacts-prod/autoscaling/vpa-admission-controller"` | The location of the vpa admission controller image |

--- a/stable/vpa/ci/test-values.yaml
+++ b/stable/vpa/ci/test-values.yaml
@@ -6,3 +6,6 @@ updater:
 admissionController:
   enabled: true
   generateCertificate: true
+  certGen:
+    env:
+      ENVIRONMENTVARIABLE: exists

--- a/stable/vpa/templates/admission-controller-certgen.yaml
+++ b/stable/vpa/templates/admission-controller-certgen.yaml
@@ -117,5 +117,10 @@ spec:
             # Clean up after we're done.
             echo "Deleting ${TMP_DIR}."
             rm -rf ${TMP_DIR}
+        env:
+          {{- range $key, $value := .Values.admissionController.certGen.env }}
+          - name: {{ $key }}
+            value: {{ $value | quote }}
+          {{- end }}
 {{- end }}
 {{- end }}

--- a/stable/vpa/values.yaml
+++ b/stable/vpa/values.yaml
@@ -104,6 +104,8 @@ admissionController:
       tag: v11-alpine
       # admissionController.certGen.image.pullPolicy -- The pull policy for the certgen image. Recommend not changing this
       pullPolicy: Always
+      # admissionController.certGen.env -- Additional environment variables to be added to the certgen container. Format is KEY: Value format
+    env: {}
   # admissionController.cleanupOnDelete -- If true, a post-delete job will remove the mutatingwebhookconfiguration and the tls secret for the admission controller
   cleanupOnDelete: true
   replicaCount: 1


### PR DESCRIPTION
**Why This PR?**

Fixes #425

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.