### PR TITLE
[insights-agent] fleet install mechanism

### DIFF
--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 1.11.0
+version: 1.12.0
 appVersion: 3.2.0
 maintainers:
   - name: rbren

--- a/stable/insights-agent/README.md
+++ b/stable/insights-agent/README.md
@@ -49,15 +49,18 @@ To better serve customers with a large number of clusters, we've created a flow
 that allows you to easily deploy the Insights Agent across your fleet. You'll
 simply need to set the following flags:
 * `fleetInstall=true` - enable this flow
-* `insights.adminToken=xyz` - you can get this admin token from your organization's settings page at insights.fairwinds.com
+* `insights.apiToken=xyz` - you can get this admin token from your organization's settings page at insights.fairwinds.com
 * `insights.tokenSecretName` - the name of the secret where Insights will store your cluster's token. We recommend `insights-token`
+* `insights.organization` - the name your organization in Insights
 * `insights.cluster` - the name you want to give this cluster in the Insights UI. You might want to auto-generate this from your kubectl context
 
 With these flags set, the Helm chart will create a new cluster in the Insights UI with the specified name
 (unless a cluster with that name already exists) before installing the agent.
 
-When reinstalling the agent, you can omit `adminToken` and `fleetInstall`, and simply specify `tokenSecretName`.
-This allows you to hand off control of the agent to other teams without sharing your organization's adminToken.
+When reinstalling the agent in the same cluster, you can omit `apiToken` and `fleetInstall`,
+and simply specify `tokenSecretName`.
+This allows you to hand off control of the agent to other teams without sharing your
+organization's apiToken.
 
 ## Configuration
 Parameter | Description | Default
@@ -69,7 +72,7 @@ Parameter | Description | Default
 `insights.host` | The location of the Insights server | https://insights.fairwinds.com
 `rbac.disabled` | Don't use any of the built-in RBAC | `false`
 `fleetInstall` | See Fleet Installation docs | `false`
-`insights.adminToken` | Only needed if `fleetInstall=true` | ""
+`insights.apiToken` | Only needed if `fleetInstall=true` | ""
 `uploader.image.repository`  | The repository to pull the uploader script from | quay.io/fairwinds/insights-uploader
 `uploader.image.tag` | The tag to use for the uploader script | 0.2
 `uploader.resources` | CPU/memory requests and limits for the uploader script |

--- a/stable/insights-agent/README.md
+++ b/stable/insights-agent/README.md
@@ -53,6 +53,9 @@ simply need to set the following flags:
 * `insights.tokenSecretName` - the name of the secret where Insights will store your cluster's token. We recommend `insights-token`
 * `insights.cluster` - the name you want to give this cluster in the Insights UI. You might want to auto-generate this from your kubectl context
 
+With these flags set, the Helm chart will create a new cluster in the Insights UI with the specified name
+(unless a cluster with that name already exists) before installing the agent.
+
 When reinstalling the agent, you can omit `adminToken` and `fleetInstall`, and simply specify `tokenSecretName`.
 This allows you to hand off control of the agent to other teams without sharing your organization's adminToken.
 

--- a/stable/insights-agent/README.md
+++ b/stable/insights-agent/README.md
@@ -40,6 +40,22 @@ There are several different report types which can be enabled and configured:
 
 See below for configuration details.
 
+## Fleet Installation
+If you're installing the Insights Agent across a large fleet of clusters,
+it can be tedious to use the UI to create each cluster, then copy out the
+cluster's access token.
+
+To better serve customers with a large number of clusters, we've created a flow
+that allows you to easily deploy the Insights Agent across your fleet. You'll
+simply need to set the following flags:
+* `fleetInstall=true` - enable this flow
+* `insights.adminToken=xyz` - you can get this admin token from your organization's settings page at insights.fairwinds.com
+* `insights.tokenSecretName` - the name of the secret where Insights will store your cluster's token. We recommend `insights-token`
+* `insights.cluster` - the name you want to give this cluster in the Insights UI. You might want to auto-generate this from your kubectl context
+
+When reinstalling the agent, you can omit `adminToken` and `fleetInstall`, and simply specify `tokenSecretName`.
+This allows you to hand off control of the agent to other teams without sharing your organization's adminToken.
+
 ## Configuration
 Parameter | Description | Default
 --------- | ----------- | -------
@@ -49,6 +65,8 @@ Parameter | Description | Default
 `insights.tokenSecretName` | If you don't provide a `base64token`, you can specify the name of a secret to pull the token from | ""
 `insights.host` | The location of the Insights server | https://insights.fairwinds.com
 `rbac.disabled` | Don't use any of the built-in RBAC | `false`
+`fleetInstall` | See Fleet Installation docs | `false`
+`insights.adminToken` | Only needed if `fleetInstall=true` | ""
 `uploader.image.repository`  | The repository to pull the uploader script from | quay.io/fairwinds/insights-uploader
 `uploader.image.tag` | The tag to use for the uploader script | 0.2
 `uploader.resources` | CPU/memory requests and limits for the uploader script |

--- a/stable/insights-agent/templates/fleet-installer/admin-secret.yaml
+++ b/stable/insights-agent/templates/fleet-installer/admin-secret.yaml
@@ -1,0 +1,12 @@
+{{ if .Values.fleetInstall }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "insights-agent.fullname" . }}-admin-token
+  annotations:
+    "helm.sh/hook-weight": "5"
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+stringData:
+  token: {{ required "You must specify insights.adminToken if you're doing a fleet install" .Values.insights.adminToken | quote }}
+{{ end }}

--- a/stable/insights-agent/templates/fleet-installer/admin-secret.yaml
+++ b/stable/insights-agent/templates/fleet-installer/admin-secret.yaml
@@ -2,11 +2,11 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "insights-agent.fullname" . }}-admin-token
+  name: {{ include "insights-agent.fullname" . }}-api-token
   annotations:
     "helm.sh/hook-weight": "5"
     "helm.sh/hook": pre-install
     "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
 stringData:
-  token: {{ required "You must specify insights.adminToken if you're doing a fleet install" .Values.insights.adminToken | quote }}
+  token: {{ required "You must specify insights.apiToken if you're doing a fleet install" .Values.insights.apiToken | quote }}
 {{ end }}

--- a/stable/insights-agent/templates/fleet-installer/job.yaml
+++ b/stable/insights-agent/templates/fleet-installer/job.yaml
@@ -48,7 +48,7 @@ spec:
           - name: ADMIN_TOKEN
             valueFrom:
               secretKeyRef:
-                name:  {{ include "insights-agent.fullname" . }}-admin-token
+                name:  {{ include "insights-agent.fullname" . }}-api-token
                 key: token
         volumeMounts:
         - name: tmp

--- a/stable/insights-agent/templates/fleet-installer/job.yaml
+++ b/stable/insights-agent/templates/fleet-installer/job.yaml
@@ -22,23 +22,25 @@ spec:
         args:
           - -c
           - |
-            echo "start!"
+            echo "Checking if cluster already exists..."
+            CLUSTER_FILE="/tmp/cluster.json"
+            SECRET_NAME="{{ required "You must specify insights.tokenSecretName for a fleet install" .Values.insights.tokenSecretName }}"
             AUTH_HEADER="Authorization: Bearer $ADMIN_TOKEN"
-            echo "Auth $AUTH_HEADER"
             CLUSTER_URL="{{ .Values.insights.host }}/v0/organizations/{{ .Values.insights.organization }}/clusters/{{ .Values.insights.cluster }}"
-            echo "url $CLUSTER_URL"
-            EXISTS=$(curl -s -o /dev/null -w "%{http_code}" "$CLUSTER_URL" -H "$AUTH_HEADER")
-            echo "Cluster exists? $EXISTS"
+            EXISTS=$(curl -s -o $CLUSTER_FILE -w "%{http_code}" "$CLUSTER_URL?showToken=true" -H "$AUTH_HEADER")
             if [[ $EXISTS -eq 404 ]]; then
               echo "Creating cluster..."
-              RESP=$(curl -X POST "$CLUSTER_URL" -H "$AUTH_HEADER")
-              CLUSTER_TOKEN=$(echo $RESP | sed 's/^.*"AuthToken":"\([^{"}]*\)".*$/\1/')
-              kubectl create secret generic \
-                --from-literal="token=$CLUSTER_TOKEN" \
-                -n {{ .Release.Namespace }} \
-                {{ include "insights-agent.fullname" . }}-token
-              echo "Created secret with auth token"
+              curl -X POST "$CLUSTER_URL" -H "$AUTH_HEADER" -o $CLUSTER_FILE
+            else
+              echo "Cluster already exists"
             fi
+            CLUSTER_TOKEN=$(cat $CLUSTER_FILE | sed 's/^.*"AuthToken":"\([^{"}]*\)".*$/\1/')
+            kubectl delete secret $SECRET_NAME || 1
+            kubectl create secret generic \
+              --from-literal="token=$CLUSTER_TOKEN" \
+              -n {{ .Release.Namespace }} \
+              $SECRET_NAME
+            echo "Created secret with auth token"
 
         resources:
           {{- toYaml .Values.cronjobExecutor.resources | nindent 10 }}

--- a/stable/insights-agent/templates/fleet-installer/job.yaml
+++ b/stable/insights-agent/templates/fleet-installer/job.yaml
@@ -1,0 +1,66 @@
+{{- if .Values.fleetInstall -}}
+{{- $_ := set . "Label" "fleet-installer" }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  {{- include "metadata" . }}
+    "helm.sh/hook-weight": "10"
+    "helm.sh/hook": pre-install
+    # "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+spec:
+  ttlSecondsAfterFinished: 3000
+  backoffLimit: {{ .Values.cronjobs.backoffLimit }}
+  template:
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{ include "insights-agent.fullname" . }}-fleet-installer
+      containers:
+      - name: fleet-installer
+        image: "{{ .Values.cronjobExecutor.image.repository }}:{{ .Values.cronjobExecutor.image.tag }}"
+        imagePullPolicy: Always
+        command: ["sh"]
+        args:
+          - -c
+          - |
+            echo "start!"
+            AUTH_HEADER="Authorization: Bearer $ADMIN_TOKEN"
+            echo "Auth $AUTH_HEADER"
+            CLUSTER_URL="{{ .Values.insights.host }}/v0/organizations/{{ .Values.insights.organization }}/clusters/{{ .Values.insights.cluster }}"
+            echo "url $CLUSTER_URL"
+            EXISTS=$(curl -s -o /dev/null -w "%{http_code}" "$CLUSTER_URL" -H "$AUTH_HEADER")
+            echo "Cluster exists? $EXISTS"
+            if [[ $EXISTS -eq 404 ]]; then
+              echo "Creating cluster..."
+              RESP=$(curl -X POST "$CLUSTER_URL" -H "$AUTH_HEADER")
+              CLUSTER_TOKEN=$(echo $RESP | sed 's/^.*"AuthToken":"\([^{"}]*\)".*$/\1/')
+              kubectl create secret generic \
+                --from-literal="token=$CLUSTER_TOKEN" \
+                -n {{ .Release.Namespace }} \
+                {{ include "insights-agent.fullname" . }}-token
+              echo "Created secret with auth token"
+            fi
+
+        resources:
+          {{- toYaml .Values.cronjobExecutor.resources | nindent 10 }}
+        env:
+          - name: ADMIN_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name:  {{ include "insights-agent.fullname" . }}-admin-token
+                key: token
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+        securityContext:
+          runAsUser: 1000
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+          privileged: false
+          runAsNonRoot: true
+          capabilities:
+            drop:
+              - ALL
+      volumes:
+      - name: tmp
+        emptyDir: {}
+{{- end -}}

--- a/stable/insights-agent/templates/fleet-installer/rbac.yaml
+++ b/stable/insights-agent/templates/fleet-installer/rbac.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.fleetInstall -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "insights-agent.fullname" . }}-fleet-installer
+  labels:
+    app: insights-agent
+  annotations:
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "insights-agent.fullname" . }}-fleet-installer
+  labels:
+    app: insights-agent
+  annotations:
+    "helm.sh/hook-weight": "2"
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "insights-agent.fullname" . }}-fleet-installer
+  labels:
+    app: insights-agent
+  annotations:
+    "helm.sh/hook-weight": "3"
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "insights-agent.fullname" . }}-fleet-installer
+subjects:
+- kind: ServiceAccount
+  name: {{ include "insights-agent.fullname" . }}-fleet-installer
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/stable/insights-agent/templates/fleet-installer/rbac.yaml
+++ b/stable/insights-agent/templates/fleet-installer/rbac.yaml
@@ -23,7 +23,7 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: ["secrets"]
-  verbs: ["create"]
+  verbs: ["create", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/stable/insights-agent/templates/token-secret.yaml
+++ b/stable/insights-agent/templates/token-secret.yaml
@@ -1,4 +1,4 @@
-{{ if not .Values.insights.tokenSecretName }}
+{{ if not (or .Values.insights.tokenSecretName .Values.insights.adminToken) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/stable/insights-agent/templates/token-secret.yaml
+++ b/stable/insights-agent/templates/token-secret.yaml
@@ -4,5 +4,5 @@ kind: Secret
 metadata:
   name: {{ include "insights-agent.fullname" . }}-token
 data:
-  token: {{ required "You must set base64token or tokenName" .Values.insights.base64token | quote }}
+  token: {{ required "You must set base64token or tokenSecretName" .Values.insights.base64token | quote }}
 {{ end }}


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

This add support for installing Insights across many clusters with a single admin token. This will obviate the need to log into the UI, add a cluster, and copy the access token for every cluster in your fleet.

Specifically, you can run:
```bash
helm upgrade --install insights-agent fairwinds-stable/insights-agent \
  --namespace insights-agent \
  --set polaris.enabled="true" \
  --set insights.organization="acme-co"  \
  --set insights.cluster="your-name-for-this-cluster" \
  --set insights.adminToken="thisisanadmintoken" \
  --set fleetInstall=true \
  --set insights.tokenSecretName=insights-agent-token
```

This will create the cluster if it doesn't already exist, or get the current token if it does.

On future runs, you can omit the admin token and `fleetInstall`, and simply run
```bash
helm upgrade --install insights-agent fairwinds-stable/insights-agent \
  --namespace insights-agent \
  --set polaris.enabled="true" \
  --set insights.organization="acme-co"  \
  --set insights.cluster="your-name-for-this-cluster" \
  --set insights.tokenSecretName=insights-agent-token
```


Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
