### PR TITLE
Fix test-pod.yaml so it actually checks cronjobs status

### DIFF
--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 1.17.13
+version: 1.17.15
 appVersion: 6.5.1
 maintainers:
   - name: rbren

--- a/stable/insights-agent/ci/test-values.yaml
+++ b/stable/insights-agent/ci/test-values.yaml
@@ -5,53 +5,101 @@ insights:
   base64token: Zm9v
 
 uploader:
+  resources:
+    requests:
+      cpu: 50m
   env:
   - name: foo
     value: bar
 
+# We set the CPU requests to 50m so the node doesn't run out of CPU
+# TODO: why is this disabled?
 goldilocks:
-  enabled: false  # TODO: why is this disabled?
+  enabled: false
+  resources:
+    requests:
+      cpu: 50m
 
 opa:
   enabled: true
+  resources:
+    requests:
+      cpu: 50m
+
+workloads:
+  resources:
+    requests:
+      cpu: 50m
 
 test:
   enabled: true
 
 kubebench:
   enabled: true
+  resources:
+    requests:
+      cpu: 50m
 
+# This is being removed in the near future
 kubesec:
-  enabled: true
+  enabled: false
+  resources:
+    requests:
+      cpu: 50m
 
 polaris:
   enabled: true
+  resources:
+    requests:
+      cpu: 50m
 
 pluto:
   enabled: true
+  resources:
+    requests:
+      cpu: 50m
 
 nova:
   enabled: true
+  resources:
+    requests:
+      cpu: 50m
 
 kubehunter:
   enabled: true
+  resources:
+    requests:
+      cpu: 50m
 
 trivy:
   enabled: true
   maxScansPerRun: 2
+  resources:
+    requests:
+      cpu: 50m
 
 resourcemetrics:
   enabled: true
   installPrometheus: true
+  resources:
+    requests:
+      cpu: 50m
+
+prometheus:
+  server:
+    resources:
+      requests:
+        cpu: 100m
 
 admission:
   enabled: true
 
+# We don't want to test AWS here with real secrets
 awscosts:
-  enabled: true
+  enabled: false
   secretName: awscosts-secret
-  awsAccessKeyId: YXdzX2Nvc3RzX2tleQo=
-  awsSecretAccessKey: YXdzX2Nvc3RzX3NlY3JldF9rZXkK
+  awsAccessKeyId: someAccessID
+  awsSecretAccessKey: someAccessKey
   region: us-east-1
   database: athena_cur_database
   table: fairwinds_insights_cur_report
@@ -60,6 +108,10 @@ awscosts:
   tagvalue: staging.internal.reactiveops.com
   workgroup: cur_athena_workgroup
 
+# Falco does not work well with KIND cluster
 falco:
-  installFalco: false  # Falco does not work well with KIND cluster
+  installFalco: false
   enabled: true
+  resources:
+    requests:
+      cpu: 50m

--- a/stable/insights-agent/ci/test-values.yaml
+++ b/stable/insights-agent/ci/test-values.yaml
@@ -89,7 +89,7 @@ prometheus:
   server:
     resources:
       requests:
-        cpu: 100m
+        cpu: 200m
 
 admission:
   enabled: true

--- a/stable/insights-agent/download-kubectl.sh
+++ b/stable/insights-agent/download-kubectl.sh
@@ -1,6 +1,6 @@
 #! /bin/sh
 
-set -eo pipeline
+set -e
 
 mkdir /tmp/bin
 export PATH=$PATH:/tmp/bin

--- a/stable/insights-agent/templates/test/test-pod.yaml
+++ b/stable/insights-agent/templates/test/test-pod.yaml
@@ -19,7 +19,7 @@ spec:
       args:
         - -c
         - |
-          {{ .Files.Get "download-kubectl.sh" | nindent 12 }}
+          {{ .Files.Get "download-kubectl.sh" | nindent 10 }}
           sleep 15
           kubectl wait --for=condition=complete job/falco --timeout=240s
           kubectl wait --for=condition=complete job/nova --timeout=240s

--- a/stable/insights-agent/templates/test/test-pod.yaml
+++ b/stable/insights-agent/templates/test/test-pod.yaml
@@ -7,35 +7,74 @@ metadata:
     app: insights-agent
     component: test-job
   annotations:
-    "helm.sh/hook": test
+    "helm.sh/hook": post-install,post-upgrade
 spec:
   serviceAccountName: {{ include "insights-agent.fullname" . }}-cronjob-executor
   restartPolicy: Never
   containers:
-  - command:
-    - sh
-    args:
-    - -c
-    - |
-      sleep 15
-      kubectl get cj --selector=app=insights-agent -o custom-columns=NAME:.metadata.name --no-headers | xargs -I~job~ kubectl wait --for=condition=complete job/~job~ --timeout=120s
-    image: '{{.Values.cronjobExecutor.image.repository}}:{{.Values.cronjobExecutor.image.tag}}'
-    imagePullPolicy: Always
-    name: test
-    resources:
-      limits:
-        cpu: 1
-        memory: 1Gi
-      requests:
-        cpu: 100m
-        memory: 128Mi
-    securityContext:
-      runAsUser: 1000
-      allowPrivilegeEscalation: false
-      privileged: false
-      readOnlyRootFilesystem: true
-      runAsNonRoot: true
-      capabilities:
-        drop:
-        - ALL
+    - name: test
+      image: '{{.Values.cronjobExecutor.image.repository}}:{{.Values.cronjobExecutor.image.tag}}'
+      imagePullPolicy: Always
+      command: 
+        - "sh"
+        - "-c"
+        - |
+          set -eo pipefail
+          mkdir /tmp/bin
+          export PATH=$PATH:/tmp/bin
+          cd /tmp/bin
+          # Download kubectl to match the cluster version,
+          # using kubectl 1.19 for clusters <= 1.19.
+          default_kubectl_version='v1.19.6'
+          echo "Downloading jq . . ."
+          curl -Lo jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && chmod +x jq
+          echo "Getting the Kubernetes version from the API. . ."
+          kube_version=$(curl -ks https://kubernetes.default.svc/version?timeout=32s | jq -r .gitVersion | cut -d- -f1)
+          kube_minor_version=$(echo $kube_version |cut -d. -f2)
+          if [ "x${kube_version}" == "x" ] ; then
+            kubectl_version="${default_kubectl_version}"
+            echo "Using kubectl version ${kubectl_version} because I was unable to get the Kubernetes cluster version"
+          elif [ "$kube_minor_version" -gt 19 ] ; then
+            kubectl_version="${kube_version}"
+            echo "Using kubectl version ${kubectl_version} to match the cluster"
+          else
+            kubectl_version="${default_kubectl_version}"
+            echo "Using kubectl version ${kubectl_version} because the cluster is <= version 1.19"
+          fi
+          echo Downloading kubectl version ${kubectl_version}
+          curl -Lo kubectl "https://dl.k8s.io/release/${kubectl_version}/bin/linux/amd64/kubectl" && chmod +x kubectl
+          sleep 15
+          kubectl wait --for=condition=complete job/falco --timeout=240s
+          kubectl wait --for=condition=complete job/nova --timeout=240s
+          kubectl wait --for=condition=complete job/opa --timeout=240s
+          kubectl wait --for=condition=complete job/pluto --timeout=240s
+          kubectl wait --for=condition=complete job/polaris --timeout=240s
+          kubectl wait --for=condition=complete job/resource-metrics --timeout=240s
+          kubectl wait --for=condition=complete job/trivy --timeout=240s
+          kubectl wait --for=condition=complete job/workloads --timeout=240s
+          kubectl wait --for=condition=complete job/kube-bench --timeout=240s
+          kubectl wait --for=condition=complete job/kube-hunter --timeout=240s
+          kubectl get jobs
+      resources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 50m
+          memory: 128Mi
+      volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+      securityContext:
+        runAsUser: 1000
+        allowPrivilegeEscalation: false
+        privileged: false
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+        capabilities:
+          drop:
+            - ALL
+  volumes:
+    - name: tmp
+      emptyDir: {}
 {{- end -}}

--- a/stable/insights-agent/templates/test/test-pod.yaml
+++ b/stable/insights-agent/templates/test/test-pod.yaml
@@ -15,9 +15,9 @@ spec:
     - name: test
       image: '{{.Values.cronjobExecutor.image.repository}}:{{.Values.cronjobExecutor.image.tag}}'
       imagePullPolicy: Always
-      command: 
-        - "sh"
-        - "-c"
+      command: ["sh"]
+      args:
+        - -c
         - |
           {{ .Files.Get "download-kubectl.sh" | nindent 12 }}
           sleep 15

--- a/stable/insights-agent/templates/test/test-pod.yaml
+++ b/stable/insights-agent/templates/test/test-pod.yaml
@@ -19,6 +19,7 @@ spec:
       args:
         - -c
         - |
+          set -eo pipeline
           {{ .Files.Get "download-kubectl.sh" | nindent 10 }}
           sleep 15
           kubectl wait --for=condition=complete job/falco --timeout=240s


### PR DESCRIPTION
**Why This PR?**
Just fixes the pipeline test to actually check the cronjobs status

Fixes #

**Changes**
Changes proposed in this pull request:

* Fail if the cronjobs do not complete successfully

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
