### PR TITLE
[goldilocks] enable to pull uninstall image from custom repository

### DIFF
--- a/stable/goldilocks/Chart.yaml
+++ b/stable/goldilocks/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 appVersion: "v4.0.0"
-version: 4.0.1
+version: 4.0.2
 description: |
   A Helm chart for running Fairwinds Goldilocks. See https://github.com/FairwindsOps/goldilocks
 name: goldilocks

--- a/stable/goldilocks/README.md
+++ b/stable/goldilocks/README.md
@@ -49,7 +49,10 @@ This will completely remove the VPA and then re-install it using the new method.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| uninstallVPA | bool | `false` | Enabling this flag will remove a vpa installation that was previously managed with this chart. It is considered deprecated and will be removed in a later release. |
+| uninstallVPA | object | `{"enabled":false,"image":{"repository":"quay.io/reactiveops/ci-images","tag":"v9-alpine"}}` | Enabling this flag will remove a vpa installation that was previously managed with this chart. It is considered deprecated and will be removed in a later release. |
+| uninstallVPA.enabled | bool | `false` | Enabling this flag will remove installation that was previously managed with this chart. |
+| uninstallVPA.image.repository | string | `"quay.io/reactiveops/ci-images"` | Repository for the remove vpa installation image |
+| uninstallVPA.image.tag | string | `"v9-alpine"` | The remove vpa installation image tag to use |
 | vpa.enabled | bool | `false` | If true, the vpa will be installed as a sub-chart |
 | vpa.updater.enabled | bool | `false` |  |
 | metrics-server.enabled | bool | `false` | If true, the metrics-server will be installed as a sub-chart |

--- a/stable/goldilocks/templates/vpa-uninstall-hook.yaml
+++ b/stable/goldilocks/templates/vpa-uninstall-hook.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.uninstallVPA }}
+{{- if .Values.uninstallVPA.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -60,7 +60,7 @@ spec:
       serviceAccountName: {{ include "goldilocks.fullname" . }}-vpa-uninstall
       containers:
       - name: vpa-uninstall
-        image: quay.io/reactiveops/ci-images:v9-alpine
+        image: {{ .Values.uninstallVPA.image.repository }}:{{ .Values.uninstallVPA.image.tag }}
         command: ["bash"]
         args:
           - -c

--- a/stable/goldilocks/values.yaml
+++ b/stable/goldilocks/values.yaml
@@ -1,5 +1,12 @@
 # uninstallVPA -- Enabling this flag will remove a vpa installation that was previously managed with this chart. It is considered deprecated and will be removed in a later release.
-uninstallVPA: false
+uninstallVPA:
+  # uninstallVPA.enabled -- Enabling this flag will remove installation that was previously managed with this chart.
+  enabled: false
+  image:
+    # uninstallVPA.image.repository -- Repository for the remove vpa installation image
+    repository: quay.io/reactiveops/ci-images
+    # uninstallVPA.image.tag -- The remove vpa installation image tag to use
+    tag: v9-alpine
 
 vpa:
   # vpa.enabled -- If true, the vpa will be installed as a sub-chart


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

This image was pulling from a constant repository. Some developers or organizations want to use own their repository. It will be enabled to use custom repository by this feature.

Fixes #

It will be enabled to use custom repository by this feature.

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
