### PR TITLE
Remove default runAsUser

### DIFF
--- a/stable/goldilocks/Chart.yaml
+++ b/stable/goldilocks/Chart.yaml
@@ -4,7 +4,7 @@ description: |
   A Helm chart for running Fairwinds Goldilocks. See https://github.com/FairwindsOps/goldilocks
 name: goldilocks
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/goldilocks/icon.png
-version: 3.2.1
+version: 3.2.2
 maintainers:
   - name: sudermanjr
   - name: lucasreed

--- a/stable/goldilocks/templates/controller-deployment.yaml
+++ b/stable/goldilocks/templates/controller-deployment.yaml
@@ -41,8 +41,10 @@ spec:
             {{- range $name, $value := .Values.controller.flags }}
             - --{{ $name }}={{ $value }}
             {{- end }}
+        {{- if .Values.controller.securityContext }}
           securityContext:
             {{- toYaml .Values.controller.securityContext | nindent 12 }}
+        {{- end }}
           resources:
             {{- toYaml .Values.controller.resources | nindent 12 }}
       {{- with .Values.controller.nodeSelector }}

--- a/stable/goldilocks/templates/dashboard-deployment.yaml
+++ b/stable/goldilocks/templates/dashboard-deployment.yaml
@@ -39,8 +39,10 @@ spec:
             - dashboard
             - --exclude-containers={{ .Values.dashboard.excludeContainers }}
             - -v{{ .Values.dashboard.logVerbosity }}
+        {{- if .Values.dashboard.securityContext }}
           securityContext:
             {{- toYaml .Values.dashboard.securityContext | nindent 12 }}
+        {{- end }}
           ports:
             - name: http
               containerPort: 8080


### PR DESCRIPTION
 **Why This PR?**

Same as in https://github.com/FairwindsOps/charts/pull/271/files - fixed runAsUser breaks deployments on OpenShift. Alternative, I can adjust the code to allow skipping security context completely.