### PR TITLE
Add options to set additional labels to CRDs and RBAC resources in rbac-manager helm chart

### DIFF
--- a/stable/rbac-manager/Chart.yaml
+++ b/stable/rbac-manager/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rbac-manager
-version: 1.10.0
+version: 1.10.1
 appVersion: 1.0.0
 description: A Kubernetes operator that simplifies the management of Role Bindings and Service Accounts.
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/rbac-manager/icon.png

--- a/stable/rbac-manager/README.md
+++ b/stable/rbac-manager/README.md
@@ -58,6 +58,8 @@ In the above workflow, an RBAC Definition installed between revision 1 and 2 sho
 | image.imagePullSecrets | list | `[]` |  |
 | extraArgs | object | `{}` | A map of flag=value to pass to rbac-manager |
 | installCRDs | bool | `true` | If true, install and upgrade CRDs. See the Helm documentation for [best practices regarding CRDs](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/#install-a-crd-declaration-before-using-the-resource). |
+| crds.additionalLabels | object | `{}` | add additional labels to the installed CRDs |
+| rbac.additionalLabels | object | `{}` | add additional labels to the installed RBAC resources |
 | resources | object | `{"limits":{"cpu":"100m","memory":"128Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | A resources block for the rbac-manager pods |
 | priorityClassName | string | `""` | The name of a priorityClass to use |
 | nodeSelector | object | `{}` | Deployment nodeSelector |

--- a/stable/rbac-manager/templates/clusterrole.yaml
+++ b/stable/rbac-manager/templates/clusterrole.yaml
@@ -7,6 +7,10 @@ metadata:
     chart: {{ template "rbac-manager.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- if .Values.rbac.additionalLabels }}
+{{ toYaml .Values.rbac.additionalLabels | indent 4 }}
+    {{- end }}
+
 rules:
   - apiGroups:
       - rbacmanager.reactiveops.io

--- a/stable/rbac-manager/templates/clusterrolebinding.yaml
+++ b/stable/rbac-manager/templates/clusterrolebinding.yaml
@@ -7,6 +7,9 @@ metadata:
     chart: {{ template "rbac-manager.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- if .Values.rbac.additionalLabels }}
+{{ toYaml .Values.rbac.additionalLabels | indent 4 }}
+    {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/stable/rbac-manager/templates/customresourcedefinition.yaml
+++ b/stable/rbac-manager/templates/customresourcedefinition.yaml
@@ -8,6 +8,9 @@ metadata:
     chart: {{ template "rbac-manager.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- if .Values.crds.additionalLabels }}
+{{ toYaml .Values.crds.additionalLabels | indent 4 }}
+    {{- end }}
 spec:
   group: rbacmanager.reactiveops.io
   names:

--- a/stable/rbac-manager/templates/serviceaccount.yaml
+++ b/stable/rbac-manager/templates/serviceaccount.yaml
@@ -7,3 +7,6 @@ metadata:
     chart: {{ template "rbac-manager.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- if .Values.rbac.additionalLabels }}
+{{ toYaml .Values.rbac.additionalLabels | indent 4 }}
+    {{- end }}

--- a/stable/rbac-manager/values.yaml
+++ b/stable/rbac-manager/values.yaml
@@ -14,6 +14,14 @@ extraArgs: {}
 # installCRDs -- If true, install and upgrade CRDs. See the Helm documentation for [best practices regarding CRDs](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/#install-a-crd-declaration-before-using-the-resource).
 installCRDs: true
 
+crds:
+# crds.additionalLabels -- add additional labels to the installed CRDs
+  additionalLabels: {}
+
+rbac:
+# rbac.additionalLabels -- add additional labels to the installed RBAC resources
+  additionalLabels: {}
+
 # resources -- A resources block for the rbac-manager pods
 resources:
   requests:


### PR DESCRIPTION
**Why This PR?**
This PR adds the option to add labels to RBAC-resources and CRDs created by this chart.
This is useful if you want to autogenerate ClusterRoles for CRDs and want to include/exclude them by labels.
It is also useful if you want to more granularly control RBAC with Policies based upon labels.


**Changes**
Changes proposed in this pull request:

* Add option to set labels on RBAC and CRDs created by the Chart
*

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
