### PR TITLE
[incubator/basic-demo] Update chart to use newer ingress options

### DIFF
--- a/incubator/basic-demo/Chart.yaml
+++ b/incubator/basic-demo/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Basic Kubernetes Demo Chart
 name: basic-demo
-version: 0.4.3
+version: 0.5.0
 maintainers:
   - name: sudermanjr

--- a/incubator/basic-demo/templates/ingress.yaml
+++ b/incubator/basic-demo/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "basic-demo.fullname" . -}}
 {{- $ingressPaths := .Values.ingress.paths -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -15,6 +15,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+{{- if .Values.ingress.ingressClassName }}
+  ingressClassName: .Values.ingress.ingressClassName
+{{- end }}
 {{- if .Values.ingress.tls }}
   tls:
   {{- range .Values.ingress.tls }}
@@ -30,11 +33,11 @@ spec:
     - host: {{ . | quote }}
       http:
         paths:
-	{{- range $ingressPaths }}
+  {{- range $ingressPaths }}
           - path: {{ . }}
             backend:
               serviceName: {{ $fullName }}
               servicePort: http
-	{{- end }}
+  {{- end }}
   {{- end }}
 {{- end }}

--- a/incubator/basic-demo/values.yaml
+++ b/incubator/basic-demo/values.yaml
@@ -35,6 +35,7 @@ service:
 
 ingress:
   enabled: false
+  ingressClassName: ""
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"


### PR DESCRIPTION
**Why This PR?**
Update the basic-demo chart to use networking.k8s.io/v1 and allow setting ingressClassName

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.