### PR TITLE
Update insights-agent chart to allow for two installations side by side

### DIFF
--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 1.9.0
+version: 1.9.2
 appVersion: 2.3.0
 maintainers:
   - name: rbren

--- a/stable/insights-agent/README.md
+++ b/stable/insights-agent/README.md
@@ -79,6 +79,7 @@ Parameter | Description | Default
 `trivy.namespaceBlacklist` | Specifies which namespaces to not scan, takes an array of namespaces for example: `--set trivy.namespaceBlacklist="{kube-system,default}"` | nil
 `opa.role` | Specifies which ClusterRole to grant the OPA agent access to | view
 `opa.additionalAccess` | Specifies additional access to grant the OPA agent. This should contain an array of objects with each having an array of apiGroups, an array of resources, and an array of verbs. Just like a RoleBinding. | null
+`opa.installCRDs` | Specifies whether to install the `customcheckinstances.insights.fairwinds.com` CRD. If you are installing the `insights-agent` chart twice you will want to set this flag to `false` on *one* of the installs, doesn't matter which. | true
 `goldilocks.controller.flags.exclude-namespaces` | Namespaces to exclude from the goldilocks report | `kube-system`
 `goldilocks.installVPA` | Install the Vertical Pod Autoscaler as part of the Goldilocks installation | true
 `goldilocks.controller.flags.on-by-default` | Goldilocks will by default monitor all namespaces that aren't excluded | true

--- a/stable/insights-agent/templates/opa/check.yaml
+++ b/stable/insights-agent/templates/opa/check.yaml
@@ -38,7 +38,7 @@ properties:
         type: string
 {{- end }}
 
-{{- if .Values.opa.enabled -}}
+{{- if and (.Values.opa.enabled) (.Values.opa.installCRDs) -}}
 kind: CustomResourceDefinition
 metadata:
   # name must match the spec fields below, and be in the form: <plural>.<group>

--- a/stable/insights-agent/templates/opa/instance.yaml
+++ b/stable/insights-agent/templates/opa/instance.yaml
@@ -41,9 +41,8 @@ properties:
           category:
             type: string
 {{- end }}
-{{- if .Values.opa.enabled -}}
 
-
+{{- if and (.Values.opa.enabled) (.Values.opa.installCRDs) -}}
 kind: CustomResourceDefinition
 metadata:
   # name must match the spec fields below, and be in the form: <plural>.<group>

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -149,6 +149,7 @@ opa:
     requests:
       cpu: 10m
       memory: 64Mi
+  installCRDs: true
 
 workloads:
   enabled: true


### PR DESCRIPTION
**Why This PR?**
If you try to install a new deployment of `insights-agent` alongside an existing one - as we do installing `fw-telemetry` for clients who already have `insights-agent` present in their cluster - it will fail, because both deployments want to modify the same CRD.

**Fixes**

We need to allow the option to not install the CRD on a deployment.

**Changes**
Changes proposed in this pull request:

* Update the insights-agent OPA `values.yaml` to take an `installCRDs` option, with default of `true`.
* Modify the CRD logic in the insights-agent OPA templates to require the flag to be true to install the CRD.

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
