### PR TITLE
[fairwinds-insights] add support for dual ingress

### DIFF
--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "4.4.0"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 0.2.6
+version: 0.2.7
 maintainers:
 - name: rbren
 - name: makoscafee

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "4.4.0"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 0.2.7
+version: 0.2.8
 maintainers:
 - name: rbren
 - name: makoscafee

--- a/stable/fairwinds-insights/ci/test-values.yaml
+++ b/stable/fairwinds-insights/ci/test-values.yaml
@@ -1,4 +1,5 @@
 ingress:
+  enabled: true
   hostedZones:
   - test.cluster.local
 

--- a/stable/fairwinds-insights/templates/ingress.yaml
+++ b/stable/fairwinds-insights/templates/ingress.yaml
@@ -1,12 +1,12 @@
 {{- if .Values.ingress.enabled }}
 {{- $fullName := include "fairwinds-insights.fullname" . -}}
+{{- if not .Values.ingress.separate }}
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
   labels:
     {{- include "fairwinds-insights.labels" . | nindent 4 }}
-    app.kubernetes.io/component: ingress-api
   annotations:
     {{ with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
@@ -45,4 +45,83 @@ spec:
             path: /
             {{ end }}
     {{- end }}
+{{- else }}
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}-api
+  labels:
+    {{- include "fairwinds-insights.labels" . | nindent 4 }}
+  annotations:
+    {{ with .Values.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{ end }}
+    {{- if .Values.ingress.api }}
+    {{ with .Values.ingress.api.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{ end }}
+    {{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+    - secretName: {{ $fullName }}-cert
+      hosts:
+        {{- range .Values.ingress.hostedZones }}
+        - {{ include "fairwinds-insights.sanitizedPrefix" $ }}{{ . }}
+        {{- end }}
+{{- end }}
+  rules:
+    {{- range .Values.ingress.hostedZones }}
+    - host: {{ include "fairwinds-insights.sanitizedPrefix" $ }}{{ . }}
+      http:
+        paths:
+          - backend:
+              serviceName: {{ $fullName }}-api
+              servicePort: http
+            {{ if $.Values.ingress.starPaths }}
+            path: /v0/*
+            {{ else }}
+            path: /v0
+            {{ end }}
+    {{- end }}
+---
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}-dashboard
+  labels:
+    {{- include "fairwinds-insights.labels" . | nindent 4 }}
+  annotations:
+    {{ with .Values.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{ end }}
+    {{- if .Values.ingress.dashboard }}
+    {{ with .Values.ingress.dashboard.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{ end }}
+    {{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+    - secretName: {{ $fullName }}-cert
+      hosts:
+        {{- range .Values.ingress.hostedZones }}
+        - {{ include "fairwinds-insights.sanitizedPrefix" $ }}{{ . }}
+        {{- end }}
+{{- end }}
+  rules:
+    {{- range .Values.ingress.hostedZones }}
+    - host: {{ include "fairwinds-insights.sanitizedPrefix" $ }}{{ . }}
+      http:
+        paths:
+          - backend:
+              serviceName: {{ $fullName }}-dashboard
+              servicePort: http
+            {{ if $.Values.ingress.starPaths }}
+            path: /*
+            {{ else }}
+            path: /
+            {{ end }}
+    {{- end }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [ ] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
