### PR TITLE
[insights-admission] Add webhook port option

### DIFF
--- a/stable/insights-admission/Chart.yaml
+++ b/stable/insights-admission/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: insights-admission
 description: A Validating Webhook Admission Controller that utilizes Fairwinds Insights.
 type: application
-version: 0.4.4
+version: 0.4.5
 appVersion: "0.4"
 maintainers:
 - name: rbren

--- a/stable/insights-admission/README.md
+++ b/stable/insights-admission/README.md
@@ -79,6 +79,7 @@ rules:
 | securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":15000}` | Security Context for the container. |
 | service.type | string | `"ClusterIP"` | Type of service to create. |
 | service.port | int | `443` | Port to use for the service. |
+| service.usePod443 | bool | `false` | Force binding to port 443 on pods. This is useful for GKE private clusters. Requires running as root |
 | nodeSelector | object | `{}` | nodSelector to add to the controller. |
 | tolerations | list | `[]` | Toleratations to add to the controller. |
 | affinity | object | `{}` | Pod affinity/anti-affinity rules |

--- a/stable/insights-admission/templates/deployment.yaml
+++ b/stable/insights-admission/templates/deployment.yaml
@@ -38,7 +38,7 @@ spec:
           ports:
           - name: https
             {{- if .Values.service.usePod443 }}
-            {{- if or (.Values.securityContext.runAsNonRoot (ne .Values.securityContext.runAsUser 0)) }}
+            {{- if or ((ne .Values.securityContext.runAsNonRoot false) (ne .Values.securityContext.runAsUser 0)) }}
               {{- fail "If using usePod443, you must specify securityContext.runAsNonRoot=false and securityContext.runAsUser=0" }}
             {{- end }}
             containerPort: 443

--- a/stable/insights-admission/templates/deployment.yaml
+++ b/stable/insights-admission/templates/deployment.yaml
@@ -37,7 +37,14 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
           - name: https
+            {{- if .Values.service.usePod443 }}
+            {{- if or (.Values.securityContext.runAsNonRoot (ne .Values.securityContext.runAsUser 0)) }}
+              {{- fail "If using usePod443, you must specify securityContext.runAsNonRoot=false and securityContext.runAsUser=0" }}
+            {{- end }}
+            containerPort: 443
+            {{- else }}
             containerPort: 8443
+            {{- end }}
             protocol: TCP
           - name: health
             containerPort: 8081
@@ -55,6 +62,10 @@ spec:
             mountPath: /opt/cert/
             readOnly: true
           env:
+          {{- if .Values.service.usePod443 }}
+          - name: WEBHOOK_PORT
+            value: "443"
+          {{- end }}
           - name: FAIRWINDS_TOKEN
             valueFrom:
               secretKeyRef:

--- a/stable/insights-admission/values.yaml
+++ b/stable/insights-admission/values.yaml
@@ -161,6 +161,8 @@ service:
   type: ClusterIP
   # service.port -- Port to use for the service.
   port: 443
+  # service.usePod443 -- Force binding to port 443 on pods. This is useful for GKE private clusters. Requires running as root
+  usePod443: false
 
 # nodeSelector -- nodSelector to add to the controller.
 nodeSelector: {}


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_
Adds an option to allow forcing the webhook to listen on port 443, which is helpful in some contexts (e.g. GKE private clusters)

Fixes #

**Changes**
Changes proposed in this pull request:
* add `service.usePod443` option

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
