### PR TITLE
[vpa] Add automountServiceAccountToken to vpa certGen and cleanup

### DIFF
--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 0.3.2
+version: 0.3.3
 appVersion: 0.9.2
 maintainers:
   - name: sudermanjr

--- a/stable/vpa/templates/admission-controller-certgen.yaml
+++ b/stable/vpa/templates/admission-controller-certgen.yaml
@@ -2,6 +2,7 @@
 {{- if .Values.admissionController.generateCertificate }}
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 metadata:
   annotations:
     "helm.sh/hook": "pre-install,pre-upgrade"

--- a/stable/vpa/templates/admission-controller-cleanup.yaml
+++ b/stable/vpa/templates/admission-controller-cleanup.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.admissionController.cleanupOnDelete }}
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 metadata:
   annotations:
     "helm.sh/hook": "post-delete"


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Add ability to specify automountServiceAccountToken on the vpa certGen and cleanup service accounts

Fixes #

**Changes**
Changes proposed in this pull request:

* Apply serviceAccount.automountServiceAccountToken value to certGen and cleanup service accounts
*

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
