### PR TITLE
add prometheuscrd bac

### DIFF
--- a/stable/polaris/Chart.yaml
+++ b/stable/polaris/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Validation of best practices in your Kubernetes clusters
 name: polaris
-version: 3.1.0
+version: 3.1.1
 appVersion: "3.1"
 icon: https://raw.githubusercontent.com/FairwindsOps/polaris/master/pkg/dashboard/assets/favicon-32x32.png
 maintainers:

--- a/stable/polaris/templates/rbac.yaml
+++ b/stable/polaris/templates/rbac.yaml
@@ -30,7 +30,7 @@ rules:
     verbs:
       - 'get'
       - 'list'
- - apiGroups: 
+  - apiGroups: 
       - 'monitoring.coreos.com'
     resources: 
       - 'prometheuses'

--- a/stable/polaris/templates/rbac.yaml
+++ b/stable/polaris/templates/rbac.yaml
@@ -30,6 +30,15 @@ rules:
     verbs:
       - 'get'
       - 'list'
+ - apiGroups: 
+      - 'monitoring.coreos.com'
+    resources: 
+      - 'prometheuses'
+      - 'alertmanagers'
+    verbs: 
+      - 'get'
+      - 'list'
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
**Why This PR?**
```
ime="2021-02-11T14:12:00Z" level=warning msg="Error retrieving parent object API v1 and Kind alertmanagers because of error: alertmanagers.monitoring.coreos.com is forbidden: User \"system:serviceaccount:cpt:polaris\" cannot list resource \"alertmanagers\" in API group \"monitoring.coreos.com\" at the cluster scope"
time="2021-02-11T14:12:00Z" level=warning msg="Error caching objects of Kind Alertmanager alertmanagers.monitoring.coreos.com is forbidden: User \"system:serviceaccount:cpt:polaris\" cannot list resource \"alertmanagers\" in API group \"monitoring.coreos.com\" at the cluster scope"
time="2021-02-11T14:12:00Z" level=warning msg="Error retrieving parent object API v1 and Kind prometheuses because of error: prometheuses.monitoring.coreos.com is forbidden: User \"system:serviceaccount:cpt:polaris\" cannot list resource \"prometheuses\" in API group \"monitoring.coreos.com\" at the cluster scope"
```

Fixes #

Update RBAC

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
