### PR TITLE
Add role parameter to letsencrypt-setup

### DIFF
--- a/incubator/letsencrypt-setup/Chart.yaml
+++ b/incubator/letsencrypt-setup/Chart.yaml
@@ -1,6 +1,6 @@
 name: letsencrypt-setup
 apiVersion: v1
-version: v2.2.1
+version: v2.2.2
 appVersion: v0.11.1
 description: Setup clusterIssuers for cert-manager
 maintainers:

--- a/incubator/letsencrypt-setup/README.md
+++ b/incubator/letsencrypt-setup/README.md
@@ -40,7 +40,8 @@ The following table lists the configurable parameters of the chart and their def
 | Parameter | Description |
 | --------- | --------- |
 | `accessKeyID` | For use with specific IAM account credentials, not necessary if nodes have IAM role that gives access to route53|
-| `hostedZoneID` | Route53 hosted zone ID |
+| `role` | Role ARN to assume. Handy for cross-account route53 record management |
+| `hostedZoneID` | Route53 hosted zone ID; recommended if using cross-account IAM role assumption |
 | `region` | Required if using `accessKeyID` for authentication |
 | `secretName` | Required if using `accessKeyID`, name of kubernetes secret that contains the IAM secret access key correlating to the `accessKeyID` |
 | `secretKey` | Required if using `accessKeyID`, key within a kubernetes secret data block that holds the IAM secret access key |

--- a/incubator/letsencrypt-setup/templates/_helpers.tpl
+++ b/incubator/letsencrypt-setup/templates/_helpers.tpl
@@ -60,6 +60,9 @@ solvers:
     route53:
       hostedZoneID: {{ .hostedZoneID | default "" }}
       region: {{ .region }}
+      {{- if .role }}
+      role: {{ .role }}
+      {{- end }} {{- /* endif .role */ -}}
       {{- if .secretName }}
       accessKeyID: {{ .accessKeyID }}
       secretAccessKeySecretRef:


### PR DESCRIPTION
**Why This PR?**
Cert-manager allows for specifying an IAM role to assume for managing route53 records when using route53 to solve dns01 ACME challenges, see [here](https://cert-manager.io/docs/configuration/acme/dns01/route53/#creating-an-issuer-or-clusterissuer). 

This comes in handy when you're running a cluster in an AWS account separate from where your route53 records exist, as you can specify a role ARN in the account where the route53 zone lives. Cert-manager will assume it using its AWS credentials (as long as they have permission). I've tested this on EKS using EKS's service accounts, but it should work the same using kube2iam or kiam. 

There is actually a `role` parameter commented out in the values.yml example for the chart, but the template wasn't implemented yet. So, this is just adding that parameter to the template.

**Changes**
Changes proposed in this pull request:

* Add a `role` parameter to the letsencrypt-setup chart template

**Checklist:**

* [ ✅ ] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [ ✅ ] Any new values are backwards compatible and/or have sensible default.
* [ ✅  ] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
