### PR TITLE
Skip Insights tests on forked PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,11 @@ jobs:
       - run:
           name: Run Insights Checks
           command: |
-            curl -L https://insights.fairwinds.com/v0/insights-ci.sh | bash
+            if [[ -z $CIRCLE_PR_NUMBER ]]; then
+              curl -L https://insights.fairwinds.com/v0/insights-ci.sh | bash
+            else
+              echo "Skipping Insights tests for forked PR"
+            fi
 
   sync:
     docker:


### PR DESCRIPTION
**Why This PR?**
Insights tests fail on forked PRs every time because of CircleCI setup

Fixes #

**Changes**
Changes proposed in this pull request:

* skip Insights test for now on forked PRs

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.