### PR TITLE
Add nova tmp for pulling config file from http. Add flag for logLevel to debug

### DIFF
--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 1.9.5
+version: 1.9.6
 appVersion: 2.3.0
 maintainers:
   - name: rbren

--- a/stable/insights-agent/README.md
+++ b/stable/insights-agent/README.md
@@ -87,3 +87,4 @@ Parameter | Description | Default
 `goldilocks.dashboard.enabled` | Installs the Goldilocks Dashboard | false
 `resourcemetrics.installPrometheus` | Install a new Prometheus instance for the resourcemetrics report | false
 `resourcemetrics.address` | The address of an existing Prometheus instance to query in the form `<scheme>://<service-name>.<namespace>[:<port>]` for example `http://prometheus-server.prometheus` | `"http://prometheus-server"`
+`nova.logLevel` | The klog log-level to use when running Nova | `3`

--- a/stable/insights-agent/templates/nova/cronjob.yaml
+++ b/stable/insights-agent/templates/nova/cronjob.yaml
@@ -24,10 +24,13 @@ spec:
               mountPath: /output
             - name: config
               mountPath: /config
+            - name: tmp
+              mountPath: /tmp
             command:
               - /nova
               - find
               - --config={{ .Config.configLocation }}
+              - -v{{ .Config.logLevel }}
             {{ include "security-context" . | indent 12 | trim }}
           {{ include "uploaderContainer" . | indent 10 | trim }}
           volumes:
@@ -36,4 +39,6 @@ spec:
             - name: config
               configMap:
                 name: {{ include "insights-agent.fullname" $ }}-nova-config
+            - name: tmp
+              emptyDir: {}
 {{- end -}}

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -170,6 +170,7 @@ nova:
   enabled: false
   schedule: "rand * * * *"
   timeout: 300
+  logLevel: 3
   image:
     repository: quay.io/fairwinds/nova
     tag: "2.3"


### PR DESCRIPTION
**Why This PR?**
When using `nova --config=https://<>` nova expects to be able to use `/tmp` to store the file. This creates an emptyDir volume for that purpose

Fixes #

**Changes**
Changes proposed in this pull request:

* Also adds a value `nova.logLevel` that gets passed, defaults to 3.

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.