### PR TITLE
Add PDB for VPA admission-controller

### DIFF
--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 0.3.4
+version: 0.4.0
 appVersion: 0.9.2
 maintainers:
   - name: sudermanjr

--- a/stable/vpa/README.md
+++ b/stable/vpa/README.md
@@ -60,7 +60,7 @@ recommender:
 | recommender.enabled | bool | `true` | If true, the vpa recommender component will be installed. |
 | recommender.extraArgs | object | `{"pod-recommendation-min-cpu-millicores":15,"pod-recommendation-min-memory-mb":100,"v":"4"}` | A set of key-value flags to be passed to the recommender |
 | recommender.replicaCount | int | `1` |  |
-| recommender.podDisruptionBudget | object | `{}` | This is the configuration for the pod disruption budget |
+| recommender.podDisruptionBudget | object | `{}` | This is the setting for the pod disruption budget |
 | recommender.image.repository | string | `"us.gcr.io/k8s-artifacts-prod/autoscaling/vpa-recommender"` | The location of the recommender image |
 | recommender.image.pullPolicy | string | `"Always"` | The pull policy for the recommender image. Recommend not changing this |
 | recommender.image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion |
@@ -75,7 +75,7 @@ recommender:
 | updater.enabled | bool | `true` | If true, the updater component will be deployed |
 | updater.extraArgs | object | `{}` | A key-value map of flags to pass to the updater |
 | updater.replicaCount | int | `1` |  |
-| updater.podDisruptionBudget | object | `{}` | This is the configuration for the pod disruption budget |
+| updater.podDisruptionBudget | object | `{}` | This is the setting for the pod disruption budget |
 | updater.image.repository | string | `"us.gcr.io/k8s-artifacts-prod/autoscaling/vpa-updater"` | The location of the updater image |
 | updater.image.pullPolicy | string | `"Always"` | The pull policy for the updater image. Recommend not changing this |
 | updater.image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion |
@@ -95,7 +95,7 @@ recommender:
 | admissionController.certGen.env | object | `{}` | Additional environment variables to be added to the certgen container. Format is KEY: Value format |
 | admissionController.cleanupOnDelete | bool | `true` | If true, a post-delete job will remove the mutatingwebhookconfiguration and the tls secret for the admission controller |
 | admissionController.replicaCount | int | `1` |  |
-| admissionController.podDisruptionBudget | object | `{}` | This is the configuration for the pod disruption budget |
+| admissionController.podDisruptionBudget | object | `{}` | This is the setting for the pod disruption budget |
 | admissionController.image.repository | string | `"us.gcr.io/k8s-artifacts-prod/autoscaling/vpa-admission-controller"` | The location of the vpa admission controller image |
 | admissionController.image.pullPolicy | string | `"Always"` | The pull policy for the admission controller image. Recommend not changing this |
 | admissionController.image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion |

--- a/stable/vpa/README.md
+++ b/stable/vpa/README.md
@@ -60,7 +60,7 @@ recommender:
 | recommender.enabled | bool | `true` | If true, the vpa recommender component will be installed. |
 | recommender.extraArgs | object | `{"pod-recommendation-min-cpu-millicores":15,"pod-recommendation-min-memory-mb":100,"v":"4"}` | A set of key-value flags to be passed to the recommender |
 | recommender.replicaCount | int | `1` |  |
-| recommender.maxUnavailable | int | `1` | This is the max unavailable setting for the pod disruption budget |
+| recommender.podDisruptionBudget | object | `{}` | This is the configuration for the pod disruption budget |
 | recommender.image.repository | string | `"us.gcr.io/k8s-artifacts-prod/autoscaling/vpa-recommender"` | The location of the recommender image |
 | recommender.image.pullPolicy | string | `"Always"` | The pull policy for the recommender image. Recommend not changing this |
 | recommender.image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion |
@@ -75,7 +75,7 @@ recommender:
 | updater.enabled | bool | `true` | If true, the updater component will be deployed |
 | updater.extraArgs | object | `{}` | A key-value map of flags to pass to the updater |
 | updater.replicaCount | int | `1` |  |
-| updater.maxUnavailable | int | `1` | This is the max unavailable setting for the pod disruption budget |
+| updater.podDisruptionBudget | object | `{}` | This is the configuration for the pod disruption budget |
 | updater.image.repository | string | `"us.gcr.io/k8s-artifacts-prod/autoscaling/vpa-updater"` | The location of the updater image |
 | updater.image.pullPolicy | string | `"Always"` | The pull policy for the updater image. Recommend not changing this |
 | updater.image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion |
@@ -95,6 +95,7 @@ recommender:
 | admissionController.certGen.env | object | `{}` | Additional environment variables to be added to the certgen container. Format is KEY: Value format |
 | admissionController.cleanupOnDelete | bool | `true` | If true, a post-delete job will remove the mutatingwebhookconfiguration and the tls secret for the admission controller |
 | admissionController.replicaCount | int | `1` |  |
+| admissionController.podDisruptionBudget | object | `{}` | This is the configuration for the pod disruption budget |
 | admissionController.image.repository | string | `"us.gcr.io/k8s-artifacts-prod/autoscaling/vpa-admission-controller"` | The location of the vpa admission controller image |
 | admissionController.image.pullPolicy | string | `"Always"` | The pull policy for the admission controller image. Recommend not changing this |
 | admissionController.image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion |

--- a/stable/vpa/templates/admission-controller-pdb.yaml
+++ b/stable/vpa/templates/admission-controller-pdb.yaml
@@ -1,0 +1,13 @@
+---
+{{- if and .Values.admissionController.podDisruptionBudget (gt (int .Values.admissionController.replicaCount) 1) }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: "{{ template "vpa.fullname" . }}-admission-controller-pdb"
+spec:
+  {{- toYaml .Values.admissionController.podDisruptionBudget | nindent 2 }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: admission-controller
+      app.kubernetes.io/name: {{ template "vpa.fullname" . }}
+{{- end }}

--- a/stable/vpa/templates/recommender-pdb.yaml
+++ b/stable/vpa/templates/recommender-pdb.yaml
@@ -1,11 +1,11 @@
 ---
-{{- if .Values.recommender.maxUnavailable }}
+{{- if and .Values.recommender.podDisruptionBudget (gt (int .Values.recommender.replicaCount) 1) }}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: "{{ template "vpa.fullname" . }}-recommender-pdb"
 spec:
-  maxUnavailable: {{ .Values.recommender.maxUnavailable }}
+  {{- toYaml .Values.recommender.podDisruptionBudget | nindent 2 }}
   selector:
     matchLabels:
       app.kubernetes.io/component: recommender

--- a/stable/vpa/templates/updater-pdb.yaml
+++ b/stable/vpa/templates/updater-pdb.yaml
@@ -1,11 +1,11 @@
 ---
-{{- if .Values.updater.maxUnavailable }}
+{{- if and .Values.updater.podDisruptionBudget (gt (int .Values.updater.replicaCount) 1) }}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: "{{ template "vpa.fullname" . }}-updater-pdb"
 spec:
-  maxUnavailable: {{ .Values.updater.maxUnavailable }}
+  {{- toYaml .Values.updater.podDisruptionBudget | nindent 2 }}
   selector:
     matchLabels:
       app.kubernetes.io/component: updater

--- a/stable/vpa/values.yaml
+++ b/stable/vpa/values.yaml
@@ -33,7 +33,7 @@ recommender:
     pod-recommendation-min-cpu-millicores: 15
     pod-recommendation-min-memory-mb: 100
   replicaCount: 1
-  # recommender.podDisruptionBudget -- This is the setting for the pod disruption budget.
+  # recommender.podDisruptionBudget -- This is the setting for the pod disruption budget
   podDisruptionBudget: {}
     # maxUnavailable: 1
   image:

--- a/stable/vpa/values.yaml
+++ b/stable/vpa/values.yaml
@@ -33,8 +33,9 @@ recommender:
     pod-recommendation-min-cpu-millicores: 15
     pod-recommendation-min-memory-mb: 100
   replicaCount: 1
-  # recommender.maxUnavailable -- This is the max unavailable setting for the pod disruption budget
-  maxUnavailable: 1
+  # recommender.podDisruptionBudget -- This is the setting for the pod disruption budget
+  podDisruptionBudget: {}
+    # maxUnavailable: 1
   image:
     # recommender.image.repository -- The location of the recommender image
     repository: us.gcr.io/k8s-artifacts-prod/autoscaling/vpa-recommender
@@ -68,8 +69,9 @@ updater:
   # updater.extraArgs -- A key-value map of flags to pass to the updater
   extraArgs: {}
   replicaCount: 1
-  # updater.maxUnavailable -- This is the max unavailable setting for the pod disruption budget
-  maxUnavailable: 1
+  # updater.podDisruptionBudget -- This is the setting for the pod disruption budget
+  podDisruptionBudget: {}
+    # maxUnavailable: 1
   image:
     # updater.image.repository -- The location of the updater image
     repository: us.gcr.io/k8s-artifacts-prod/autoscaling/vpa-updater
@@ -115,6 +117,9 @@ admissionController:
   # admissionController.cleanupOnDelete -- If true, a post-delete job will remove the mutatingwebhookconfiguration and the tls secret for the admission controller
   cleanupOnDelete: true
   replicaCount: 1
+  # admissionController.podDisruptionBudget -- This is the setting for the pod disruption budget
+  podDisruptionBudget: {}
+    # maxUnavailable: 1
   image:
     # admissionController.image.repository -- The location of the vpa admission controller image
     repository: us.gcr.io/k8s-artifacts-prod/autoscaling/vpa-admission-controller

--- a/stable/vpa/values.yaml
+++ b/stable/vpa/values.yaml
@@ -33,7 +33,7 @@ recommender:
     pod-recommendation-min-cpu-millicores: 15
     pod-recommendation-min-memory-mb: 100
   replicaCount: 1
-  # recommender.podDisruptionBudget -- This is the setting for the pod disruption budget
+  # recommender.podDisruptionBudget -- This is the setting for the pod disruption budget.
   podDisruptionBudget: {}
     # maxUnavailable: 1
   image:


### PR DESCRIPTION
**Why This PR?**

Adds PDB for vpa-admission-controller. Makes the PDB configuration of recommender and updater more flexible.

Fixes #509. Addresses queries raised in #510 

**Changes**
Changes proposed in this pull request:

* Have the ability to define PDB with minAvailable or maxUnavailable
* Create a PDB only if replicaCount is greater than 1. If the deployment is not running HA in the first place, we do not need a PDB.

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
