### PR TITLE
rbac-manager - Add serviceMonitor.additionalLabels

### DIFF
--- a/stable/rbac-manager/Chart.yaml
+++ b/stable/rbac-manager/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rbac-manager
-version: 1.8.0
+version: 1.8.1
 appVersion: 0.10.0
 description: A Kubernetes operator that simplifies the management of Role Bindings and Service Accounts.
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/rbac-manager/icon.png

--- a/stable/rbac-manager/README.md
+++ b/stable/rbac-manager/README.md
@@ -65,6 +65,7 @@ In the above workflow, an RBAC Definition installed between revision 1 and 2 sho
 | podAnnotations | object | `{}` | Annotations to apply to the pods |
 | podLabels | object | `{}` | Labels to apply to the pod |
 | serviceMonitor.enabled | bool | `false` | If true, a ServiceMonitor will be created for Prometheus |
+| serviceMonitor.additionalLabels | list | `[]` | Additional labels to ServiceMonitor |
 | serviceMonitor.annotations | object | `{}` | Annotations to apply to the serviceMonitor and headless service |
 | serviceMonitor.namespace | string | `""` | The namespace to deploy the serviceMonitor into |
 | serviceMonitor.interval | string | `"60s"` | How often to scrape the metrics endpoint |

--- a/stable/rbac-manager/templates/servicemonitor.yaml
+++ b/stable/rbac-manager/templates/servicemonitor.yaml
@@ -12,6 +12,9 @@ metadata:
     chart: {{ template "rbac-manager.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- if .Values.serviceMonitor.additionalLabels }}
+{{ toYaml .Values.serviceMonitor.additionalLabels | indent 4 }}
+    {{- end }}
 {{- with .Values.serviceMonitor.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}

--- a/stable/rbac-manager/values.yaml
+++ b/stable/rbac-manager/values.yaml
@@ -40,6 +40,8 @@ podLabels: {}
 serviceMonitor:
   # serviceMonitor.enabled -- If true, a ServiceMonitor will be created for Prometheus
   enabled: false
+  # serviceMonitor.additionalLabels -- Additional labels to ServiceMonitor
+  additionalLabels: []
   # serviceMonitor.annotations -- Annotations to apply to the serviceMonitor and headless service
   annotations: {}
   # serviceMonitor.namespace -- The namespace to deploy the serviceMonitor into


### PR DESCRIPTION
**Why This PR?**

When using
[serviceMonitorSelector](https://coreos.com/operators/prometheus/docs/latest/user-guides/getting-started.html#include-servicemonitors) it may be needed to add additional labels to the ServiceMonitor object.

**Changes**
Changes proposed in this pull request:

* This implements the serviceMonitor.additionalLabels list variable.

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
