### PR TITLE
Bug fix for vpa running outside kube-system namespace

### DIFF
--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 0.3.1
+version: 0.3.2
 appVersion: 0.9.2
 maintainers:
   - name: sudermanjr

--- a/stable/vpa/templates/updater-deployment.yaml
+++ b/stable/vpa/templates/updater-deployment.yaml
@@ -44,6 +44,11 @@ spec:
             - --{{ $key }}={{ $value }}
           {{- end }}
           {{- end }}
+          env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           livenessProbe:
             failureThreshold: 6
             httpGet:


### PR DESCRIPTION
**Why This PR?**
The VPA updater is unable to read the `leases` object when running outside the kube-system namespace.

**Changes**
Changes proposed in this pull request:

* Set the `NAMESPACE` env var on the updater deployment. See where this var is used [here](https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/pkg/updater/main.go#L66)

**Checklist:**

* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
