### PR TITLE
    fix(goldilocks): rbac.extraRules to silence missing permissions errors

### DIFF
--- a/stable/goldilocks/Chart.yaml
+++ b/stable/goldilocks/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 appVersion: "v4.0.0"
-version: 4.0.3
+version: 4.0.4
 description: |
   A Helm chart for running Fairwinds Goldilocks. See https://github.com/FairwindsOps/goldilocks
 name: goldilocks

--- a/stable/goldilocks/README.md
+++ b/stable/goldilocks/README.md
@@ -61,6 +61,7 @@ This will completely remove the VPA and then re-install it using the new method.
 | fullnameOverride | string | `""` |  |
 | controller.enabled | bool | `true` | Whether or not to install the controller deployment |
 | controller.rbac.create | bool | `true` | If set to true, rbac resources will be created for the controller |
+| controller.rbac.extraRules | list | `[]` | Extra rbac rules for the controller clusterrole |
 | controller.serviceAccount.create | bool | `true` | If true, a service account will be created for the controller. If set to false, you must set `controller.serviceAccount.name` |
 | controller.serviceAccount.name | string | `nil` | The name of an existing service account to use for the controller. Combined with `controller.serviceAccount.create` |
 | controller.flags | object | `{}` | A map of additional flags to pass to the controller |

--- a/stable/goldilocks/ci/test-values.yaml
+++ b/stable/goldilocks/ci/test-values.yaml
@@ -15,6 +15,16 @@ controller:
   deployment:
     additionalLabels:
       test: value
+  rbac:
+    extraRules:
+      - apiGroups:
+          - "batch"
+        resources:
+          - "*"
+        verbs:
+          - "get"
+          - "list"
+          - "watch"
 
 dashboard:
   replicaCount: 2

--- a/stable/goldilocks/templates/controller-clusterrole.yaml
+++ b/stable/goldilocks/templates/controller-clusterrole.yaml
@@ -45,4 +45,7 @@ rules:
       - 'get'
       - 'list'
       - 'watch'
+  {{- if .Values.controller.rbac.extraRules -}}
+  {{ toYaml .Values.controller.rbac.extraRules | nindent 2 }}
+  {{- end }}
 {{- end }}

--- a/stable/goldilocks/values.yaml
+++ b/stable/goldilocks/values.yaml
@@ -30,6 +30,8 @@ controller:
   rbac:
     # controller.rbac.create -- If set to true, rbac resources will be created for the controller
     create: true
+    # controller.rbac.extraRules -- Extra rbac rules for the controller clusterrole
+    extraRules: []
   serviceAccount:
     # controller.serviceAccount.create -- If true, a service account will be created for the controller. If set to false, you must set `controller.serviceAccount.name`
     create: true
@@ -118,7 +120,8 @@ dashboard:
   ingress:
     # dashboard.ingress.enabled -- Enables an ingress object for the dashboard.
     enabled: false
-    annotations: {}
+    annotations:
+      {}
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
     hosts:


### PR DESCRIPTION
**Why This PR?**
the list of `list,get,watch` permissions required by the controller is a growing rabbit-hole, so it should be customizable on a case-by-case basis. for instance, i see a flood of errors related to missing permissions on `alertmanagers.monitoring.coreos.com` and `batch` resources. the log noise generated by 'error occured retrieving' messages is excessive to the point where it could incur significant charges from a saas logging provider

Fixes #

**Changes**
Changes proposed in this pull request:

* add additional custom rules in the controller clusterrole

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.