### PR TITLE
Switch default VPA images to use k8s.gcr.io vanity domain

### DIFF
--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 0.4.3
+version: 0.4.4
 appVersion: 0.9.2
 maintainers:
   - name: sudermanjr

--- a/stable/vpa/README.md
+++ b/stable/vpa/README.md
@@ -61,7 +61,7 @@ recommender:
 | recommender.extraArgs | object | `{"pod-recommendation-min-cpu-millicores":15,"pod-recommendation-min-memory-mb":100,"v":"4"}` | A set of key-value flags to be passed to the recommender |
 | recommender.replicaCount | int | `1` |  |
 | recommender.podDisruptionBudget | object | `{}` | This is the setting for the pod disruption budget |
-| recommender.image.repository | string | `"us.gcr.io/k8s-artifacts-prod/autoscaling/vpa-recommender"` | The location of the recommender image |
+| recommender.image.repository | string | `"k8s.gcr.io/autoscaling/vpa-recommender"` | The location of the recommender image |
 | recommender.image.pullPolicy | string | `"Always"` | The pull policy for the recommender image. Recommend not changing this |
 | recommender.image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion |
 | recommender.podAnnotations | object | `{}` | Annotations to add to the recommender pod |
@@ -76,7 +76,7 @@ recommender:
 | updater.extraArgs | object | `{}` | A key-value map of flags to pass to the updater |
 | updater.replicaCount | int | `1` |  |
 | updater.podDisruptionBudget | object | `{}` | This is the setting for the pod disruption budget |
-| updater.image.repository | string | `"us.gcr.io/k8s-artifacts-prod/autoscaling/vpa-updater"` | The location of the updater image |
+| updater.image.repository | string | `"k8s.gcr.io/autoscaling/vpa-updater"` | The location of the updater image |
 | updater.image.pullPolicy | string | `"Always"` | The pull policy for the updater image. Recommend not changing this |
 | updater.image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion |
 | updater.podAnnotations | object | `{}` | Annotations to add to the updater pod |
@@ -97,7 +97,7 @@ recommender:
 | admissionController.cleanupOnDelete | bool | `true` | If true, a post-delete job will remove the mutatingwebhookconfiguration and the tls secret for the admission controller |
 | admissionController.replicaCount | int | `1` |  |
 | admissionController.podDisruptionBudget | object | `{}` | This is the setting for the pod disruption budget |
-| admissionController.image.repository | string | `"us.gcr.io/k8s-artifacts-prod/autoscaling/vpa-admission-controller"` | The location of the vpa admission controller image |
+| admissionController.image.repository | string | `"k8s.gcr.io/autoscaling/vpa-admission-controller"` | The location of the vpa admission controller image |
 | admissionController.image.pullPolicy | string | `"Always"` | The pull policy for the admission controller image. Recommend not changing this |
 | admissionController.image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion |
 | admissionController.podAnnotations | object | `{}` | Annotations to add to the admission controller pod |

--- a/stable/vpa/values.yaml
+++ b/stable/vpa/values.yaml
@@ -38,7 +38,7 @@ recommender:
     # maxUnavailable: 1
   image:
     # recommender.image.repository -- The location of the recommender image
-    repository: us.gcr.io/k8s-artifacts-prod/autoscaling/vpa-recommender
+    repository: k8s.gcr.io/autoscaling/vpa-recommender
     # recommender.image.pullPolicy -- The pull policy for the recommender image. Recommend not changing this
     pullPolicy: Always
     # recommender.image.tag -- Overrides the image tag whose default is the chart appVersion
@@ -74,7 +74,7 @@ updater:
     # maxUnavailable: 1
   image:
     # updater.image.repository -- The location of the updater image
-    repository: us.gcr.io/k8s-artifacts-prod/autoscaling/vpa-updater
+    repository: k8s.gcr.io/autoscaling/vpa-updater
     # updater.image.pullPolicy -- The pull policy for the updater image. Recommend not changing this
     pullPolicy: Always
     # updater.image.tag -- Overrides the image tag whose default is the chart appVersion
@@ -124,7 +124,7 @@ admissionController:
     # maxUnavailable: 1
   image:
     # admissionController.image.repository -- The location of the vpa admission controller image
-    repository: us.gcr.io/k8s-artifacts-prod/autoscaling/vpa-admission-controller
+    repository: k8s.gcr.io/autoscaling/vpa-admission-controller
     # admissionController.image.pullPolicy -- The pull policy for the admission controller image. Recommend not changing this
     pullPolicy: Always
     # admissionController.image.tag -- Overrides the image tag whose default is the chart appVersion


### PR DESCRIPTION
**Why This PR?**

The default images in Kubernetes VPA has been [updated](https://github.com/kubernetes/autoscaler/commit/2c7c56f68e2ddabfd2b60a6a809fd9f8a56afd32#diff-a53d46370ff1a6f11577b219c047c1e893d674a315108d0982b4590aafa0c5d6).

**Changes**
Changes proposed in this pull request:

* Change default VPA images to use k8s.gcr.io vanity domain (`k8s.gcr.io/autoscaling`)

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
