### PR TITLE
Make CRD installation optional

### DIFF
--- a/stable/rbac-manager/Chart.yaml
+++ b/stable/rbac-manager/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rbac-manager
-version: 1.7.0
+version: 1.8.0
 appVersion: 0.10.0
 description: A Kubernetes operator that simplifies the management of Role Bindings and Service Accounts.
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/rbac-manager/icon.png

--- a/stable/rbac-manager/README.md
+++ b/stable/rbac-manager/README.md
@@ -56,6 +56,7 @@ In the above workflow, an RBAC Definition installed between revision 1 and 2 sho
 | image.tag | string | `"v0.10.0"` | The tag of the image to run |
 | image.pullPolicy | string | `"Always"` | The image pullPolicy. Recommend not changing this |
 | image.imagePullSecrets | list | `[]` |  |
+| installCRDs | bool | `true` | If true, install and upgrade CRDs. See the Helm documentation for [best practices regarding CRDs](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/#install-a-crd-declaration-before-using-the-resource). |
 | resources | object | `{"limits":{"cpu":"100m","memory":"128Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | A resources block for the rbac-manager pods |
 | priorityClassName | string | `""` | The name of a priorityClass to use |
 | nodeSelector | object | `{}` | Deployment nodeSelector |

--- a/stable/rbac-manager/templates/customresourcedefinition.yaml
+++ b/stable/rbac-manager/templates/customresourcedefinition.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.installCRDs }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -110,3 +111,4 @@ spec:
               type: array
             status:
               type: object
+{{- end -}}

--- a/stable/rbac-manager/values.yaml
+++ b/stable/rbac-manager/values.yaml
@@ -8,6 +8,9 @@ image:
   # imagePullSecrets -- A list of imagePullSecrets to reference for pulling the image
   imagePullSecrets: []
 
+# installCRDs -- If true, install and upgrade CRDs. See the Helm documentation for [best practices regarding CRDs](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/#install-a-crd-declaration-before-using-the-resource).
+installCRDs: true
+
 # resources -- A resources block for the rbac-manager pods
 resources:
   requests:


### PR DESCRIPTION
**Why This PR?**
Right now there is no way for a user to manage CRDs outside of this chart.
The recommended Helm3 way using --skip-crds does not work, since the CRD are placed in the templates/ folder.
This PR uses the value `installCRDs` to install and upgrade CRDs like other resources (like Helm2 did).
An alternative approach is discussed in #428 
Fixes #427

**Changes**
Changes proposed in this pull request:

* Use the variable `installCRDs` to opt-in to CRD installation

This does not follow Helm3's recommended way of installing CRDs. See #428 for a discussion revolving around that.

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
