### PR TITLE
[insights-agent] Update workloads to get unique kinds

### DIFF
--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 1.16.5
+version: 1.16.7
 appVersion: 6.5.1
 maintainers:
   - name: rbren

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 1.16.7
+version: 1.17.0
 appVersion: 6.5.1
 maintainers:
   - name: rbren

--- a/stable/insights-agent/templates/workloads/rbac.yaml
+++ b/stable/insights-agent/templates/workloads/rbac.yaml
@@ -9,7 +9,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "insights-agent.fullname" . }}-workloads-view
+  name: {{ include "insights-agent.fullname" . }}-workloads
   labels:
     app: insights-agent
 roleRef:

--- a/stable/insights-agent/templates/workloads/rbac.yaml
+++ b/stable/insights-agent/templates/workloads/rbac.yaml
@@ -7,52 +7,15 @@ metadata:
     app: insights-agent
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: {{ include "insights-agent.fullname" . }}-workloads
-  labels:
-    app: insights-agent
-rules:
-  - apiGroups:
-      - 'apps'
-      - 'extensions'
-    resources:
-      - 'deployments'
-      - 'statefulsets'
-      - 'replicasets'
-      - 'daemonsets'
-    verbs:
-      - 'get'
-      - 'list'
-  - apiGroups:
-      - 'batch'
-    resources:
-      - 'jobs'
-      - 'cronjobs'
-    verbs:
-      - 'get'
-      - 'list'
-  - apiGroups:
-      - ''
-    resources:
-      - 'nodes'
-      - 'namespaces'
-      - 'pods'
-      - 'replicationcontrollers'
-    verbs:
-      - 'get'
-      - 'list'
----
-apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "insights-agent.fullname" . }}-workloads
+  name: {{ include "insights-agent.fullname" . }}-workloads-view
   labels:
     app: insights-agent
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "insights-agent.fullname" . }}-workloads
+  name: view
 subjects:
   - kind: ServiceAccount
     name: {{ include "insights-agent.fullname" . }}-workloads

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -166,7 +166,7 @@ workloads:
   timeout: 300
   image:
     repository: quay.io/fairwinds/workloads
-    tag: "2.1"
+    tag: "2.2"
   resources:
     limits:
       cpu: 250m


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

changed RBAC to using `view` to get unique kinds that were not listed

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [ ] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
