### PR TITLE
[fairwinds-insights] add support for insights in readonly mode

### DIFF
--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "4.4.0"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 0.1.7
+version: 0.1.8
 maintainers:
 - name: rbren
 - name: makoscafee

--- a/stable/fairwinds-insights/templates/_env.yaml
+++ b/stable/fairwinds-insights/templates/_env.yaml
@@ -53,7 +53,7 @@ env:
   value: {{ .Values.postgresql.sslMode | default "require" }}
 - name: POSTGRES_HOST
   value: {{ .Values.postgresql.postgresqlHost | default (printf "%s-%s" .Release.Name "postgresql") }}
-{{- if .Values.fairwindsInsights.postgresql.readOnly }}
+{{- if .Values.postgresql.readOnly }}
 - name: POSTGRES_PASSWORD
   valueFrom:
     secretKeyRef:

--- a/stable/fairwinds-insights/templates/_env.yaml
+++ b/stable/fairwinds-insights/templates/_env.yaml
@@ -53,11 +53,19 @@ env:
   value: {{ .Values.postgresql.sslMode | default "require" }}
 - name: POSTGRES_HOST
   value: {{ .Values.postgresql.postgresqlHost | default (printf "%s-%s" .Release.Name "postgresql") }}
+{{- if .Values.fairwindsInsights.postgresql.readOnly }}
 - name: POSTGRES_PASSWORD
   valueFrom:
     secretKeyRef:
-      name: {{ .Values.postgresql.existingSecret }}
+      name: {{ .Values.fairwindsInsights.postgresql.existingSecret }}
+      key: readonly-password
+{{- else }}
+- name: POSTGRES_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.fairwindsInsights.postgresql.existingSecret }}
       key: postgresql-password
+{{- end }}
 {{- with .Values.options.insightsSAASHost }}
 - name: INSIGHTS_SAAS_HOST
   value: {{ . | quote }}

--- a/stable/fairwinds-insights/templates/_env.yaml
+++ b/stable/fairwinds-insights/templates/_env.yaml
@@ -57,13 +57,13 @@ env:
 - name: POSTGRES_PASSWORD
   valueFrom:
     secretKeyRef:
-      name: {{ .Values.fairwindsInsights.postgresql.existingSecret }}
+      name: {{ .Values.postgresql.existingSecret }}
       key: readonly-password
 {{- else }}
 - name: POSTGRES_PASSWORD
   valueFrom:
     secretKeyRef:
-      name: {{ .Values.fairwindsInsights.postgresql.existingSecret }}
+      name: {{ .Values.postgresql.existingSecret }}
       key: postgresql-password
 {{- end }}
 {{- with .Values.options.insightsSAASHost }}


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [ ] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
