### PR TITLE
Use GCR Pluto image

### DIFF
--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 1.17.11
+version: 1.17.12
 appVersion: 6.5.1
 maintainers:
   - name: rbren

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -275,7 +275,7 @@ pluto:
   targetVersions: ""
   image:
     repository: us-docker.pkg.dev/fairwinds-ops/oss/pluto
-    tag: "v5.0"
+    tag: "v5.3"
   resources:
     limits:
       cpu: 250m

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -274,7 +274,7 @@ pluto:
   timeout: 300
   targetVersions: ""
   image:
-    repository: quay.io/fairwinds/pluto
+    repository: us-docker.pkg.dev/fairwinds-ops/oss/pluto
     tag: "v5.0"
   resources:
     limits:


### PR DESCRIPTION
**Why This PR?**
Pluto image has moved to GCR

**Changes**
Changes proposed in this pull request:

* use `us-docker.pkg.dev/fairwinds-ops/oss/pluto` as the pluto image repository
* bump pluto to v5.3

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.