### PR TITLE
Add the ability to pass config to nova via configmap

### DIFF
--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 1.5.6
+version: 1.6.0
 appVersion: 2.3.0
 maintainers:
   - name: rbren

--- a/stable/insights-agent/ci/test-values.yaml
+++ b/stable/insights-agent/ci/test-values.yaml
@@ -8,36 +8,36 @@ goldilocks:
   enabled: false
 
 opa:
-  enabled: false
+  enabled: true
 
 test:
-  enabled: false
+  enabled: true
 
 kubebench:
-  enabled: false
+  enabled: true
 
 kubesec:
-  enabled: false
+  enabled: true
 
 polaris:
-  enabled: false
+  enabled: true
 
 pluto:
-  enabled: false
+  enabled: true
 
 nova:
   enabled: true
 
 kubehunter:
-  enabled: false
+  enabled: true
 
 trivy:
-  enabled: false
+  enabled: true
   maxScansPerRun: 2
 
 resourcemetrics:
-  enabled: false
-  installPrometheus: false
+  enabled: true
+  installPrometheus: true
 
 admission:
-  enabled: false
+  enabled: true

--- a/stable/insights-agent/ci/test-values.yaml
+++ b/stable/insights-agent/ci/test-values.yaml
@@ -8,36 +8,36 @@ goldilocks:
   enabled: false
 
 opa:
-  enabled: true
+  enabled: false
 
 test:
-  enabled: true
+  enabled: false
 
 kubebench:
-  enabled: true
+  enabled: false
 
 kubesec:
-  enabled: true
+  enabled: false
 
 polaris:
-  enabled: true
+  enabled: false
 
 pluto:
-  enabled: true
+  enabled: false
 
 nova:
   enabled: true
 
 kubehunter:
-  enabled: true
+  enabled: false
 
 trivy:
-  enabled: true
+  enabled: false
   maxScansPerRun: 2
 
 resourcemetrics:
-  enabled: true
-  installPrometheus: true
+  enabled: false
+  installPrometheus: false
 
 admission:
-  enabled: true
+  enabled: false

--- a/stable/insights-agent/templates/nova/configmap.yaml
+++ b/stable/insights-agent/templates/nova/configmap.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.nova.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "insights-agent.fullname" $ }}-nova-config
+data:
+  nova.yaml: |
+{{ .Values.nova.config | toYaml | indent 4 }}
+{{- end }}

--- a/stable/insights-agent/templates/nova/cronjob.yaml
+++ b/stable/insights-agent/templates/nova/cronjob.yaml
@@ -18,18 +18,16 @@ spec:
             command:
               - /nova
               - find
-              - -u
-              - https://charts.fairwinds.com/stable
-              - -u
-              - https://charts.fairwinds.com/incubator
-              - -u
-              - https://kubernetes-charts.storage.googleapis.com
-              - -u
-              - https://kubernetes-charts-incubator.storage.googleapis.com
-              - --output-file
-              - /output/nova.json
-              - --helm-version
-              - auto
+              - --config=/config/nova.yaml
+            volumeMounts:
+              - name: config
+                mountPath: /config
             {{ include "security-context" . | indent 12 | trim }}
           {{ include "uploaderContainer" . | indent 10 | trim }}
+          volumes:
+            - name: output
+              emptyDir: {}
+            - name: config
+              configMap:
+                name: {{ include "insights-agent.fullname" $ }}-nova-config
 {{- end -}}

--- a/stable/insights-agent/templates/nova/cronjob.yaml
+++ b/stable/insights-agent/templates/nova/cronjob.yaml
@@ -14,14 +14,20 @@ spec:
         spec:
           {{ include "job-template-spec" . | indent 10 | trim }}
           containers:
-          - {{ include "container-spec" . | indent 12 | trim }}
+          - name: {{ .Label }}
+            image: "{{ .Config.image.repository }}:{{ .Config.image.tag }}"
+            imagePullPolicy: Always
+            resources:
+              {{- toYaml .Config.resources | nindent 14 }}
+            volumeMounts:
+            - name: output
+              mountPath: /output
+            - name: config
+              mountPath: /config
             command:
               - /nova
               - find
               - --config=/config/nova.yaml
-            volumeMounts:
-              - name: config
-                mountPath: /config
             {{ include "security-context" . | indent 12 | trim }}
           {{ include "uploaderContainer" . | indent 10 | trim }}
           volumes:

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -172,6 +172,19 @@ nova:
     requests:
       cpu: 25m
       memory: 128Mi
+  SkipVolumes: true
+  config:
+    desired-versions: {}
+    helm-hub-config: https://raw.githubusercontent.com/helm/hub/master/config/repo-values.yaml
+    helm-version: "auto"
+    output-file: "/output/nova.json"
+    poll-helm-hub: true
+    url:
+    - https://charts.fairwinds.com/stable
+    - https://charts.fairwinds.com/incubator
+    - https://kubernetes-charts.storage.googleapis.com
+    - https://kubernetes-charts-incubator.storage.googleapis.com
+    - https://charts.jetstack.io
 
 rbacreporter:
   enabled: false

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -164,7 +164,7 @@ nova:
   timeout: 300
   image:
     repository: quay.io/fairwinds/nova
-    tag: "2.0"
+    tag: "2.2"
   resources:
     limits:
       cpu: 100m


### PR DESCRIPTION
**Why This PR?**
Nova will soon support adding config via a file, which will support passing desired-versions. This will allow us to specify that when deploying the agent.

**Changes**
Changes proposed in this pull request:

* Add a configmap to nova called RELEASE-NAME-nova-config
* Mount the configmap to /config/nova.yaml
* Change the cmd for nova to be /nova find --config=/config/nova.yaml

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.