### PR TITLE
If/fwi-976  Migrate from ValidatingWebhookConfiguration v1beta1 to support k8s 1.22

### DIFF
--- a/stable/insights-admission/Chart.yaml
+++ b/stable/insights-admission/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: insights-admission
 description: A Validating Webhook Admission Controller that utilizes Fairwinds Insights.
 type: application
-version: 0.4.2
+version: 0.4.3
 appVersion: "0.4"
 maintainers:
 - name: rbren

--- a/stable/insights-admission/templates/configuration.yaml
+++ b/stable/insights-admission/templates/configuration.yaml
@@ -1,4 +1,8 @@
+{{- if .Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1" }}
 apiVersion: admissionregistration.k8s.io/v1
+{{- else }}
+apiVersion: admissionregistration.k8s.io/v1beta1
+{{- end }}
 kind: ValidatingWebhookConfiguration
 metadata:
   name: {{ include "insights-admission.fullname" . }}
@@ -8,7 +12,9 @@ metadata:
     {{- end }}
 webhooks:
 - admissionReviewVersions:
+{{- if .Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1" }}
   - v1
+{{- end }}
   - v1beta1
   clientConfig:
     {{- if .Values.caBundle }}

--- a/stable/insights-admission/templates/configuration.yaml
+++ b/stable/insights-admission/templates/configuration.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: {{ include "insights-admission.fullname" . }}
@@ -8,7 +8,7 @@ metadata:
     {{- end }}
 webhooks:
 - admissionReviewVersions:
-  - v1beta1
+  - v1
   clientConfig:
     {{- if .Values.caBundle }}
     caBundle: {{ .Values.caBundle | quote }}

--- a/stable/insights-admission/templates/configuration.yaml
+++ b/stable/insights-admission/templates/configuration.yaml
@@ -9,6 +9,7 @@ metadata:
 webhooks:
 - admissionReviewVersions:
   - v1
+  - v1beta1
   clientConfig:
     {{- if .Values.caBundle }}
     caBundle: {{ .Values.caBundle | quote }}


### PR DESCRIPTION
**Why This PR?**
Update the admission controller chart to support Kube 1.22.

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [ ] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
