### PR TITLE
FWI-1368 - Release `insights-admission` version 1.0 chart

### DIFF
--- a/stable/insights-admission/Chart.yaml
+++ b/stable/insights-admission/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: insights-admission
 description: A Validating Webhook Admission Controller that utilizes Fairwinds Insights.
 type: application
-version: 0.4.5
-appVersion: "0.4"
+version: 1.0.0
+appVersion: "0.5"
 maintainers:
 - name: rbren
 - name: makoscafee

--- a/stable/insights-admission/README.md
+++ b/stable/insights-admission/README.md
@@ -47,7 +47,7 @@ rules:
 | insights.configmap.create | bool | `true` | Create a config map with Insights configuration |
 | insights.configmap.nameOverride | string | `nil` | The name of the configmap to use. |
 | insights.configmap.suffix | string | `"configmap"` | The suffix to add onto the release name to get the configmap that contains the host/organization/cluster |
-| webhookConfig.failurePolicy | string | `"Fail"` | failurePolicy for the ValidatingWebhookConfiguration |
+| webhookConfig.failurePolicy | string | `"Ignore"` | failurePolicy for the ValidatingWebhookConfiguration |
 | webhookConfig.matchPolicy | string | `"Exact"` | matchPolicy for the ValidatingWebhookConfiguration |
 | webhookConfig.namespaceSelector | object | `{"matchExpressions":[{"key":"control-plane","operator":"DoesNotExist"}]}` | namespaceSelector for the ValidatingWebhookConfiguration |
 | webhookConfig.objectSelector | object | `{}` | objectSelector for the ValidatingWebhookConfiguration |
@@ -86,4 +86,4 @@ rules:
 | caBundle | string | `""` | If you are providing your own certificate then this is the Certificate Authority for that certificate |
 | secretName | string | `""` | If you are providing your own certificate then this is the name of the secret holding the certificate. |
 | clusterDomain | string | `"cluster.local"` | The base domain to use for cluster DNS |
-| test | object | `{"enabled":false,"image":{"repository":"python","tag":"3.8-alpine"}}` | Used for chart CI only - deploys a test deployment |
+| test | object | `{"enabled":false,"image":{"repository":"python","tag":"3.10-alpine"}}` | Used for chart CI only - deploys a test deployment |

--- a/stable/insights-admission/values.yaml
+++ b/stable/insights-admission/values.yaml
@@ -24,7 +24,7 @@ insights:
 
 webhookConfig:
   # webhookConfig.failurePolicy -- failurePolicy for the ValidatingWebhookConfiguration
-  failurePolicy: Fail
+  failurePolicy: Ignore
   # webhookConfig.matchPolicy -- matchPolicy for the ValidatingWebhookConfiguration
   matchPolicy: Exact
   # webhookConfig.namespaceSelector -- namespaceSelector for the ValidatingWebhookConfiguration
@@ -185,4 +185,4 @@ test:
   enabled: false
   image:
     repository: "python"
-    tag: "3.8-alpine"
+    tag: "3.10-alpine"


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_
This PR changes the default webhook `failurePolicy` from `Fail` to `Ignore` and release new insights-admission chart
Fixes #

**Changes**
Changes proposed in this pull request:

* Change default `webhook.failurePolicy` value from `Fail` to `Ignore`
* Update testing python version from `3.8` to `3.10`

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.


[Internal Ticket FWI-1368](https://fairwinds.myjetbrains.com/youtrack/issue/FWI-1368)