### PR TITLE
Add PDB to insights-admission

### DIFF
--- a/stable/insights-admission/Chart.yaml
+++ b/stable/insights-admission/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: insights-admission
 description: A Validating Webhook Admission Controller that utilizes Fairwinds Insights.
 type: application
-version: 0.4.1
+version: 0.4.2
 appVersion: "0.4"
 maintainers:
 - name: rbren

--- a/stable/insights-admission/README.md
+++ b/stable/insights-admission/README.md
@@ -64,6 +64,7 @@ rules:
 | autoscaling.maxReplicas | int | `5` | Maximum number of pods to run. |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` | Target CPU to scale towards. |
 | autoscaling.targetMemoryUtilizationPercentage | string | `nil` | Target memory to scale towards. |
+| pdb.minAvailable | int | `1` | The minimum number of admission controller pods that must still be available after an eviction, expressed as an absolute number or a percentage. A PDB is only created when autoscaling.minReplicas > 1 or replicaCount >1 |
 | nameOverride | string | `""` | Overrides the name of the release. |
 | fullnameOverride | string | `""` | Long name of the release to override. |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |

--- a/stable/insights-admission/README.md
+++ b/stable/insights-admission/README.md
@@ -64,7 +64,8 @@ rules:
 | autoscaling.maxReplicas | int | `5` | Maximum number of pods to run. |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` | Target CPU to scale towards. |
 | autoscaling.targetMemoryUtilizationPercentage | string | `nil` | Target memory to scale towards. |
-| pdb.minAvailable | int | `1` | The minimum number of admission controller pods that must still be available after an eviction, expressed as an absolute number or a percentage. A PDB is only created when autoscaling.minReplicas > 1 or replicaCount >1 |
+| pdb.enabled | bool | `true` | Create a Pod Disruption Budget (PDB). This also requires `autoscaling.minReplicas` > 1 or `replicaCount` > 1 |
+| pdb.minAvailable | int | `1` | The minimum number of admission controller pods that must still be available after an eviction, expressed as an absolute number or a percentage. |
 | nameOverride | string | `""` | Overrides the name of the release. |
 | fullnameOverride | string | `""` | Long name of the release to override. |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |

--- a/stable/insights-admission/templates/pdb.yaml
+++ b/stable/insights-admission/templates/pdb.yaml
@@ -1,4 +1,4 @@
-{{- if or (and .Values.autoscaling.enabled (gt (.Values.autoscaling.minReplicas | int) 1)) (and (not .Values.autoscaling.enabled) (gt (.Values.replicaCount | int) 1)) }}
+{{- if or (and .Values.pdb.enabled .Values.autoscaling.enabled (gt (.Values.autoscaling.minReplicas | int) 1)) (and .Values.pdb.enabled (not .Values.autoscaling.enabled) (gt (.Values.replicaCount | int) 1)) }}
 apiVersion: {{ ternary "policy/v1" "policy/v1beta1" (semverCompare ">=1.21.0-0" .Capabilities.KubeVersion.Version) }}
 kind: PodDisruptionBudget
 metadata:

--- a/stable/insights-admission/templates/pdb.yaml
+++ b/stable/insights-admission/templates/pdb.yaml
@@ -1,0 +1,14 @@
+{{- if or (and .Values.autoscaling.enabled (gt (.Values.autoscaling.minReplicas | int) 1)) (and (not .Values.autoscaling.enabled) (gt (.Values.replicaCount | int) 1)) }}
+apiVersion: {{ ternary "policy/v1" "policy/v1beta1" (semverCompare ">=1.21.0-0" .Capabilities.KubeVersion.Version) }}
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "insights-admission.fullname" . }}-admission
+  labels:
+    {{- include "insights-admission.labels" . | nindent 4 }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "insights-admission.selectorLabels" . | nindent 6 }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
+{{- end }}

--- a/stable/insights-admission/values.yaml
+++ b/stable/insights-admission/values.yaml
@@ -111,6 +111,15 @@ autoscaling:
   # autoscaling.targetMemoryUtilizationPercentage -- Target memory to scale towards.
   targetMemoryUtilizationPercentage: null
 
+# Pod Disruption Budget
+# PDB is enabled if either:
+# 1. autoscaling.enabled=true and autoscaling.minReplicas > 1
+# 2. autoscaling.enabled=false and replicaCount > 1
+pdb:
+  # The minimum number of admission controller pods that must still be
+  # available after an eviction, expressed as an absolute number or a percentage.
+  minAvailable: 1
+
 # nameOverride -- Overrides the name of the release.
 nameOverride: ""
 # fullnameOverride -- Long name of the release to override.

--- a/stable/insights-admission/values.yaml
+++ b/stable/insights-admission/values.yaml
@@ -112,12 +112,11 @@ autoscaling:
   targetMemoryUtilizationPercentage: null
 
 pdb:
-# A Pod Disruption Budget (PDB) is enabled if either:
-# 1. autoscaling.enabled=true and autoscaling.minReplicas > 1
-# 2. autoscaling.enabled=false and replicaCount > 1
+  # pdb.enabled -- Create a Pod Disruption Budget (PDB).
+  # This also requires `autoscaling.minReplicas` > 1 or `replicaCount` > 1
+  enabled: true
   # pdb.minAvailable -- The minimum number of admission controller pods that must still be
   # available after an eviction, expressed as an absolute number or a percentage.
-  # A PDB is only created when autoscaling.minReplicas > 1 or replicaCount >1
   minAvailable: 1
 
 # nameOverride -- Overrides the name of the release.

--- a/stable/insights-admission/values.yaml
+++ b/stable/insights-admission/values.yaml
@@ -111,13 +111,13 @@ autoscaling:
   # autoscaling.targetMemoryUtilizationPercentage -- Target memory to scale towards.
   targetMemoryUtilizationPercentage: null
 
-# Pod Disruption Budget
-# PDB is enabled if either:
+pdb:
+# A Pod Disruption Budget (PDB) is enabled if either:
 # 1. autoscaling.enabled=true and autoscaling.minReplicas > 1
 # 2. autoscaling.enabled=false and replicaCount > 1
-pdb:
-  # The minimum number of admission controller pods that must still be
+  # pdb.minAvailable -- The minimum number of admission controller pods that must still be
   # available after an eviction, expressed as an absolute number or a percentage.
+  # A PDB is only created when autoscaling.minReplicas > 1 or replicaCount >1
   minAvailable: 1
 
 # nameOverride -- Overrides the name of the release.


### PR DESCRIPTION
I'd appreciate some additional eyes on the logic at the top of the PDB template -

* is this a reasonable way to enable the PDB (based on whether the HPA is enabled or replicaCount being more than 1)?

**Why This PR?**
_a short description of why this PR is needed_
**Changes**
Changes proposed in this pull request:
Adds a PDB for the insights-admission chart. This was born from a customer that spins down a cluster, which caused there to be no admission controller pods available to facilitate workloads being spun back up.

**Checklist:**

* [ ] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [ ] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
