### PR TITLE
add irsa_arn_annotation

### DIFF
--- a/stable/fairwinds-insights/templates/rbac.yaml
+++ b/stable/fairwinds-insights/templates/rbac.yaml
@@ -2,6 +2,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "fairwinds-insights.fullname" . }}-insights
+  {{- if .Values.additioanalEnvironmentVariables.ENABLE_IRP }}
+  annotations:
+    eks.amazonaws.com/role-arn: {{ .Values.options.irsa_role_arn }}
+  {{- end }}
 ---
 {{- if .Values.options.insightsSAASHost }}
 apiVersion: rbac.authorization.k8s.io/v1

--- a/stable/fairwinds-insights/templates/rbac.yaml
+++ b/stable/fairwinds-insights/templates/rbac.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "fairwinds-insights.fullname" . }}-insights
-  {{- if .Values.additioanalEnvironmentVariables.ENABLE_IRP }}
+  {{- if .Values.additionalEnvironmentVariables.ENABLE_IRP }}
   annotations:
     eks.amazonaws.com/role-arn: {{ .Values.options.irsa_role_arn }}
   {{- end }}


### PR DESCRIPTION
**Why This PR?**
When using IRSA you need to annotate the serviceaccount with the irsa_role_arn.  See here: https://docs.aws.amazon.com/eks/latest/userguide/specify-service-account-role.html

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [ ] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
