### PR TITLE
[vpa] Add container resource configuration to vpa certGen

### DIFF
--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 0.3.4
+version: 0.3.5
 appVersion: 0.9.2
 maintainers:
   - name: sudermanjr

--- a/stable/vpa/README.md
+++ b/stable/vpa/README.md
@@ -93,6 +93,7 @@ recommender:
 | admissionController.certGen.image.tag | string | `"v11-alpine"` | An image tag for the admissionController.certGen.image.repository image. Only used if admissionController.generateCertificate is true |
 | admissionController.certGen.image.pullPolicy | string | `"Always"` | The pull policy for the certgen image. Recommend not changing this |
 | admissionController.certGen.env | object | `{}` | Additional environment variables to be added to the certgen container. Format is KEY: Value format |
+| admissionController.certGen.resources | object | `{}` | The resources block for the certgen pod |
 | admissionController.cleanupOnDelete | bool | `true` | If true, a post-delete job will remove the mutatingwebhookconfiguration and the tls secret for the admission controller |
 | admissionController.replicaCount | int | `1` |  |
 | admissionController.image.repository | string | `"us.gcr.io/k8s-artifacts-prod/autoscaling/vpa-admission-controller"` | The location of the vpa admission controller image |

--- a/stable/vpa/templates/admission-controller-certgen.yaml
+++ b/stable/vpa/templates/admission-controller-certgen.yaml
@@ -123,5 +123,7 @@ spec:
           - name: {{ $key }}
             value: {{ $value | quote }}
           {{- end }}
+        resources:
+            {{- toYaml .Values.admissionController.certGen.resources | nindent 10 }}
 {{- end }}
 {{- end }}

--- a/stable/vpa/values.yaml
+++ b/stable/vpa/values.yaml
@@ -112,6 +112,8 @@ admissionController:
       pullPolicy: Always
       # admissionController.certGen.env -- Additional environment variables to be added to the certgen container. Format is KEY: Value format
     env: {}
+    # admissionController.certGen.resources -- The resources block for the certgen pod
+    resources: {}
   # admissionController.cleanupOnDelete -- If true, a post-delete job will remove the mutatingwebhookconfiguration and the tls secret for the admission controller
   cleanupOnDelete: true
   replicaCount: 1


### PR DESCRIPTION
**Why This PR?**

Add ability to specify the resource limits and requests for vpa certGen

Fixes #

**Changes**
Changes proposed in this pull request:

* Add resources block to vpa certGen container
*

**Checklist:**

* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
