### PR TITLE
[rbac-manager] fix links to documentation

### DIFF
--- a/stable/rbac-manager/Chart.yaml
+++ b/stable/rbac-manager/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rbac-manager
-version: 1.10.1
+version: 1.10.2
 appVersion: 1.0.0
 description: A Kubernetes operator that simplifies the management of Role Bindings and Service Accounts.
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/rbac-manager/icon.png

--- a/stable/rbac-manager/templates/NOTES.txt
+++ b/stable/rbac-manager/templates/NOTES.txt
@@ -1,7 +1,7 @@
 Thanks for installing RBAC Manager! To see what it's doing, use `kubectl logs` for your new RBAC Manager pod.
 
-If you haven't already installed an RBAC Definition to configure your authorization, visit https://fairwindsops.github.io/rbac-manager/rbacdefinitions.html for more information.
+If you haven't already installed an RBAC Definition to configure your authorization, visit https://rbac-manager.docs.fairwinds.com/ for more information.
 
-For more information on integrating RBAC with common authentication patterns, visit https://fairwindsops.github.io/rbac-manager/.
+For more information on integrating RBAC with common authentication patterns, visit https://rbac-manager.docs.fairwinds.com/ -> Cloud Provider Auth.
 
 If you run into any problems or find something missing in the documentation, don't hesitate to open an issue here: https://github.com/fairwindsops/rbac-manager/issues.


### PR DESCRIPTION
The pull request fixes links to the RBAC Manager documentation displayed after a helm installation.

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
