### PR TITLE
[goldilocks] Added flags to goldilocks dashboard deployment

### DIFF
--- a/stable/goldilocks/Chart.yaml
+++ b/stable/goldilocks/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 appVersion: "v4.0.0"
-version: 4.0.2
+version: 4.0.3
 description: |
   A Helm chart for running Fairwinds Goldilocks. See https://github.com/FairwindsOps/goldilocks
 name: goldilocks

--- a/stable/goldilocks/README.md
+++ b/stable/goldilocks/README.md
@@ -81,6 +81,7 @@ This will completely remove the VPA and then re-install it using the new method.
 | dashboard.service.type | string | `"ClusterIP"` | The type of the dashboard service |
 | dashboard.service.port | int | `80` | The port to run the dashboard service on |
 | dashboard.service.annotations | object | `{}` | Extra annotations for the dashboard service |
+| dashboard.flags | object | `{}` | A map of additional flags to pass to the dashboard |
 | dashboard.logVerbosity | string | `"2"` | Dashboard log verbosity. Can be set from 1-10 with 10 being extremely verbose |
 | dashboard.excludeContainers | string | `"linkerd-proxy,istio-proxy"` | Container names to exclude from displaying in the Goldilocks dashboard |
 | dashboard.rbac.create | bool | `true` | If set to true, rbac resources will be created for the dashboard |

--- a/stable/goldilocks/templates/dashboard-deployment.yaml
+++ b/stable/goldilocks/templates/dashboard-deployment.yaml
@@ -49,6 +49,9 @@ spec:
             - dashboard
             - --exclude-containers={{ .Values.dashboard.excludeContainers }}
             - -v{{ .Values.dashboard.logVerbosity }}
+            {{- range $name, $value := .Values.dashboard.flags }}
+            - --{{ $name }}={{ $value }}
+            {{- end }}
         {{- if .Values.dashboard.securityContext }}
           securityContext:
             {{- toYaml .Values.dashboard.securityContext | nindent 12 }}

--- a/stable/goldilocks/values.yaml
+++ b/stable/goldilocks/values.yaml
@@ -90,6 +90,8 @@ dashboard:
     port: 80
     # dashboard.service.annotations -- Extra annotations for the dashboard service
     annotations: {}
+  # dashboard.flags -- A map of additional flags to pass to the dashboard
+  flags: {}
   # dashboard.logVerbosity -- Dashboard log verbosity. Can be set from 1-10 with 10 being extremely verbose
   logVerbosity: "2"
   # dashboard.excludeContainers -- Container names to exclude from displaying in the Goldilocks dashboard


### PR DESCRIPTION
**Why This PR?**
Adds the ability pass through flags to the dashboard deployment, similar to the way the controller is done.


**Changes**
Changes proposed in this pull request:
* Adding the flag values like controller has to the dashboard deployment.

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
