### PR TITLE
[Astro] allow passing env variables to deployment

### DIFF
--- a/stable/astro/Chart.yaml
+++ b/stable/astro/Chart.yaml
@@ -1,5 +1,5 @@
 name: astro
-version: 1.0.7
+version: 1.0.8
 apiVersion: v1
 appVersion: "1.5.3"
 description: Emit datadog monitors based on kubernetes state.

--- a/stable/astro/README.md
+++ b/stable/astro/README.md
@@ -34,23 +34,24 @@ Kubernetes 1.11+, Helm 2.13+
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| image.repository | string | `"quay.io/fairwinds/astro"` | Docker image repo |
-| image.tag | string | `"v1.5.3"` | Docker image tag |
-| image.pullPolicy | string | `"IfNotPresent"` | Docker image pull policy |
-| resources | object | `{"limits":{"cpu":"100m","memory":"128Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | The resources block for the deployment. |
-| nodeSelector | object | `{}` | Deployment ndoeSelector |
-| tolerations | list | `[]` | Deployment tolerations |
 | affinity | object | `{}` | Deployment affinity |
+| custom_config.data | string | "" | An astro configuration file. See the [Astro repo readme](https://github.com/fairwindsops/astro) for more details. |
+| custom_config.enabled | bool | `false` | If true a custom configuration must be specified in `custom_config.data`. |
 | datadog.apiKey | string | `""` | Datadog API key |
 | datadog.appKey | string | `""` | Datadog app key |
-| rbac.create | bool | `true` | If true, RBAC resources will be created. |
+| definitionsPath | string | `"conf.yml"` | The path to the monitor definitions configuration. This can be a local path or a URL. |
+| deployment.env | string | `nil` | Map of key value pairs for environment variables to pass into deployment. Ex.: env:   THING: value   THING2: value2 |
+| deployment.replicas | int | `2` | The number of replicas to use. |
 | deployment.serviceAccount.create | bool | `true` | If true, a service account will be created. If false, you must set `deployment.serviceAccount.name`. |
 | deployment.serviceAccount.name | string | `nil` | The name of an existing service account to use. |
-| deployment.replicas | int | `2` | The number of replicas to use. |
+| dryRun | bool | `false` | When set to true monitors will not be managed in datadog. |
+| image.pullPolicy | string | `"IfNotPresent"` | Docker image pull policy |
+| image.repository | string | `"quay.io/fairwinds/astro"` | Docker image repo |
+| image.tag | string | `"v1.5.3"` | Docker image tag |
+| nodeSelector | object | `{}` | Deployment ndoeSelector |
+| owner | string | `"astro"` | A unique name to designate as teh owner. This will be applied as a tag to identified managed monitors. |
+| rbac.create | bool | `true` | If true, RBAC resources will be created. |
+| resources | object | `{"limits":{"cpu":"100m","memory":"128Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | The resources block for the deployment. |
 | secret.create | bool | `true` | If true, a secret with API credentials will be created. If false, you must set `secret.name` |
 | secret.name | string | `nil` | The name of an existing secret to mount to the container. |
-| definitionsPath | string | `"conf.yml"` | The path to the monitor definitions configuration. This can be a local path or a URL. |
-| owner | string | `"astro"` | A unique name to designate as teh owner. This will be applied as a tag to identified managed monitors. |
-| dryRun | bool | `false` | When set to true monitors will not be managed in datadog. |
-| custom_config.enabled | bool | `false` | If true a custom configuration must be specified in `custom_config.data`. |
-| custom_config.data | string | "" | An astro configuration file. See the [Astro repo readme](https://github.com/fairwindsops/astro) for more details. |
+| tolerations | list | `[]` | Deployment tolerations |

--- a/stable/astro/README.md
+++ b/stable/astro/README.md
@@ -34,24 +34,24 @@ Kubernetes 1.11+, Helm 2.13+
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| affinity | object | `{}` | Deployment affinity |
-| custom_config.data | string | "" | An astro configuration file. See the [Astro repo readme](https://github.com/fairwindsops/astro) for more details. |
-| custom_config.enabled | bool | `false` | If true a custom configuration must be specified in `custom_config.data`. |
-| datadog.apiKey | string | `""` | Datadog API key |
-| datadog.appKey | string | `""` | Datadog app key |
-| definitionsPath | string | `"conf.yml"` | The path to the monitor definitions configuration. This can be a local path or a URL. |
-| deployment.env | string | `nil` | Map of key value pairs for environment variables to pass into deployment. Ex.: env:   THING: value   THING2: value2 |
-| deployment.replicas | int | `2` | The number of replicas to use. |
-| deployment.serviceAccount.create | bool | `true` | If true, a service account will be created. If false, you must set `deployment.serviceAccount.name`. |
-| deployment.serviceAccount.name | string | `nil` | The name of an existing service account to use. |
-| dryRun | bool | `false` | When set to true monitors will not be managed in datadog. |
-| image.pullPolicy | string | `"IfNotPresent"` | Docker image pull policy |
 | image.repository | string | `"quay.io/fairwinds/astro"` | Docker image repo |
 | image.tag | string | `"v1.5.3"` | Docker image tag |
-| nodeSelector | object | `{}` | Deployment ndoeSelector |
-| owner | string | `"astro"` | A unique name to designate as teh owner. This will be applied as a tag to identified managed monitors. |
-| rbac.create | bool | `true` | If true, RBAC resources will be created. |
+| image.pullPolicy | string | `"IfNotPresent"` | Docker image pull policy |
 | resources | object | `{"limits":{"cpu":"100m","memory":"128Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | The resources block for the deployment. |
+| nodeSelector | object | `{}` | Deployment ndoeSelector |
+| tolerations | list | `[]` | Deployment tolerations |
+| affinity | object | `{}` | Deployment affinity |
+| datadog.apiKey | string | `""` | Datadog API key |
+| datadog.appKey | string | `""` | Datadog app key |
+| rbac.create | bool | `true` | If true, RBAC resources will be created. |
+| deployment.env | string | `nil` | Map of key value pairs for environment variables to pass into deployment. Ex.: env:   THING: value   THING2: value2 |
+| deployment.serviceAccount.create | bool | `true` | If true, a service account will be created. If false, you must set `deployment.serviceAccount.name`. |
+| deployment.serviceAccount.name | string | `nil` | The name of an existing service account to use. |
+| deployment.replicas | int | `2` | The number of replicas to use. |
 | secret.create | bool | `true` | If true, a secret with API credentials will be created. If false, you must set `secret.name` |
 | secret.name | string | `nil` | The name of an existing secret to mount to the container. |
-| tolerations | list | `[]` | Deployment tolerations |
+| definitionsPath | string | `"conf.yml"` | The path to the monitor definitions configuration. This can be a local path or a URL. |
+| owner | string | `"astro"` | A unique name to designate as teh owner. This will be applied as a tag to identified managed monitors. |
+| dryRun | bool | `false` | When set to true monitors will not be managed in datadog. |
+| custom_config.enabled | bool | `false` | If true a custom configuration must be specified in `custom_config.data`. |
+| custom_config.data | string | "" | An astro configuration file. See the [Astro repo readme](https://github.com/fairwindsops/astro) for more details. |

--- a/stable/astro/templates/deployment.yaml
+++ b/stable/astro/templates/deployment.yaml
@@ -37,6 +37,13 @@ spec:
             - --namespace={{ .Release.Namespace }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- if .Values.deployment.env }}
+          env:
+          {{- range $key, $value := .Values.deployment.env }}
+          - name: {{ $key }}
+            value: {{ $value | quote }}
+          {{- end }}
+          {{- end }}
           envFrom:
           - configMapRef:
               name: {{ include "astro.fullname" . }}

--- a/stable/astro/values.yaml
+++ b/stable/astro/values.yaml
@@ -28,6 +28,12 @@ rbac:
   # -- If true, RBAC resources will be created.
   create: true
 deployment:
+  # -- Map of key value pairs for environment variables to pass into deployment.
+  # Ex.:
+  # env:
+  #   THING: value
+  #   THING2: value2
+  env:
   serviceAccount:
     # -- If true, a service account will be created. If false, you must set `deployment.serviceAccount.name`.
     create: true


### PR DESCRIPTION
**Why This PR?**
This allows passing env variables to the Astro deployment

Fixes #
In order to create monitors in an EU Datadog account, we need to allow
passing the following env var:

```yaml
env:
  name: DATADOG_HOST
  value: https://api.datadoghq.eu
```

**Changes**
Changes proposed in this pull request:

* new `deployment.env` setting in the values file. Should be set as a
  map of key,value pairs
* Updated chart version

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.