### PR TITLE
feat: add topology spread constraints for goldilocks

### DIFF
--- a/stable/goldilocks/Chart.yaml
+++ b/stable/goldilocks/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 appVersion: "v4.0.0"
-version: 4.0.0
+version: 4.0.1
 description: |
   A Helm chart for running Fairwinds Goldilocks. See https://github.com/FairwindsOps/goldilocks
 name: goldilocks

--- a/stable/goldilocks/README.md
+++ b/stable/goldilocks/README.md
@@ -68,6 +68,7 @@ This will completely remove the VPA and then re-install it using the new method.
 | controller.nodeSelector | object | `{}` | Node selector for the controller pod |
 | controller.tolerations | list | `[]` | Tolerations for the controller pod |
 | controller.affinity | object | `{}` | Affinity for the controller pods |
+| controller.topologySpreadConstraints | list | `[]` | Topology spread constraints for the controller pods |
 | controller.resources | object | `{"limits":{"cpu":"25m","memory":"32Mi"},"requests":{"cpu":"25m","memory":"32Mi"}}` | The resources block for the controller pods |
 | controller.podSecurityContext | object | `{}` | Defines the podSecurityContext for the controller pod |
 | controller.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":10324}` | The container securityContext for the controller container |
@@ -100,3 +101,4 @@ This will completely remove the VPA and then re-install it using the new method.
 | dashboard.nodeSelector | object | `{}` |  |
 | dashboard.tolerations | list | `[]` |  |
 | dashboard.affinity | object | `{}` |  |
+| dashboard.topologySpreadConstraints | list | `[]` | Topology spread constraints for the dashboard pods |

--- a/stable/goldilocks/ci/test-values.yaml
+++ b/stable/goldilocks/ci/test-values.yaml
@@ -17,6 +17,14 @@ controller:
       test: value
 
 dashboard:
+  replicaCount: 2
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: DoNotSchedule
+      labelSelector:
+        matchLabels:
+          app: alertmanager
   deployment:
     additionalLabels:
       test: value

--- a/stable/goldilocks/templates/controller-deployment.yaml
+++ b/stable/goldilocks/templates/controller-deployment.yaml
@@ -77,4 +77,8 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- with .Values.controller.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
 {{- end }}

--- a/stable/goldilocks/templates/dashboard-deployment.yaml
+++ b/stable/goldilocks/templates/dashboard-deployment.yaml
@@ -87,4 +87,8 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- with .Values.controller.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
 {{- end }}

--- a/stable/goldilocks/values.yaml
+++ b/stable/goldilocks/values.yaml
@@ -46,6 +46,8 @@ controller:
   tolerations: []
   # controller.affinity -- Affinity for the controller pods
   affinity: {}
+  # controller.topologySpreadConstraints -- Topology spread constraints for the controller pods
+  topologySpreadConstraints: []
   # controller.resources -- The resources block for the controller pods
   resources:
     limits:
@@ -148,3 +150,5 @@ dashboard:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  # dashboard.topologySpreadConstraints -- Topology spread constraints for the dashboard pods
+  topologySpreadConstraints: []


### PR DESCRIPTION
Signed-off-by: Dysproz <szymon.krasuski@starburstdata.com>

**Why This PR?**
Add additional options to set up topology spread constraints to for example ensure that the goldilocks deployments will be spread across different cloud availability zones.


**Changes**
Changes proposed in this pull request:

* topologySpreadConstraints filed added to the controller and dashboard deployments of goldilocks

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
