### PR TITLE
[Fairwinds Insights] Add installation code environment variable

### DIFF
--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 3-5-0-beta2
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 0.1.3
+version: 0.1.4
 maintainers:
 - name: rbren
 - name: makoscafee

--- a/stable/fairwinds-insights/README.md
+++ b/stable/fairwinds-insights/README.md
@@ -12,6 +12,7 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/self-hoste
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | image.tag | string | `nil` | Docker image tag, defaults to the Chart appVersion |
+| installationCode | string | `nil` | Installation code provided by Fairwinds. |
 | polaris.config | string | `nil` | Configuration for Polaris |
 | dashboardImage.repository | string | `"quay.io/fairwinds/insights-dashboard"` | Docker image repository for the front end |
 | apiImage.repository | string | `"quay.io/fairwinds/insights-api"` | Docker image repository for the API server |

--- a/stable/fairwinds-insights/templates/_env.yaml
+++ b/stable/fairwinds-insights/templates/_env.yaml
@@ -17,6 +17,10 @@ env:
 {{- with .Values.additionalEnvironmentVariables }}
 {{ toYaml . }}
 {{- end }}
+{{- with .Values.installationCode }}
+- name: INSTALLATION_CODE
+  value: {{ . | quote }}
+{{- end }}
 - name: CACHE_BUST_TOKEN
   value: {{ randAlphaNum 10 }}
 - name: FAIRWINDS_AGENT_CHART_TARGET_VERSION

--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -2,6 +2,9 @@ image:
   # -- Docker image tag, defaults to the Chart appVersion
   tag:
 
+# -- Installation code provided by Fairwinds.
+installationCode:
+
 polaris:
   # -- Configuration for Polaris
   config:


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_
Adds an environment variable for an installation code from Sales to get passed up to the SaaS.

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
