### PR TITLE
[gemini] fix deprecated rbac api

### DIFF
--- a/stable/gemini/Chart.yaml
+++ b/stable/gemini/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Automated backup and restore of PersistentVolumes using the  VolumeSnapshot API
 name: gemini
-version: 0.0.4
+version: 0.0.6
 appVersion: 0.1.0
 maintainers:
   - name: rbren

--- a/stable/gemini/templates/rbac.yaml
+++ b/stable/gemini/templates/rbac.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "gemini.labels" . | nindent 4 }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "gemini.fullname" . }}-controller

--- a/stable/gemini/templates/rbac.yaml
+++ b/stable/gemini/templates/rbac.yaml
@@ -45,7 +45,7 @@ rules:
       - create
       - delete
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "gemini.fullname" . }}-controller


### PR DESCRIPTION
**Why This PR?**

API rbac.authorization.k8s.io/v1beta1 is deprecated since Kubernetes 1.17

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
