### PR TITLE
[insights-agent] fix fleet installer

### DIFF
--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 1.14.7
+version: 1.14.8
 appVersion: 3.2.0
 maintainers:
   - name: rbren

--- a/stable/insights-agent/templates/fleet-installer/job.yaml
+++ b/stable/insights-agent/templates/fleet-installer/job.yaml
@@ -22,6 +22,30 @@ spec:
         args:
           - -c
           - |
+            mkdir /tmp/bin
+            export PATH=$PATH:/tmp/bin
+            cd /tmp/bin
+            # Download kubectl to match the cluster version,
+            # using kubectl 1.19 for clusters <= 1.19.
+            default_kubectl_version='v1.19.6'
+            echo "Downloading jq . . ."
+            curl -Lo jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && chmod +x jq
+            echo "Getting the Kubernetes version from the API. . ."
+            kube_version=$(curl -ks https://kubernetes.default.svc/version?timeout=32s |jq -r .gitVersion)
+            kube_minor_version=$(echo $kube_version |cut -d. -f2)
+            if [ "x${kube_version}" == "x" ] ; then
+              kubectl_version="${default_kubectl_version}"
+              echo "Using kubectl version ${kubectl_version} because I was unable to get the Kubernetes cluster version"
+            elif [ "$kube_minor_version" -gt 19 ] ; then
+              kubectl_version="${kube_version}"
+              echo "Using kubectl version ${kubectl_version} to match the cluster"
+            else
+              kubectl_version="${default_kubectl_version}"
+              echo "Using kubectl version ${kubectl_version} because the cluster is <= version 1.19"
+            fi
+            echo Downloading kubectl version ${kubectl_version}
+            curl -Lo kubectl "https://dl.k8s.io/release/${kubectl_version}/bin/linux/amd64/kubectl" && chmod +x kubectl
+          
             echo "Checking if cluster already exists..."
             CLUSTER_FILE="/tmp/cluster.json"
             SECRET_NAME="{{ required "You must specify insights.tokenSecretName for a fleet install" .Values.insights.tokenSecretName }}"


### PR DESCRIPTION
**Why This PR?**
The image changed, and no longer has kubectl - this installs kubectl

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
