### PR TITLE
[Goldilocks] feat: Adding Argo rollout support

### DIFF
--- a/stable/goldilocks/Chart.yaml
+++ b/stable/goldilocks/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 appVersion: "v4.0.0"
-version: 4.0.1
+version: 4.0.2
 description: |
   A Helm chart for running Fairwinds Goldilocks. See https://github.com/FairwindsOps/goldilocks
 name: goldilocks

--- a/stable/goldilocks/templates/controller-clusterrole.yaml
+++ b/stable/goldilocks/templates/controller-clusterrole.yaml
@@ -37,4 +37,12 @@ rules:
       - 'create'
       - 'delete'
       - 'update'
+  - apiGroups:
+      - 'argoproj.io'
+    resources:
+      - rollouts
+    verbs:
+      - 'get'
+      - 'list'
+      - 'watch'
 {{- end }}

--- a/stable/goldilocks/templates/dashboard-clusterrole.yaml
+++ b/stable/goldilocks/templates/dashboard-clusterrole.yaml
@@ -32,4 +32,11 @@ rules:
     verbs:
       - 'get'
       - 'list'
+  - apiGroups:
+      - 'argoproj.io'
+    resources:
+      - rollouts
+    verbs:
+      - 'get'
+      - 'list'
 {{- end }}


### PR DESCRIPTION
**Why This PR?**
Support for Argo rollouts.

Fixes #
Argo rollout API access
```bash
controller.go:169]  "msg"="Error retrieving parent object" "error"="rollouts.argoproj.io is forbidden: User \"system:serviceaccount:goldilocks:goldilocks-controller\" cannot list resource \"rollouts\" in API group \"argoproj.io\" in the namespace \"namespace\""  "v1alpha1"="rollouts"
```
```bash
summary.go:152] no matching Workloads found for VPA/workload-name
```

**Changes**
Changes proposed in this pull request:

* Added the controller clusterrole access to get, list, and watch for the rollouts resource
* Added the dashboard clusterrole access to get and list for the rollouts resource
* Chart minor version bump

**Checklist:**

* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [N/A] Any new values are backwards compatible and/or have sensible default.
* [N/A] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
