### PR TITLE
Add PDB for VPA admission-controller

### DIFF
--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 0.3.4
+version: 0.3.5
 appVersion: 0.9.2
 maintainers:
   - name: sudermanjr

--- a/stable/vpa/README.md
+++ b/stable/vpa/README.md
@@ -95,6 +95,7 @@ recommender:
 | admissionController.certGen.env | object | `{}` | Additional environment variables to be added to the certgen container. Format is KEY: Value format |
 | admissionController.cleanupOnDelete | bool | `true` | If true, a post-delete job will remove the mutatingwebhookconfiguration and the tls secret for the admission controller |
 | admissionController.replicaCount | int | `1` |  |
+| admissionController.maxUnavailable | int | `1` | This is the max unavailable setting for the pod disruption budget |
 | admissionController.image.repository | string | `"us.gcr.io/k8s-artifacts-prod/autoscaling/vpa-admission-controller"` | The location of the vpa admission controller image |
 | admissionController.image.pullPolicy | string | `"Always"` | The pull policy for the admission controller image. Recommend not changing this |
 | admissionController.image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion |

--- a/stable/vpa/templates/admission-controller-pdb.yaml
+++ b/stable/vpa/templates/admission-controller-pdb.yaml
@@ -1,0 +1,13 @@
+---
+{{- if .Values.admissionController.maxUnavailable }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: "{{ template "vpa.fullname" . }}-admission-controller-pdb"
+spec:
+  maxUnavailable: {{ .Values.admissionController.maxUnavailable }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: admission-controller
+      app.kubernetes.io/name: {{ template "vpa.fullname" . }}
+{{- end }}

--- a/stable/vpa/values.yaml
+++ b/stable/vpa/values.yaml
@@ -115,6 +115,8 @@ admissionController:
   # admissionController.cleanupOnDelete -- If true, a post-delete job will remove the mutatingwebhookconfiguration and the tls secret for the admission controller
   cleanupOnDelete: true
   replicaCount: 1
+  # admissionController.maxUnavailable -- This is the max unavailable setting for the pod disruption budget
+  maxUnavailable: 1
   image:
     # admissionController.image.repository -- The location of the vpa admission controller image
     repository: us.gcr.io/k8s-artifacts-prod/autoscaling/vpa-admission-controller


### PR DESCRIPTION
**Why This PR?**

Adds PDB for vpa-admission-controller

Fixes #509 

**Changes**
Changes proposed in this pull request:

* PDB for vpa-admission-controller with a default of maxUnavailable 1

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
