### PR TITLE
Allow get pods in rbac for node termination handler

### DIFF
--- a/stable/gke-node-termination-handler/Chart.yaml
+++ b/stable/gke-node-termination-handler/Chart.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 appVersion: "1.0"
 description: This helm chart provides an adapter for translating GCE node termination events to graceful pod terminations in Kubernetes.
 name: gke-node-termination-handler
-version: 1.2.0
+version: 1.2.1
 maintainers:
-  - name: bbensky
-  - name: hopson
+  - name: sudermanjr

--- a/stable/gke-node-termination-handler/templates/rbac.yaml
+++ b/stable/gke-node-termination-handler/templates/rbac.yaml
@@ -29,7 +29,7 @@ rules:
   # Allow Node Termination Handler to list and delete pods (for draining nodes)
 - apiGroups: [""]
   resources: ["pods"]
-  verbs: ["list", "delete"]
+  verbs: ["list", "delete", "get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
**Why This PR?**
Some changes were needed

**Changes**
Changes proposed in this pull request:

* add 'get' permissions for pods

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.