### PR TITLE
[insights-agent] change from using ebpf support for falco to falco-probe kernel module

### DIFF
--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 1.16.4
+version: 1.16.5
 appVersion: 6.5.1
 maintainers:
   - name: rbren

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -440,8 +440,8 @@ falcosecurity:
   falco:
     jsonOutput: true
   ebpf:
-    # Enable eBPF support for Falco
-    enabled: true
+    # Enable eBPF support for Falco instead of falco-probe kernel module
+    enabled: false
   falcosidekick:
     # enable falcosidekick deployment
     enabled: true


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

if you look driver download page [here](https://download.falco.org/?prefix=driver/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/) for Falco for our nodes kernel `5.8.0-1041-aws` you will see we only have `falco-probe` kernel module driver(with extension `.ko`) but no `eBPF` probe (with extension `.o`) which means enabling ebpf module will sometimes not work. Reverted to default Falco installation behaviour.

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [ ] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
