### PR TITLE
[gemini] Fix trailing whitespace in chart description

### DIFF
--- a/stable/gemini/Chart.yaml
+++ b/stable/gemini/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-description: Automated backup and restore of PersistentVolumes using the  VolumeSnapshot API
+description: Automated backup and restore of PersistentVolumes using the VolumeSnapshot API
 name: gemini
 version: 0.0.4
 appVersion: 0.1.0

--- a/stable/gemini/Chart.yaml
+++ b/stable/gemini/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Automated backup and restore of PersistentVolumes using the VolumeSnapshot API
 name: gemini
-version: 0.0.4
+version: 0.0.5
 appVersion: 0.1.0
 maintainers:
   - name: rbren


### PR DESCRIPTION
**Why This PR?**

Don't know why this happen, but when I try to sync the chart with [Helm S3](https://github.com/hypnoglow/helm-s3) an error occured only on this chart

```
helm s3 push gemini-0.0.4.tgz  my-charts
upload chart to s3: upload object to s3: SignatureDoesNotMatch: The request signature we calculated does not match the signature you provided. Check your key and signing method.
        status code: 403, request id: 000001787A8ED53E44159C169D02DFB2, host id: 32AAAQAAEAABAAAQAAEAABAAAQAAEAABCSFn189jbxYn409J2SCvNCASwa3KzQys
Error: plugin "s3" exited with error
```

I investigated the chart in each detail and at the end whitespace in the description line caused this error.

Fixes https://github.com/hypnoglow/helm-s3/issues/141

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
