### PR TITLE
[Insights Agent] Retrieve Polaris config from Insights

### DIFF
--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 1.10.0
+version: 1.11.0
 appVersion: 3.2.0
 maintainers:
   - name: rbren

--- a/stable/insights-agent/templates/_specs.yaml
+++ b/stable/insights-agent/templates/_specs.yaml
@@ -42,6 +42,54 @@ volumeMounts:
   mountPath: /output
 {{- end }}
 
+{{ define "get-config-container" }}
+initContainers:
+- name: insights-config-downloader
+  image: "{{ .Values.uploader.image.repository }}:{{ .Values.uploader.image.tag }}"
+  imagePullPolicy: Always
+  command:
+  - ./download.sh
+  - --datatype
+  - {{ .Label }}
+  - --organization
+  - {{ required "You must set an organization" .Values.insights.organization | quote }}
+  - --cluster
+  - {{ required "You must set a cluster" .Values.insights.cluster | quote }}
+  {{- with .Values.insights.host }}
+  - --host
+  - {{ . | quote }}
+  {{- end }}
+  - --file
+  - /output/{{ .Label }}-config.yaml
+  env:
+  - name: FAIRWINDS_TOKEN
+    valueFrom:
+      secretKeyRef:
+        {{ if .Values.insights.tokenSecretName -}}
+        name: {{ .Values.insights.tokenSecretName }}
+        {{ else -}}
+        name: {{ include "insights-agent.fullname" . }}-token
+        {{ end -}}
+        key: token
+  {{- with .Values.uploader.env }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
+  volumeMounts:
+  - name: output
+    mountPath: /output
+  resources:
+    {{- toYaml .Values.uploader.resources | nindent 4 }}
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    privileged: false
+    capabilities:
+      drop:
+        - ALL
+{{- end }}
+
 {{ define "security-context" }}
 securityContext:
   readOnlyRootFilesystem: true

--- a/stable/insights-agent/templates/_specs.yaml
+++ b/stable/insights-agent/templates/_specs.yaml
@@ -62,6 +62,8 @@ initContainers:
   - --file
   - /output/{{ .Label }}-config.yaml
   env:
+  - name: DEBUG
+    value: "true"
   - name: FAIRWINDS_TOKEN
     valueFrom:
       secretKeyRef:

--- a/stable/insights-agent/templates/_specs.yaml
+++ b/stable/insights-agent/templates/_specs.yaml
@@ -62,8 +62,6 @@ initContainers:
   - --file
   - /output/{{ .Label }}-config.yaml
   env:
-  - name: DEBUG
-    value: "true"
   - name: FAIRWINDS_TOKEN
     valueFrom:
       secretKeyRef:

--- a/stable/insights-agent/templates/polaris/cronjob.yaml
+++ b/stable/insights-agent/templates/polaris/cronjob.yaml
@@ -18,6 +18,7 @@ spec:
             configMap:
               name: polaris
           {{ end }}
+          {{ include "get-config-container" . | indent 10 | trim }}
           containers:
           - {{ include "container-spec" . | indent 12 | trim }}
             {{ if .Values.polaris.config }}
@@ -26,15 +27,20 @@ spec:
               subPath: config.yaml
               readOnly: true
             {{ end }}
-            command: [
-              "polaris", "audit",
-              {{ if .Values.polaris.config }}
-              "--config", "/opt/app/config.yaml",
-              {{ end }}
-              "--output-file", "/output/polaris.json",
-              "--format", "json",
-              "--display-name", "{{ .Values.insights.cluster }}",
-            ]
+            command:
+            - "sh"
+            - "-c"
+            - |
+              CONFIG=""
+              if [ -f '/output/polaris-config.yaml' ]
+              then
+                CONFIG='--config /output/polaris-config.yaml'
+              fi
+              if [ -f '/opt/app/config.yaml' ]
+              then
+                CONFIG='--config /opt/app/config.yaml'
+              fi
+              polaris audit --output-file /output/polaris.json --format json --display-name {{ .Values.insights.cluster }} $CONFIG
             {{ include "security-context" . | indent 12 | trim }}
           {{ include "uploaderContainer" . | indent 10 | trim }}
 {{- end -}}

--- a/stable/insights-agent/templates/test/test-deployment.yaml
+++ b/stable/insights-agent/templates/test/test-deployment.yaml
@@ -36,6 +36,7 @@ spec:
             from http.server import BaseHTTPRequestHandler, HTTPServer
             class FileHandler(BaseHTTPRequestHandler):
               def do_GET(self):
+                print(self.path)
                 content = "{}".encode(encoding="utf-8")
                 if "trivy" in self.path or "polaris" in self.path:
                   self.send_response(404, "Not Found")
@@ -47,6 +48,7 @@ spec:
                 self.wfile.write(content)
                 return
               def do_POST(self):
+                print(self.path)
                 content = '{"Success": true}'.encode(encoding="utf-8")
                 self.send_response(200, "success")
                 self.send_header("Content-type", "application/json")

--- a/stable/insights-agent/templates/test/test-deployment.yaml
+++ b/stable/insights-agent/templates/test/test-deployment.yaml
@@ -37,7 +37,7 @@ spec:
             class FileHandler(BaseHTTPRequestHandler):
               def do_GET(self):
                 content = "{}".encode(encoding="utf-8")
-                if "trivy" in self.path:
+                if "trivy" in self.path or "polaris" in self.path:
                   self.send_response(404, "Not Found")
                 else:
                   self.send_response(200, "success")

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -11,7 +11,7 @@ rbac:
 uploader:
   image:
     repository: quay.io/fairwinds/insights-uploader
-    tag: "0.2"
+    tag: "0.3"
   sendFailures: true
   resources:
     limits:

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -11,7 +11,7 @@ rbac:
 uploader:
   image:
     repository: quay.io/fairwinds/insights-uploader
-    tag: "0.3"
+    tag: "bb-fix2-download"
   sendFailures: true
   resources:
     limits:

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -11,7 +11,7 @@ rbac:
 uploader:
   image:
     repository: quay.io/fairwinds/insights-uploader
-    tag: "bb-fix2-download"
+    tag: "0.3"
   sendFailures: true
   resources:
     limits:


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_
Retrieves the config for Polaris from Insights on startup.

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
