### PR TITLE
[insights-agent] Use FQDN for service and modify SA access

### DIFF
--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 1.16.1
+version: 1.16.2
 appVersion: 6.5.1
 maintainers:
   - name: rbren

--- a/stable/insights-agent/templates/falco/rbac.yaml
+++ b/stable/insights-agent/templates/falco/rbac.yaml
@@ -5,4 +5,34 @@ metadata:
   name: {{ include "insights-agent.fullname" . }}-falco
   labels:
     app: insights-agent
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "insights-agent.fullname" . }}-falco
+  labels:
+    app: insights-agent
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - 'pods'
+    verbs:
+      - 'get'
+      - 'list'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "insights-agent.fullname" . }}-falco
+  labels:
+    app: insights-agent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "insights-agent.fullname" . }}-falco
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "insights-agent.fullname" . }}-falco
+    namespace: {{ .Release.Namespace }}
 {{- end -}}

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -406,7 +406,7 @@ falco:
     port: 3031
   image:
     repository: quay.io/fairwinds/falco-agent
-    tag: "0.1.0"
+    tag: "0.1.2"
     pullPolicy: Always
   podSecurityContext:
     fsGroup: 101

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -430,6 +430,13 @@ falco:
       memory: 128Mi
 
 falcosecurity:
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 50m
+      memory: 128Mi
   falco:
     jsonOutput: true
   ebpf:

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -438,6 +438,7 @@ falcosecurity:
   falcosidekick:
     # enable falcosidekick deployment
     enabled: true
+    fullfqdn: true
     webui:
       enabled: true
     config:


### PR DESCRIPTION
…ds to rbac

**Why This PR?**
Use  FQDN for service name instead of IP and give access to pod list to agent to fix
```
level=error msg="Error retrieving pod using podname: pods \"xxx \" is forbidden: User \"system:serviceaccount:insights-agent:insights-agent-falco\" cannot get resource \"pods\" in API group \"\" in the namespace \"xxx\""
```

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [ ] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
