### PR TITLE
[rbac-manager] use latest release

### DIFF
--- a/stable/rbac-manager/Chart.yaml
+++ b/stable/rbac-manager/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: rbac-manager
-version: 1.8.3
-appVersion: 0.10.0
+version: 1.9.0
+appVersion: 1.0.0
 description: A Kubernetes operator that simplifies the management of Role Bindings and Service Accounts.
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/rbac-manager/icon.png
 keywords:

--- a/stable/rbac-manager/README.md
+++ b/stable/rbac-manager/README.md
@@ -53,7 +53,7 @@ In the above workflow, an RBAC Definition installed between revision 1 and 2 sho
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | image.repository | string | `"quay.io/reactiveops/rbac-manager"` | The image to run for rbac manager |
-| image.tag | string | `"v0.10.0"` | The tag of the image to run |
+| image.tag | string | `"v1.0.0"` | The tag of the image to run |
 | image.pullPolicy | string | `"Always"` | The image pullPolicy. Recommend not changing this |
 | image.imagePullSecrets | list | `[]` |  |
 | installCRDs | bool | `true` | If true, install and upgrade CRDs. See the Helm documentation for [best practices regarding CRDs](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/#install-a-crd-declaration-before-using-the-resource). |

--- a/stable/rbac-manager/values.yaml
+++ b/stable/rbac-manager/values.yaml
@@ -2,7 +2,7 @@ image:
   # image.repository -- The image to run for rbac manager
   repository: quay.io/reactiveops/rbac-manager
   # image.tag -- The tag of the image to run
-  tag: v0.10.0
+  tag: v1.0.0
   # image.pullPolicy -- The image pullPolicy. Recommend not changing this
   pullPolicy: Always
   # imagePullSecrets -- A list of imagePullSecrets to reference for pulling the image


### PR DESCRIPTION
**Why This PR?**
Use the latest image for rbac-manager

Fixes #

**Changes**
Changes proposed in this pull request:

* Use tag `v1.0.0` for rbac-manager

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.