### PR TITLE
Add support for specifying affinity for dashboard and webhook pods

### DIFF
--- a/stable/polaris/Chart.yaml
+++ b/stable/polaris/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Validation of best practices in your Kubernetes clusters
 name: polaris
-version: 3.1.1
+version: 3.1.2
 appVersion: "3.1"
 icon: https://raw.githubusercontent.com/FairwindsOps/polaris/master/pkg/dashboard/assets/favicon-32x32.png
 maintainers:

--- a/stable/polaris/README.md
+++ b/stable/polaris/README.md
@@ -54,6 +54,7 @@ the 0.10.0 version of this chart will only work on kubernetes 1.14.0+
 | dashboard.service.annotations | object | `{}` | Service annotations |
 | dashboard.nodeSelector | object | `{}` | Dashboard pod nodeSelector |
 | dashboard.tolerations | list | `[]` | Dashboard pod tolerations |
+| dashboard.affinity | object | `{}` || Dashboard affinity |
 | dashboard.ingress.enabled | bool | `false` | Whether to enable ingress to the dashboard |
 | dashboard.ingress.hosts | list | `[]` | Web ingress hostnames |
 | dashboard.ingress.annotations | object | `{}` | Web ingress annotations |
@@ -63,6 +64,7 @@ the 0.10.0 version of this chart will only work on kubernetes 1.14.0+
 | webhook.replicas | int | `1` | Number of replicas |
 | webhook.nodeSelector | object | `{}` | Webhook pod nodeSelector |
 | webhook.tolerations | list | `[]` | Webhook pod tolerations |
+| webhook.affinity | object | `{}` || Webhook affinity |
 | webhook.caBundle | string | `nil` | CA Bundle to use for Validating Webhook instead of cert-manager |
 | webhook.secretName | string | `nil` | Name of the secret containing a TLS certificate to use if cert-manager is not used. |
 | webhook.failurePolicy | string | `"Fail"` | failurePolicy for the ValidatingWebhookConfiguration |

--- a/stable/polaris/README.md
+++ b/stable/polaris/README.md
@@ -54,7 +54,7 @@ the 0.10.0 version of this chart will only work on kubernetes 1.14.0+
 | dashboard.service.annotations | object | `{}` | Service annotations |
 | dashboard.nodeSelector | object | `{}` | Dashboard pod nodeSelector |
 | dashboard.tolerations | list | `[]` | Dashboard pod tolerations |
-| dashboard.affinity | object | `{}` || Dashboard pods affinity |
+| dashboard.affinity | object | `{}` | Dashboard pods affinity |
 | dashboard.ingress.enabled | bool | `false` | Whether to enable ingress to the dashboard |
 | dashboard.ingress.hosts | list | `[]` | Web ingress hostnames |
 | dashboard.ingress.annotations | object | `{}` | Web ingress annotations |
@@ -64,7 +64,7 @@ the 0.10.0 version of this chart will only work on kubernetes 1.14.0+
 | webhook.replicas | int | `1` | Number of replicas |
 | webhook.nodeSelector | object | `{}` | Webhook pod nodeSelector |
 | webhook.tolerations | list | `[]` | Webhook pod tolerations |
-| webhook.affinity | object | `{}` || Webhook pods affinity |
+| webhook.affinity | object | `{}` | Webhook pods affinity |
 | webhook.caBundle | string | `nil` | CA Bundle to use for Validating Webhook instead of cert-manager |
 | webhook.secretName | string | `nil` | Name of the secret containing a TLS certificate to use if cert-manager is not used. |
 | webhook.failurePolicy | string | `"Fail"` | failurePolicy for the ValidatingWebhookConfiguration |

--- a/stable/polaris/README.md
+++ b/stable/polaris/README.md
@@ -43,6 +43,7 @@ Parameter | Description | Default
 `dashboard.service.annotatotions` | Service annotations | {}
 `dashboard.nodeSelector` | Dashboard pod nodeSelector | {}
 `dashboard.tolerations` | Dashboard pod tolerations | []
+`dashboard.affinity` | Dashboard affinity settings | {} 
 `dashboard.ingress.enabled` | Whether to enable ingress to the dashboard | false
 `dashboard.ingress.hosts` | Web ingress hostnames | []
 `dashboard.ingress.tls` | ingress tls configuration |
@@ -53,6 +54,7 @@ Parameter | Description | Default
 `webhook.service.type` | Service type | ClusterIP
 `webhook.nodeSelector` | Webhook pod nodeSelector | {}
 `webhook.tolerations` | Webhook pod tolerations | []
+`webhook.affinity` | Webhook affinity settings | {}
 `audit.enable` | Runs a one-time audit. This is used internally at Fairwinds, and may not be useful for others | false
 `audit.outputURL` | A URL which will receive a POST request with audit results | ""
 `audit.cleanup` | Whether to delete the namespace once the audit is finished | false

--- a/stable/polaris/README.md
+++ b/stable/polaris/README.md
@@ -54,7 +54,7 @@ the 0.10.0 version of this chart will only work on kubernetes 1.14.0+
 | dashboard.service.annotations | object | `{}` | Service annotations |
 | dashboard.nodeSelector | object | `{}` | Dashboard pod nodeSelector |
 | dashboard.tolerations | list | `[]` | Dashboard pod tolerations |
-| dashboard.affinity | object | `{}` || Dashboard affinity |
+| dashboard.affinity | object | `{}` || Dashboard pods affinity |
 | dashboard.ingress.enabled | bool | `false` | Whether to enable ingress to the dashboard |
 | dashboard.ingress.hosts | list | `[]` | Web ingress hostnames |
 | dashboard.ingress.annotations | object | `{}` | Web ingress annotations |
@@ -64,7 +64,7 @@ the 0.10.0 version of this chart will only work on kubernetes 1.14.0+
 | webhook.replicas | int | `1` | Number of replicas |
 | webhook.nodeSelector | object | `{}` | Webhook pod nodeSelector |
 | webhook.tolerations | list | `[]` | Webhook pod tolerations |
-| webhook.affinity | object | `{}` || Webhook affinity |
+| webhook.affinity | object | `{}` || Webhook pods affinity |
 | webhook.caBundle | string | `nil` | CA Bundle to use for Validating Webhook instead of cert-manager |
 | webhook.secretName | string | `nil` | Name of the secret containing a TLS certificate to use if cert-manager is not used. |
 | webhook.failurePolicy | string | `"Fail"` | failurePolicy for the ValidatingWebhookConfiguration |

--- a/stable/polaris/templates/dashboard.deployment.yaml
+++ b/stable/polaris/templates/dashboard.deployment.yaml
@@ -86,4 +86,8 @@ spec:
       {{- with .Values.dashboard.tolerations }}
 {{ toYaml . | indent 6 }}
       {{- end }}
+{{- if .Values.dashboard.affinity }}
+      affinity:
+{{ toYaml .Values.dashboard.affinity | indent 8 }}
+{{- end }}      
 {{- end -}}

--- a/stable/polaris/templates/dashboard.deployment.yaml
+++ b/stable/polaris/templates/dashboard.deployment.yaml
@@ -97,4 +97,8 @@ spec:
       {{- with .Values.dashboard.tolerations }}
 {{ toYaml . | indent 6 }}
       {{- end }}
+{{- if .Values.dashboard.affinity }}
+      affinity:
+{{ toYaml .Values.dashboard.affinity | indent 8 }}
+{{- end }}      
 {{- end -}}

--- a/stable/polaris/templates/webhook.deployment.yaml
+++ b/stable/polaris/templates/webhook.deployment.yaml
@@ -89,6 +89,10 @@ spec:
       {{- with .Values.webhook.tolerations }}
 {{ toYaml . | indent 6 }}
       {{- end }}
+{{- if .Values.webhook.affinity }}
+      affinity:
+{{ toYaml .Values.webhook.affinity | indent 8 }}
+{{- end }}
       volumes:
         {{- with .Values.config }}
         - name: config

--- a/stable/polaris/templates/webhook.deployment.yaml
+++ b/stable/polaris/templates/webhook.deployment.yaml
@@ -92,6 +92,10 @@ spec:
       {{- with .Values.webhook.tolerations }}
 {{ toYaml . | indent 6 }}
       {{- end }}
+{{- if .Values.webhook.affinity }}
+      affinity:
+{{ toYaml .Values.webhook.affinity | indent 8 }}
+{{- end }}
       volumes:
         {{- with .Values.config }}
         - name: config

--- a/stable/polaris/values.yaml
+++ b/stable/polaris/values.yaml
@@ -24,6 +24,7 @@ dashboard:
     type: ClusterIP
     annotations: {}
   nodeSelector: {}
+  affinity: {}
   tolerations: []
   ingress:
     enabled: false
@@ -42,6 +43,7 @@ webhook:
   enable: false
   replicas: 1
   nodeSelector: {}
+  affinity: {}
   tolerations: []
   resources:
     requests:

--- a/stable/polaris/values.yaml
+++ b/stable/polaris/values.yaml
@@ -52,7 +52,7 @@ dashboard:
   nodeSelector: {}
   # dashboard.tolerations -- Dashboard pod tolerations
   tolerations: []
-  # dashboard.affinity -- Dashbaord pods affinity
+  # dashboard.affinity -- Dashboard pods affinity
   affinity: {}
   ingress:
     # dashboard.ingress.enabled -- Whether to enable ingress to the dashboard

--- a/stable/polaris/values.yaml
+++ b/stable/polaris/values.yaml
@@ -52,6 +52,7 @@ dashboard:
   nodeSelector: {}
   # dashboard.tolerations -- Dashboard pod tolerations
   tolerations: []
+  affinity: {}
   ingress:
     # dashboard.ingress.enabled -- Whether to enable ingress to the dashboard
     enabled: false
@@ -73,6 +74,7 @@ webhook:
   nodeSelector: {}
   # webhook.tolerations -- Webhook pod tolerations
   tolerations: []
+  affinity: {}  
   # webhook.caBundle -- CA Bundle to use for Validating Webhook instead of cert-manager
   caBundle: null
   # webhook.secretName -- Name of the secret containing a TLS certificate to use if cert-manager is not used.

--- a/stable/polaris/values.yaml
+++ b/stable/polaris/values.yaml
@@ -52,6 +52,7 @@ dashboard:
   nodeSelector: {}
   # dashboard.tolerations -- Dashboard pod tolerations
   tolerations: []
+  # dashboard.affinity -- Dashbaord pods affinity
   affinity: {}
   ingress:
     # dashboard.ingress.enabled -- Whether to enable ingress to the dashboard
@@ -74,7 +75,8 @@ webhook:
   nodeSelector: {}
   # webhook.tolerations -- Webhook pod tolerations
   tolerations: []
-  affinity: {}  
+  # webhook.affinity -- Webhook pods affinity
+  affinity: {}
   # webhook.caBundle -- CA Bundle to use for Validating Webhook instead of cert-manager
   caBundle: null
   # webhook.secretName -- Name of the secret containing a TLS certificate to use if cert-manager is not used.


### PR DESCRIPTION
**Why This PR?**
This PR will add support for specifying affinity to dashboard and webhook pods of Polaris. As such, not many people will need  podAffinity/podAntiAffinity because they will mostly run only single replica of dashboard and webhook. But it will be useful to specify nodeAffinity part of affinity settings like we do. As such using nodeSelector is deprecated, so we can remove that later as well in favour of affinity.

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
