### PR TITLE
Disallow privilege escalation on admission controller. Insights-agent sub-chart to 0.4.3

### DIFF
--- a/stable/insights-admission/Chart.yaml
+++ b/stable/insights-admission/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: insights-admission
 description: A Validating Webhook Admission Controller that utilizes Fairwinds Insights.
 type: application
-version: 0.4.3
+version: 0.4.4
 appVersion: "0.4"
 maintainers:
 - name: rbren

--- a/stable/insights-admission/README.md
+++ b/stable/insights-admission/README.md
@@ -76,7 +76,7 @@ rules:
 | serviceAccount.rbac.additionalAccess | string | `nil` | Grant the admission controller access to additional objects. This should contain an array of objects with each having an array of apiGroups, an array of resources, and an array of verbs. Just like a Role. |
 | podAnnotations | object | `{}` | Annotations to add to each pod. |
 | podSecurityContext | object | `{}` | Security Context for the entire pod. |
-| securityContext | object | `{"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":15000}` | Security Context for the container. |
+| securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":15000}` | Security Context for the container. |
 | service.type | string | `"ClusterIP"` | Type of service to create. |
 | service.port | int | `443` | Port to use for the service. |
 | nodeSelector | object | `{}` | nodSelector to add to the controller. |

--- a/stable/insights-admission/values.yaml
+++ b/stable/insights-admission/values.yaml
@@ -148,6 +148,7 @@ podSecurityContext: {}
 
 # securityContext -- Security Context for the container.
 securityContext:
+  allowPrivilegeEscalation: false
   capabilities:
     drop:
     - ALL

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 1.17.7
+version: 1.17.8
 appVersion: 6.5.1
 maintainers:
   - name: rbren

--- a/stable/insights-agent/requirements.lock
+++ b/stable/insights-agent/requirements.lock
@@ -7,9 +7,9 @@ dependencies:
   version: 14.11.0
 - name: insights-admission
   repository: https://charts.fairwinds.com/stable
-  version: 0.4.2
+  version: 0.4.3
 - name: falco
   repository: https://falcosecurity.github.io/charts
   version: 1.16.0
-digest: sha256:50d80782097d2bbead73974389467cf52fd2ad5f4dfd1b6b422208f538c934e3
-generated: "2021-11-24T14:35:34.064106941Z"
+digest: sha256:dacdc19a6ea34b27175be38b675f66c7bd11a7cc486776e923bf025b9fdda422
+generated: "2022-01-10T15:34:53.82177-07:00"

--- a/stable/insights-agent/requirements.yaml
+++ b/stable/insights-agent/requirements.yaml
@@ -9,7 +9,7 @@ dependencies:
   condition: resourcemetrics.installPrometheus
 - name: insights-admission
   repository: https://charts.fairwinds.com/stable
-  version: 0.4.2
+  version: 0.4.3
   condition: admission.enabled
 - name: falco
   repository: https://falcosecurity.github.io/charts


### PR DESCRIPTION
This will require another PR to update insights-agent when this is complete.

**Why This PR?**
The insights admission controller was missing a security setting to disallow privilege escalation. Detected via Polaris

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.