### PR TITLE
Remove duplicate labels

### DIFF
--- a/stable/gke-node-termination-handler/Chart.yaml
+++ b/stable/gke-node-termination-handler/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: "1.0"
 description: This helm chart provides an adapter for translating GCE node termination events to graceful pod terminations in Kubernetes.
 name: gke-node-termination-handler
-version: 1.2.3
+version: 1.2.4
 maintainers:
   - name: sudermanjr

--- a/stable/gke-node-termination-handler/templates/daemonset.yaml
+++ b/stable/gke-node-termination-handler/templates/daemonset.yaml
@@ -3,10 +3,6 @@ kind: DaemonSet
 metadata:
   name: {{ include "gke-node-termination-handler.fullname" . }}
   labels:
-    app.kubernetes.io/name: {{ include "gke-node-termination-handler.name" . }}
-    helm.sh/chart: {{ include "gke-node-termination-handler.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{ include "gke-node-termination-handler.labels" . | indent 4 }}
 spec:
   selector:

--- a/stable/gke-node-termination-handler/templates/rbac.yaml
+++ b/stable/gke-node-termination-handler/templates/rbac.yaml
@@ -1,22 +1,16 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  labels:
-    app.kubernetes.io/name: {{ include "gke-node-termination-handler.name" . }}
-    helm.sh/chart: {{ include "gke-node-termination-handler.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
   name: {{ include "gke-node-termination-handler.fullname" . }}
+  labels:
+{{ include "gke-node-termination-handler.labels" . | indent 4 }}
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  labels:
-    app.kubernetes.io/name: {{ include "gke-node-termination-handler.name" . }}
-    helm.sh/chart: {{ include "gke-node-termination-handler.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
   name: {{ include "gke-node-termination-handler.fullname" . }}
+  labels:
+{{ include "gke-node-termination-handler.labels" . | indent 4 }}
 rules:
   # Allow Node Termination Handler to get and update nodes (for posting taints).
 - apiGroups: [""]
@@ -34,12 +28,9 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  labels:
-    app.kubernetes.io/name: {{ include "gke-node-termination-handler.name" . }}
-    helm.sh/chart: {{ include "gke-node-termination-handler.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
   name: {{ include "gke-node-termination-handler.fullname" . }}
+  labels:
+{{ include "gke-node-termination-handler.labels" . | indent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
The labels are already part of the Block `gke-node-termination-handler.labels`

**Why This PR?**

Duplicated labels 

Fixes #

**Changes**
Changes proposed in this pull request:

* Do not duplicate labels*

**Checklist:**

* [ ] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
