### PR TITLE
[rbac-manager] Move CRDs to Helm3's standard crds/ folder

### DIFF
--- a/stable/rbac-manager/Chart.yaml
+++ b/stable/rbac-manager/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rbac-manager
-version: 1.7.0
+version: 1.8.0
 appVersion: 0.10.0
 description: A Kubernetes operator that simplifies the management of Role Bindings and Service Accounts.
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/rbac-manager/icon.png

--- a/stable/rbac-manager/crds/customresourcedefinition.yaml
+++ b/stable/rbac-manager/crds/customresourcedefinition.yaml
@@ -2,11 +2,6 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: rbacdefinitions.rbacmanager.reactiveops.io
-  labels:
-    app: {{ template "rbac-manager.name" . }}
-    chart: {{ template "rbac-manager.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
 spec:
   group: rbacmanager.reactiveops.io
   names:


### PR DESCRIPTION
**Why This PR?**
Right now there is no way for a user to manage CRDs outside of this chart.
The recommended Helm3 way using `--skip-crds` does not work, since the CRD are placed in the `templates/` folder.
Fixes #427 

**Changes**
Changes proposed in this pull request:
* Move the CustomResource Definitions to the Helm3 standard folder `crds/`
* Remove labels from the CRD since templating is not allowed/possible

This follows Helm3's recommended way of installing CRDs.
See the official [Helm3 documentation](https://helm.sh/docs/topics/charts/#custom-resource-definitions-crds).

Note though, that these CRDs are never upgraded by Helm3 after the first installation.
To manage CRDs follow the [guidelines in the Helm docs](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/#install-a-crd-declaration-before-using-the-resource).

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
  * [ ] I'm not entirely sure if this counts as a breaking change 
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.

