### PR TITLE
[rbac-manager] Allow passing extra args

### DIFF
--- a/stable/rbac-manager/Chart.yaml
+++ b/stable/rbac-manager/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rbac-manager
-version: 1.9.0
+version: 1.10.0
 appVersion: 1.0.0
 description: A Kubernetes operator that simplifies the management of Role Bindings and Service Accounts.
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/rbac-manager/icon.png

--- a/stable/rbac-manager/README.md
+++ b/stable/rbac-manager/README.md
@@ -56,6 +56,7 @@ In the above workflow, an RBAC Definition installed between revision 1 and 2 sho
 | image.tag | string | `"v1.0.0"` | The tag of the image to run |
 | image.pullPolicy | string | `"Always"` | The image pullPolicy. Recommend not changing this |
 | image.imagePullSecrets | list | `[]` |  |
+| extraArgs | object | `{}` | A map of flag=value to pass to rbac-manager |
 | installCRDs | bool | `true` | If true, install and upgrade CRDs. See the Helm documentation for [best practices regarding CRDs](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/#install-a-crd-declaration-before-using-the-resource). |
 | resources | object | `{"limits":{"cpu":"100m","memory":"128Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | A resources block for the rbac-manager pods |
 | priorityClassName | string | `""` | The name of a priorityClass to use |

--- a/stable/rbac-manager/ci/test-values.yaml
+++ b/stable/rbac-manager/ci/test-values.yaml
@@ -1,0 +1,2 @@
+extraArgs:
+  log-level: DEBUG

--- a/stable/rbac-manager/templates/deployment.yaml
+++ b/stable/rbac-manager/templates/deployment.yaml
@@ -40,6 +40,11 @@ spec:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command:
+          - /rbac-manager
+          {{- range $name, $value := .Values.extraArgs }}
+          - --{{ $name }}={{ $value }}
+          {{- end }}
         readinessProbe:
           httpGet:
             scheme: HTTP

--- a/stable/rbac-manager/values.yaml
+++ b/stable/rbac-manager/values.yaml
@@ -8,6 +8,9 @@ image:
   # imagePullSecrets -- A list of imagePullSecrets to reference for pulling the image
   imagePullSecrets: []
 
+# extraArgs -- A map of flag=value to pass to rbac-manager
+extraArgs: {}
+
 # installCRDs -- If true, install and upgrade CRDs. See the Helm documentation for [best practices regarding CRDs](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/#install-a-crd-declaration-before-using-the-resource).
 installCRDs: true
 


### PR DESCRIPTION
**Why This PR?**
Currently there is no way to pass flags to the rbac-manager process

Fixes https://github.com/FairwindsOps/rbac-manager/issues/260

**Changes**
Changes proposed in this pull request:

* Add extraArgs to values as a map

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.