### PR TITLE
Add automountServiceAccountToken to vpa

### DIFF
--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 0.3.0
+version: 0.3.1
 appVersion: 0.9.2
 maintainers:
   - name: sudermanjr

--- a/stable/vpa/README.md
+++ b/stable/vpa/README.md
@@ -56,6 +56,7 @@ recommender:
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created for each component |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service accounts for each component |
 | serviceAccount.name | string | `""` | The base name of the service account to use (appended with the component). If not set and create is true, a name is generated using the fullname template and appended for each component |
+| serviceAccount.automountServiceAccountToken | bool | `true` | Automount API credentials for the Service Account |
 | recommender.enabled | bool | `true` | If true, the vpa recommender component will be installed. |
 | recommender.extraArgs | object | `{"pod-recommendation-min-cpu-millicores":15,"pod-recommendation-min-memory-mb":100,"v":"4"}` | A set of key-value flags to be passed to the recommender |
 | recommender.replicaCount | int | `1` |  |

--- a/stable/vpa/templates/admission-controller-service-account.yaml
+++ b/stable/vpa/templates/admission-controller-service-account.yaml
@@ -2,6 +2,7 @@
 {{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 metadata:
   name: {{ include "vpa.serviceAccountName" . }}-admission-controller
   labels:

--- a/stable/vpa/templates/recommender-service-account.yaml
+++ b/stable/vpa/templates/recommender-service-account.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 metadata:
   name: {{ include "vpa.serviceAccountName" . }}-recommender
   labels:

--- a/stable/vpa/templates/updater-service-account.yaml
+++ b/stable/vpa/templates/updater-service-account.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 metadata:
   name: {{ include "vpa.serviceAccountName" . }}-updater
   labels:

--- a/stable/vpa/values.yaml
+++ b/stable/vpa/values.yaml
@@ -21,6 +21,8 @@ serviceAccount:
   annotations: {}
   # serviceAccount.name -- The base name of the service account to use (appended with the component). If not set and create is true, a name is generated using the fullname template and appended for each component
   name: ""
+  # serviceAccount.automountServiceAccountToken -- Automount API credentials for the Service Account
+  automountServiceAccountToken: true
 
 recommender:
   # recommender.enabled -- If true, the vpa recommender component will be installed.


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Add ability to specify `automountServiceAccountToken` on the vpa service accounts

Fixes #

**Changes**
Changes proposed in this pull request:

* Add vpa helm chart value for `automountServiceAccountToken`
*

**Checklist:**

* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
