### PR TITLE
Update version of helm-release-pruner image to 3.2.1

### DIFF
--- a/stable/helm-release-pruner/Chart.yaml
+++ b/stable/helm-release-pruner/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v3.2.0
 description: This chart deploys a cronjob that purges stale Helm releases and associated namespaces. Releases are selected based on regex patterns for release name and namespace along with a Bash `date` command date string to define the stale cutoff date and time.
 name: helm-release-pruner
-version: 3.2.4
+version: 3.2.5
 maintainers:
   - name: rbren
   - name: sudermanjr

--- a/stable/helm-release-pruner/README.md
+++ b/stable/helm-release-pruner/README.md
@@ -41,7 +41,7 @@ Chart version 1.0.0 introduced RBacDefinitions with rbac-manager to manage acces
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | image.repository | string | `"quay.io/fairwinds/helm-release-pruner"` | Repo for image that the job runs on |
-| image.tag | string | `"v3.2.0"` | The image tag to use |
+| image.tag | string | `"v3.2.1"` | The image tag to use |
 | image.pullPolicy | string | `"Always"` | The image pull policy. We do not recommend changing this |
 | job.backoffLimit | int | `3` | The backoff limit for the job |
 | job.restartPolicy | string | `"Never"` |  |

--- a/stable/helm-release-pruner/values.yaml
+++ b/stable/helm-release-pruner/values.yaml
@@ -4,7 +4,7 @@ image:
   # image.repository -- Repo for image that the job runs on
   repository: quay.io/fairwinds/helm-release-pruner
   # image.tag -- The image tag to use
-  tag: v3.2.0
+  tag: v3.2.1
   # image.pullPolicy -- The image pull policy. We do not recommend changing this
   pullPolicy: Always
 


### PR DESCRIPTION
**Why This PR?**
Updating the version of helm-release-pruner image to fix a minor bug

Fixes #
This will make sure the helm-release-pruner cleans up all old helm releases regardless of their status

**Changes**
Changes proposed in this pull request:

* 
*

**Checklist:**

* [ X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [ ] Any new values are backwards compatible and/or have sensible default.
* [X ] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
