### PR TITLE
[Fairwinds Insights] Add configmap for polaris config

### DIFF
--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 3-5-0-beta2
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 0.1.2
+version: 0.1.3
 maintainers:
 - name: rbren
 - name: makoscafee

--- a/stable/fairwinds-insights/README.md
+++ b/stable/fairwinds-insights/README.md
@@ -12,6 +12,7 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/self-hoste
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | image.tag | string | `nil` | Docker image tag, defaults to the Chart appVersion |
+| polaris.config | string | `nil` | Configuration for Polaris |
 | dashboardImage.repository | string | `"quay.io/fairwinds/insights-dashboard"` | Docker image repository for the front end |
 | apiImage.repository | string | `"quay.io/fairwinds/insights-api"` | Docker image repository for the API server |
 | migrationImage.repository | string | `"quay.io/fairwinds/insights-db-migration"` | Docker image repository for the database migration job |

--- a/stable/fairwinds-insights/templates/configmap.yaml
+++ b/stable/fairwinds-insights/templates/configmap.yaml
@@ -1,0 +1,11 @@
+{{- with .Values.config }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "fairwinds-insights.fullname" $ }}
+  labels:
+    {{- include "fairwinds-insights.labels" $ | nindent 4 }}
+data:
+  config.yaml: |
+    {{- toYaml . | nindent 4 }}
+{{- end }}

--- a/stable/fairwinds-insights/templates/migrate-db-job.yaml
+++ b/stable/fairwinds-insights/templates/migrate-db-job.yaml
@@ -50,12 +50,12 @@ spec:
             drop:
               - ALL
         volumeMounts:
-        - name: secrets
+        - name: polaris-config
           mountPath: /tmp/
       volumes:
-      - name: secrets
-        secret:
-          secretName: polaris-config
+      - name: polaris-config
+        configMap:
+          name: polaris-config
           optional: true
           items:
           - key: polaris-config.json

--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -2,6 +2,10 @@ image:
   # -- Docker image tag, defaults to the Chart appVersion
   tag:
 
+polaris:
+  # -- Configuration for Polaris
+  config:
+
 dashboardImage:
   # -- Docker image repository for the front end
   repository: quay.io/fairwinds/insights-dashboard


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_
Saves a configmap for the Polaris config that will get saved to Insights.


Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
