### PR TITLE
[insights-agent] Add the ability to specify a config url for nova

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
      - id: pretty-format-json
        args: ['--autofix']
   - repo: https://github.com/jumanjihouse/pre-commit-hooks
-    rev: 1.11.0
+    rev: 2.1.5
     hooks:
       - id: forbid-binary
         exclude: >

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 1.9.3
+version: 1.9.4
 appVersion: 2.3.0
 maintainers:
   - name: rbren

--- a/stable/insights-agent/templates/nova/cronjob.yaml
+++ b/stable/insights-agent/templates/nova/cronjob.yaml
@@ -27,7 +27,7 @@ spec:
             command:
               - /nova
               - find
-              - --config=/config/nova.yaml
+              - --config={{ .Config.configLocation }}
             {{ include "security-context" . | indent 12 | trim }}
           {{ include "uploaderContainer" . | indent 10 | trim }}
           volumes:

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -172,7 +172,7 @@ nova:
   timeout: 300
   image:
     repository: quay.io/fairwinds/nova
-    tag: "2.2"
+    tag: "2.3"
   resources:
     limits:
       cpu: 100m

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -181,6 +181,7 @@ nova:
       cpu: 25m
       memory: 128Mi
   SkipVolumes: true
+  configLocation: "/config/nova.yaml"
   config:
     desired-versions: {}
     helm-hub-config: https://raw.githubusercontent.com/helm/hub/master/config/repo-values.yaml


### PR DESCRIPTION
**Why This PR?**
Nova recently added the ability to specify a config url. You can enable this by settign the `nova.configLocation` to an http(s) url. This will ignore the configmap

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.