### PR TITLE
[fairwinds-insights] Use ingress host instead

### DIFF
--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "4.4.0"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 0.2.16
+version: 0.2.17
 maintainers:
 - name: rbren
 - name: makoscafee

--- a/stable/fairwinds-insights/templates/deployment-open-api.yaml
+++ b/stable/fairwinds-insights/templates/deployment-open-api.yaml
@@ -31,7 +31,7 @@ spec:
             protocol: TCP
           env:
           - name: SWAGGER_JSON_URL
-            value: {{ include "fairwinds-insights.fullname" . }}-api/v0/swagger.yaml
+            value: {{ "https://" }}{{ include "fairwinds-insights.sanitizedPrefix" $ }}{{ index .Values.ingress.hostedZones 0 }}{{ "/v0/swagger.yaml" }}
           - name: BASE_URL
             value: "/swagger"
           resources:


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

since swagger ui endpoint will be accessible over `https` using service name with http will have some cors issues... the best way is to use ingress host itself.
see
<img width="1920" alt="Screenshot 2021-09-20 at 23 36 54" src="https://user-images.githubusercontent.com/6409210/134072675-1a189bcf-351e-4c8b-938f-3731dc3e87fd.png">


Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [ ] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
