### PR TITLE
[gke-node-termination-handler] Update DaemonSet to match upstream

### DIFF
--- a/stable/gke-node-termination-handler/Chart.yaml
+++ b/stable/gke-node-termination-handler/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: "1.0"
 description: This helm chart provides an adapter for translating GCE node termination events to graceful pod terminations in Kubernetes.
 name: gke-node-termination-handler
-version: 1.2.2
+version: 1.2.3
 maintainers:
   - name: sudermanjr

--- a/stable/gke-node-termination-handler/templates/daemonset.yaml
+++ b/stable/gke-node-termination-handler/templates/daemonset.yaml
@@ -19,14 +19,19 @@ spec:
       labels:
         name: {{ include "gke-node-termination-handler.fullname" . }}
     spec:
+      # Necessary to hit the node's metadata server when using Workload Identity
+      hostNetwork: true
       # Necessary to reboot node
       hostPID: true
       serviceAccountName: {{ include "gke-node-termination-handler.fullname" . }}
       affinity:
         nodeAffinity:
-         # Restrict to preemptible nodes
+         # Restrict to GPU nodes or preemptible nodes
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
+            - matchExpressions:
+              - key: cloud.google.com/gke-accelerator
+                operator: Exists
             - matchExpressions:
               - key: cloud.google.com/gke-preemptible
                 operator: Exists
@@ -57,7 +62,8 @@ spec:
         resources:
           {{- toYaml .Values.resources | nindent 12 }}
       tolerations:
-        - effect: NoSchedule
-          operator: Exists
-        - effect: NoExecute
-          operator: Exists
+      # Run regardless of any existing taints.
+      - effect: NoSchedule
+        operator: Exists
+      - effect: NoExecute
+        operator: Exists


### PR DESCRIPTION
**Why This PR?**

The pods wont start on my private GKE cluster. I've found this issue, which explains the reasons. The fix was already applied upstream.

https://github.com/GoogleCloudPlatform/k8s-node-termination-handler/pull/23

Fixes #

**Changes**
Changes proposed in this pull request:

* https://github.com/GoogleCloudPlatform/k8s-node-termination-handler/pull/23


**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
