### PR TITLE
Upgrade vpa to .0.9.2

### DIFF
--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 0.2.3
-appVersion: 0.8.0
+version: 0.3.0
+appVersion: 0.9.2
 maintainers:
   - name: sudermanjr


### PR DESCRIPTION
This PR upgrades VPA to the latest version

**Changes**
Changes proposed in this pull request:

* Upgrade VPA images to 0.9.2

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
