### PR TITLE
Add ability to list nodes 

### DIFF
--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 1.17.1
+version: 1.17.2
 appVersion: 6.5.1
 maintainers:
   - name: rbren

--- a/stable/insights-agent/templates/workloads/rbac.yaml
+++ b/stable/insights-agent/templates/workloads/rbac.yaml
@@ -7,9 +7,39 @@ metadata:
     app: insights-agent
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "insights-agent.fullname" . }}-workloads
+  labels:
+    app: insights-agent
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - 'nodes'
+    verbs:
+      - 'get'
+      - 'list'
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "insights-agent.fullname" . }}-workloads
+  labels:
+    app: insights-agent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "insights-agent.fullname" . }}-workloads
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "insights-agent.fullname" . }}-workloads
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "insights-agent.fullname" . }}-workloads-view
   labels:
     app: insights-agent
 roleRef:


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

ClusterRole `View` does not cover node list . added another binding to be able to list nodes in a cluster.
Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [ ] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
