### PR TITLE
Add fleet install test

### DIFF
--- a/scripts/circle-e2e.sh
+++ b/scripts/circle-e2e.sh
@@ -5,10 +5,8 @@ set -o nounset
 set -x
 
 echo "Starting e2e tests"
-
-if helm version --short --client; then
-    echo "Helm 2 Detected"
-fi
+echo "Helm version: $(helm version --short --client)"
 
 cd /charts
 scripts/e2e-test.sh test
+scripts/fleet-install-test.sh

--- a/scripts/fleet-install-test.sh
+++ b/scripts/fleet-install-test.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+
+set -o errexit
+set -o nounset
+set -x
+
+# Check whether insights-agent is part of the changed charts
+cd /charts
+CHANGED="$(ct list-changed --config ./scripts/ct.yaml)"
+
+case "$CHANGED" in 
+  *insights-agent*)
+    printf "The changed charts include insights-agent. Running fleet install test\n"
+
+    # We use the be-main server to do the test. This is not ideal but will suffice for now
+    # Here we check to make sure that the server is up
+    URL="https://be-main.k8s.insights.fairwinds.com" 
+    retry=0
+    while ! curl -k --no-progress-meter $URL; do
+      printf "Server is not up yet. Waiting for it to start...\n";
+      sleep 20
+
+      retry=$(( retry + 1 ))
+      if [ $retry -gt 30 ]; then
+        printf "Unable to curl the server. Giving up on it.\n"
+        exit 1
+      fi
+    done
+
+    # Install insights-agent using the fleet install method
+    random_number=$(shuf -i 0-500 -n1)
+    cluster_name="test-fleet-$random_number"
+    printf "\nServer is up. Running Fleet install for cluster %s\n" "$cluster_name"
+    
+    helm dependency build ./stable/insights-agent
+    helm upgrade --install insights-agent ./stable/insights-agent -f ./stable/insights-agent/ci/fleet-install-test.yaml \
+      --namespace insights-agent \
+      --create-namespace \
+      --set insights.cluster="$cluster_name" 
+
+    kubectl wait --for=condition=complete job/fleet-installer --timeout=120s --namespace insights-agent
+    kubectl wait --for=condition=complete job/polaris --timeout=120s --namespace insights-agent
+    kubectl wait --for=condition=complete job/workloads --timeout=120s --namespace insights-agent
+    ;;
+esac

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 1.17.12
+version: 1.17.13
 appVersion: 6.5.1
 maintainers:
   - name: rbren

--- a/stable/insights-agent/ci/fleet-install-test.yaml
+++ b/stable/insights-agent/ci/fleet-install-test.yaml
@@ -1,0 +1,10 @@
+fleetInstall: true
+insights:
+  host: https://be-main.k8s.insights.fairwinds.com
+  organization: acme-co
+  tokenSecretName: insights-token
+  apiToken: thisisanadmintoken
+
+polaris:
+  enabled: true
+  


### PR DESCRIPTION
**Why This PR?**
Adding fleet install test for insights-agent

Fixes #

**Changes**
Changes proposed in this pull request:

* New Fleet install test run if the `insights-agent` chart changes

**Checklist:**

* [ ] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
