### PR TITLE
Add listening address flag

### DIFF
--- a/stable/polaris/Chart.yaml
+++ b/stable/polaris/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Validation of best practices in your Kubernetes clusters
 name: polaris
-version: 3.0.1
+version: 3.0.2
 appVersion: "3.0"
 icon: https://raw.githubusercontent.com/FairwindsOps/polaris/master/pkg/dashboard/assets/favicon-32x32.png
 maintainers:

--- a/stable/polaris/README.md
+++ b/stable/polaris/README.md
@@ -46,6 +46,8 @@ the 0.10.0 version of this chart will only work on kubernetes 1.14.0+
 | templateOnly | bool | `false` | Outputs Namespace names, used with `helm template` |
 | dashboard.basePath | string | `nil` | Path on which the dashboard is served. Defaults to `/` |
 | dashboard.enable | bool | `true` | Whether to run the dashboard. |
+| dashboard.port | int | `8080` | Port that the dashboard will run from. |
+| dashboard.listeningAddress | string | `nil` | Dashboard listerning address. |
 | dashboard.replicas | int | `1` | Number of replicas to run. |
 | dashboard.resources | object | `{"limits":{"cpu":"150m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | Requests and limits for the dashboard |
 | dashboard.service.type | string | `"ClusterIP"` | Service Type |

--- a/stable/polaris/templates/dashboard.deployment.yaml
+++ b/stable/polaris/templates/dashboard.deployment.yaml
@@ -48,7 +48,7 @@ spec:
         {{- end }}
         {{- with .Values.dashboard.port }}
         - --port
-        - {{ . }}
+        - {{ . | quote }}
         {{- end }}
         {{- if .Values.dashboard.listeningAddress }}
         - --listening-address

--- a/stable/polaris/templates/dashboard.deployment.yaml
+++ b/stable/polaris/templates/dashboard.deployment.yaml
@@ -46,21 +46,29 @@ spec:
         - --base-path
         - {{ . }}
         {{- end }}
+        {{- with .Values.dashboard.port }}
+        - --port
+        - {{ . }}
+        {{- end }}
+        {{- if .Values.dashboard.listeningAddress }}
+        - --listening-address
+        - {{ .Values.dashboard.listeningAddress }}
+        {{- end }}
         image: '{{.Values.image.repository}}:{{.Values.image.tag | default .Chart.AppVersion }}'
         imagePullPolicy: '{{.Values.image.pullPolicy}}'
         name: dashboard
         ports:
-        - containerPort: 8080
+        - containerPort: {{ .Values.dashboard.port }}
         livenessProbe:
           httpGet:
             path: {{.Values.dashboard.basePath | default "/" }}health
-            port: 8080
+            port: {{ .Values.dashboard.port }}
           initialDelaySeconds: 5
           periodSeconds: 20
         readinessProbe:
           httpGet:
             path: {{.Values.dashboard.basePath | default "/" }}health
-            port: 8080
+            port: {{ .Values.dashboard.port }}
           initialDelaySeconds: 5
           periodSeconds: 20
         resources:

--- a/stable/polaris/templates/dashboard.service.yaml
+++ b/stable/polaris/templates/dashboard.service.yaml
@@ -17,7 +17,7 @@ spec:
   - name: http-dashboard
     port: 80
     protocol: TCP
-    targetPort: 8080
+    targetPort: {{ .Values.dashboard.port }}
   selector:
     {{- include "polaris.selectors" . | nindent 4 }}
     component: dashboard

--- a/stable/polaris/values.yaml
+++ b/stable/polaris/values.yaml
@@ -30,6 +30,10 @@ dashboard:
   # dashboard.enable -- Whether to run the dashboard.
   enable: true
   # dashboard.replicas -- Number of replicas to run.
+  port: 8080
+  # dashboard.port -- Port that the dashboard will run from.
+  listeningAddress:
+  # dashboard.listeningAddress -- Dashboard listerning address.
   replicas: 1
   # dashboard.resources -- Requests and limits for the dashboard
   resources:

--- a/stable/polaris/values.yaml
+++ b/stable/polaris/values.yaml
@@ -29,11 +29,11 @@ dashboard:
   basePath: null
   # dashboard.enable -- Whether to run the dashboard.
   enable: true
-  # dashboard.replicas -- Number of replicas to run.
-  port: 8080
   # dashboard.port -- Port that the dashboard will run from.
-  listeningAddress:
+  port: 8080
   # dashboard.listeningAddress -- Dashboard listerning address.
+  listeningAddress:
+  # dashboard.replicas -- Number of replicas to run.
   replicas: 1
   # dashboard.resources -- Requests and limits for the dashboard
   resources:


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

This adds options to specify port and listening address.
Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
