### PR TITLE
FWI-1017 - Initial updating of memory limits

### DIFF
--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 1.17.3
+version: 1.17.4
 appVersion: 6.5.1
 maintainers:
   - name: rbren

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 1.17.4
+version: 1.17.5
 appVersion: 6.5.1
 maintainers:
   - name: rbren

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 1.17.5
+version: 1.17.6
 appVersion: 6.5.1
 maintainers:
   - name: rbren

--- a/stable/insights-agent/templates/right-sizer/controller-deployment.yaml
+++ b/stable/insights-agent/templates/right-sizer/controller-deployment.yaml
@@ -30,7 +30,7 @@ spec:
           ports:
           - containerPort: 8080
           securityContext:
-            {{- toYaml .Values.rightsizer.securityContext | nindent 12 }}
+            {{- toYaml .Values.rightsizer.containerSecurityContext | nindent 12 }}
           image: "{{ .Values.rightsizer.image.repository }}:{{ .Values.rightsizer.image.tag }}"
           imagePullPolicy: {{ .Values.rightsizer.image.pullPolicy }}
           command:
@@ -54,6 +54,17 @@ spec:
 {{- end }}
           - "--reset-ooms-window"
           - "{{ .Values.rightsizer.resetOOMsWindow }}"
+          {{- range .Values.rightsizer.extraArgs }}
+          - "{{ . }}"
+          {{- end }}
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
           resources:
             {{- toYaml .Values.rightsizer.resources | nindent 12 }}
       serviceAccountName: {{ .Values.rightsizer.serviceAccountName }}

--- a/stable/insights-agent/templates/right-sizer/controller-deployment.yaml
+++ b/stable/insights-agent/templates/right-sizer/controller-deployment.yaml
@@ -21,6 +21,10 @@ spec:
         component: right-sizer
         app: insights-agent
     spec:
+      {{- with .Values.rightsizer.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}-right-sizer-controller
           ports:

--- a/stable/insights-agent/templates/right-sizer/controller-deployment.yaml
+++ b/stable/insights-agent/templates/right-sizer/controller-deployment.yaml
@@ -35,9 +35,25 @@ spec:
           imagePullPolicy: {{ .Values.rightsizer.image.pullPolicy }}
           command:
           - "right-sizer"
-          # NOt yet supported by the controller:
-          #- "-stateconfigmap"
-          #- "{{ .Release.Namespace }}/{{ .Values.rightsizer.stateconfigmapname }}"
+          - "--state-configmap-namespace"
+          - "{{ .Release.Namespace }}"
+          - "--state-configmap-name"
+          - "{{ .Values.rightsizer.stateconfigmapname }}"
+          {{- range .Values.rightsizer.namespaces }}
+          - "--namespace"
+          - "{{ . }}"
+          {{- end }}
+          {{- if .Values.rightsizer.updateMemoryLimits.enabled }}
+          - "--update-memory-limits"
+          - "--update-memory-limits-increment"
+          - "{{ .Values.rightsizer.updateMemoryLimits.increment }}"
+          - "--update-memory-limits-max"
+          - "{{ .Values.rightsizer.updateMemoryLimits.max }}"
+          - "--update-memory-limits-min-ooms"
+          - "{{ .Values.rightsizer.updateMemoryLimits.minOOMs }}"
+{{- end }}
+          - "--reset-ooms-window"
+          - "{{ .Values.rightsizer.resetOOMsWindow }}"
           resources:
             {{- toYaml .Values.rightsizer.resources | nindent 12 }}
       serviceAccountName: {{ .Values.rightsizer.serviceAccountName }}

--- a/stable/insights-agent/templates/right-sizer/controller-deployment.yaml
+++ b/stable/insights-agent/templates/right-sizer/controller-deployment.yaml
@@ -40,5 +40,5 @@ spec:
           #- "{{ .Release.Namespace }}/{{ .Values.rightsizer.stateconfigmapname }}"
           resources:
             {{- toYaml .Values.rightsizer.resources | nindent 12 }}
-      serviceAccountName: insights-agent-right-sizer-controller
+      serviceAccountName: {{ .Values.rightsizer.serviceAccountName }}
 {{- end -}}

--- a/stable/insights-agent/templates/right-sizer/controller-rbac.yaml
+++ b/stable/insights-agent/templates/right-sizer/controller-rbac.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "insights-agent.fullname" . }}-right-sizer-controller
+  name: {{ .Values.rightsizer.serviceAccountName }}
   labels:
     app: insights-agent
 ---
@@ -56,7 +56,7 @@ roleRef:
   name: view
 subjects:
   - kind: ServiceAccount
-    name: {{ include "insights-agent.fullname" . }}-right-sizer-controller
+    name: {{ .Values.rightsizer.serviceAccountName }}
     namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -71,7 +71,7 @@ roleRef:
   name: {{ include "insights-agent.fullname" . }}-right-sizer-controller-events
 subjects:
   - kind: ServiceAccount
-    name: {{ include "insights-agent.fullname" . }}-right-sizer-controller
+    name: {{ .Values.rightsizer.serviceAccountName }}
     namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -86,6 +86,6 @@ roleRef:
   name: {{ include "insights-agent.fullname" . }}-right-sizer-controller-state
 subjects:
   - kind: ServiceAccount
-    name: {{ include "insights-agent.fullname" . }}-right-sizer-controller
+    name: {{ .Values.rightsizer.serviceAccountName }}
     namespace: {{ .Release.Namespace }}
 {{- end -}}

--- a/stable/insights-agent/templates/right-sizer/controller-rbac.yaml
+++ b/stable/insights-agent/templates/right-sizer/controller-rbac.yaml
@@ -88,4 +88,66 @@ subjects:
   - kind: ServiceAccount
     name: {{ .Values.rightsizer.serviceAccountName }}
     namespace: {{ .Release.Namespace }}
+{{ if .Values.rightsizer.updateMemoryLimits -}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "insights-agent.fullname" . }}-right-sizer-controller-update-memory-limits
+  labels:
+    app: insights-agent
+rules:
+  - apiGroups:
+      - 'apps'
+    resources:
+      - 'pods'
+      - 'deployments'
+      - 'statefulsets'
+      - 'daemonsets'
+      - 'replicasets'
+    verbs:
+      - 'update'
+      - 'patch'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "insights-agent.fullname" . }}-right-sizer-controller-update-memory-limits
+  labels:
+    app: insights-agent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "insights-agent.fullname" . }}-right-sizer-controller-update-memory-limits
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.rightsizer.serviceAccountName }}
+    namespace: {{ .Release.Namespace }}
+{{ end -}}
+{{ if .Values.rightsizer.rbac.additionalAccess -}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "insights-agent.fullname" . }}-right-sizer-controller-additional-access
+  labels:
+    app: insights-agent
+rules:
+{{ toYaml .Values.rightsizer.rbac.additionalAccess }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "insights-agent.fullname" . }}-right-sizer-controller-additional-access
+  labels:
+    app: insights-agent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "insights-agent.fullname" . }}-right-sizer-controller-additional-access
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.rightsizer.serviceAccountName }}
+  namespace: {{ .Release.Namespace }}
+{{ end }}
 {{- end -}}

--- a/stable/insights-agent/templates/right-sizer/controller-rbac.yaml
+++ b/stable/insights-agent/templates/right-sizer/controller-rbac.yaml
@@ -88,7 +88,7 @@ subjects:
   - kind: ServiceAccount
     name: {{ .Values.rightsizer.serviceAccountName }}
     namespace: {{ .Release.Namespace }}
-{{ if .Values.rightsizer.updateMemoryLimits -}}
+{{ if .Values.rightsizer.updateMemoryLimits.enabled -}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -400,6 +400,10 @@ rightsizer:
     pullPolicy: Always
   imagePullSecrets:
   stateconfigmapname: insights-agent-right-sizer-controller-state
+  updateMemoryLimits:
+    enabled: true
+    maxLimitMultiplier: "2.0"
+    increaseMultiplier: "1.2"
   SkipVolumes: true
   # Resources for the controller deployment
   resources:
@@ -423,6 +427,19 @@ rightsizer:
         - ALL
   # The global `rbac.disabled` causes this ServiceAccount to not be created.
   serviceAccountName: insights-agent-right-sizer-controller
+  rbac:
+    # See the global rbac.disabled value is used instead of `create` here.
+    additionalAccess:
+      # Grant access to additional resources, such as CRDs.
+      # Specify an array of RBAC rules,
+      # each having an array of apiGroups, resources, and verbs.
+      # For example:
+      #- apiGroups:
+      #   - ''
+      # resources:
+     #    - 'nodes'
+      # verbs:
+      #   - 'get'
 
 falco:
   enabled: false

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -401,14 +401,14 @@ rightsizer:
   imagePullSecrets:
   stateconfigmapname: insights-agent-right-sizer-controller-state
   # rightsizer.resetOOMsWindow -- The amount of time after which, if no OOMs have been seen, a resource will be removed from this Insights report.
-  resetOOMsWindow: "24H"
+  resetOOMsWindow: "24h"
   # rightsizer.namespaces -- Only operate in these Kubernetes namespaces.
   # By default, all namespaces are allowed.
   # This applies both to alerting on OOM-kills, and updating memory limits (if enabled).
   namespaces:
   updateMemoryLimits:
     # rightsizer.updateMemoryLimits.enabled -- Update memory limibs of resources whos containers are OOM-killed.
-    enabled: "false"
+    enabled: false
     # rightsizer.updateMemoryLimits.increment -- The multiplier used to increase memory limits, in response to an OOM-kill. This value is multiplied by the limits of the OOM-killed container.
     increment: "1.2"
     # rightsizer.updateMemoryLimits.minOOMs -- The number of OOM-kills required before a containers memory limits will be updated.
@@ -426,10 +426,10 @@ rightsizer:
       cpu: 100m
       memory: 128Mi
   deploymentAnnotations:
-    # Temporarily exclude these checks until the next controller release includes health-check endpoints.
-    polaris.fairwinds.com/livenessProbeMissing-exempt: "true"
-    polaris.fairwinds.com/readinessProbeMissing-exempt: "true"
-  securityContext:
+  # rightsizer.extraArgs provides a list of additional command-line flags for the controller.
+  #extraArgs:
+  #- "-v2"
+  containerSecurityContext:
     readOnlyRootFilesystem: true
     allowPrivilegeEscalation: false
     runAsNonRoot: true

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -396,7 +396,7 @@ rightsizer:
   # This image is for the controller, the agent only runs the Insights uploader.
   image:
     repository: quay.io/fairwinds/right-sizer
-    tag: 0.1.0
+    tag: 0.1.1
     pullPolicy: Always
   imagePullSecrets:
   stateconfigmapname: insights-agent-right-sizer-controller-state
@@ -421,6 +421,8 @@ rightsizer:
     capabilities:
       drop:
         - ALL
+  # The global `rbac.disabled` causes this ServiceAccount to not be created.
+  serviceAccountName: insights-agent-right-sizer-controller
 
 falco:
   enabled: false

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -440,7 +440,7 @@ rightsizer:
   deploymentAnnotations: {}
   # rightsizer.extraArgs -- Additional command-line flags for the controller.
   extraArgs: []
-  #- "-v2"
+    # - "-v2"
   # rightsizer.containerSecurityContext -- The securityContext for the
   # controller container.
   containerSecurityContext:
@@ -462,12 +462,14 @@ rightsizer:
     # Specify a list of RBAC rules,
     # each with a list of apiGroups, resources, and verbs.
     additionalAccess: []
-      #- apiGroups:
-      #   - ''
-      # resources:
-     #    - 'nodes'
-      # verbs:
-      #   - 'get'
+      # - apiGroups:
+      #     - ''
+      #  resources:
+     #     - 'ACustomResource'
+      #  verbs:
+      #    - 'get'
+      #    - 'update'
+      #    - 'patch'
 
 falco:
   enabled: false

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -398,6 +398,7 @@ rightsizer:
     repository: quay.io/fairwinds/right-sizer
     tag: 0.1.0
     pullPolicy: Always
+  imagePullSecrets:
   stateconfigmapname: insights-agent-right-sizer-controller-state
   SkipVolumes: true
   # Resources for the controller deployment

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -401,9 +401,9 @@ rightsizer:
   imagePullSecrets:
   stateconfigmapname: insights-agent-right-sizer-controller-state
   updateMemoryLimits:
-    enabled: true
-    maxLimitMultiplier: "2.0"
-    increaseMultiplier: "1.2"
+    enabled: false
+    max: "2.0"
+    increment: "1.2"
   SkipVolumes: true
   # Resources for the controller deployment
   resources:

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -400,10 +400,22 @@ rightsizer:
     pullPolicy: Always
   imagePullSecrets:
   stateconfigmapname: insights-agent-right-sizer-controller-state
+  # rightsizer.resetOOMsWindow -- The amount of time after which, if no OOMs have been seen, a resource will be removed from this Insights report.
+  resetOOMsWindow: "24H"
+  # rightsizer.namespaces -- Only operate in these Kubernetes namespaces.
+  # By default, all namespaces are allowed.
+  # This applies both to alerting on OOM-kills, and updating memory limits (if enabled).
+  namespaces:
   updateMemoryLimits:
-    enabled: false
-    max: "2.0"
+    # rightsizer.updateMemoryLimits.enabled -- Update memory limibs of resources whos containers are OOM-killed.
+    enabled: "false"
+    # rightsizer.updateMemoryLimits.increment -- The multiplier used to increase memory limits, in response to an OOM-kill. This value is multiplied by the limits of the OOM-killed container.
     increment: "1.2"
+    # rightsizer.updateMemoryLimits.minOOMs -- The number of OOM-kills required before a containers memory limits will be updated.
+    minOOMs: "2"
+    # rightsizer.updateMemoryLimits.max -- The multiplier used to calculate the maximum value to update a containers memory limits.
+    # This value is multiplied by the starting memory limits of the first OOM-killed container seen by this controller.
+    max: "2.0"
   SkipVolumes: true
   # Resources for the controller deployment
   resources:

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -396,28 +396,39 @@ rightsizer:
   # This image is for the controller, the agent only runs the Insights uploader.
   image:
     repository: quay.io/fairwinds/right-sizer
-    tag: 0.1.1
+    tag: 0.2
     pullPolicy: Always
-  imagePullSecrets:
+  # rightsizer.imagePullSecrets -- imagePullSecrets containing private registry credentials.
+  imagePullSecrets: []
+
+  # rightsizer.stateconfigmapname -- The name of a ConfigMap where controller
+  # state is stored inbetween restarts.
   stateconfigmapname: insights-agent-right-sizer-controller-state
-  # rightsizer.resetOOMsWindow -- The amount of time after which, if no OOMs have been seen, a resource will be removed from this Insights report.
+  # rightsizer.resetOOMsWindow -- The amount of time after which, if no OOMs
+  # have been seen, items will be removed from the Insights report.
   resetOOMsWindow: "24h"
-  # rightsizer.namespaces -- Only operate in these Kubernetes namespaces.
+  # rightsizer.namespaces -- Kubernetes namespaces to restrict all operations.
   # By default, all namespaces are allowed.
-  # This applies both to alerting on OOM-kills, and updating memory limits (if enabled).
-  namespaces:
+  # This applies both to OOM-kill alerts, and updating memory limits if enabled.
+  namespaces: []
   updateMemoryLimits:
-    # rightsizer.updateMemoryLimits.enabled -- Update memory limibs of resources whos containers are OOM-killed.
+    # rightsizer.updateMemoryLimits.enabled -- Update memory limits of
+    # pod-controller resources whos containers are OOM-killed.
     enabled: false
-    # rightsizer.updateMemoryLimits.increment -- The multiplier used to increase memory limits, in response to an OOM-kill. This value is multiplied by the limits of the OOM-killed container.
-    increment: "1.2"
-    # rightsizer.updateMemoryLimits.minOOMs -- The number of OOM-kills required before a containers memory limits will be updated.
-    minOOMs: "2"
-    # rightsizer.updateMemoryLimits.max -- The multiplier used to calculate the maximum value to update a containers memory limits.
-    # This value is multiplied by the starting memory limits of the first OOM-killed container seen by this controller.
-    max: "2.0"
+    # rightsizer.updateMemoryLimits.increment -- The multiplier used to
+    # increase memory limits, in response to an OOM-kill. This value is
+    # multiplied by the limits of the OOM-killed container.
+    increment: 1.2
+    # rightsizer.updateMemoryLimits.minOOMs -- The number of OOM-kills required
+    # before a pod-controller memory limits will be updated.
+    minOOMs: 2
+    # rightsizer.updateMemoryLimits.max -- The multiplier used to calculate a
+    # maximum value to update a pod-controller memory limits.
+    # This value is multiplied by the starting memory limits of the first
+    # OOM-killed container seen by this controller.
+    max: 2.0
   SkipVolumes: true
-  # Resources for the controller deployment
+  # rightsizer.resources -- Resources for the controller deployment
   resources:
     limits:
       cpu: 250m
@@ -425,10 +436,13 @@ rightsizer:
     requests:
       cpu: 100m
       memory: 128Mi
-  deploymentAnnotations:
-  # rightsizer.extraArgs provides a list of additional command-line flags for the controller.
-  #extraArgs:
+  # rightsizer.deploymentAnnotations -- Annotations to add to the right-sizer controller deployment.
+  deploymentAnnotations: {}
+  # rightsizer.extraArgs -- Additional command-line flags for the controller.
+  extraArgs: []
   #- "-v2"
+  # rightsizer.containerSecurityContext -- The securityContext for the
+  # controller container.
   containerSecurityContext:
     readOnlyRootFilesystem: true
     allowPrivilegeEscalation: false
@@ -438,14 +452,16 @@ rightsizer:
       drop:
         - ALL
   # The global `rbac.disabled` causes this ServiceAccount to not be created.
+  # rightsizer.serviceAccountName -- The Kubernetes ServiceAccount for the
+  # controller. This account will be created unless `rbac.disabled` is set to true.
   serviceAccountName: insights-agent-right-sizer-controller
   rbac:
     # See the global rbac.disabled value is used instead of `create` here.
-    additionalAccess:
-      # Grant access to additional resources, such as CRDs.
-      # Specify an array of RBAC rules,
-      # each having an array of apiGroups, resources, and verbs.
-      # For example:
+    # rightsizer.rbac.additionalAccess -- RBAC rules to be granted to the
+    # controller, providing access to custom resources.
+    # Specify a list of RBAC rules,
+    # each with a list of apiGroups, resources, and verbs.
+    additionalAccess: []
       #- apiGroups:
       #   - ''
       # resources:


### PR DESCRIPTION
**Why This PR?**
Update the insights-agent chart for right-sizer to:
* Add readiness and liveness probes (now supported in right-sizer controller).
* Enable updating of memory limits, with related configuration.
* Add global namespaces option (limits action-item creation and updating limits).
* Add additional RBAC if the `updateMemoryLimits` right-sizer option is enabled.
  * Add an optional Helm value so customers can supply additional RBAC rules, such as allowing right-sizer to update memory limits on CRDs.

See also [the accompanying right-sizer controller PR](https://github.com/FairwindsOps/insights-plugins/pull/551).

**Checklist:**

* [ ] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.


[YouTrack FWI-1017](https://fairwinds.myjetbrains.com/youtrack/issue/FWI-1017)

[Internal Ticket FWI-1017](https://fairwinds.myjetbrains.com/youtrack/issue/FWI-1017)