### PR TITLE
datadog-apm remove replicas and modify hpa memory config

### DIFF
--- a/incubator/datadog-apm/Chart.yaml
+++ b/incubator/datadog-apm/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: datadog-apm
 description: A modified chart that only installs the datadog-apm agent
 type: application
-version: 0.0.3
+version: 0.0.4
 appVersion: "7.32.4"
 maintainers:
   - name: sammc3

--- a/incubator/datadog-apm/ci/test-values.yaml
+++ b/incubator/datadog-apm/ci/test-values.yaml
@@ -15,7 +15,6 @@ datadog:
   site: datadoghq.com
 
 clusterAgent:
-  replicas: 2
   image:
     repository: datadog/agent
     pullPolicy: Always
@@ -74,7 +73,7 @@ clusterAgent:
     enabled: true
     minReplicas: 1
     maxReplicas: 6
-    averageMemoryUtilization: 130Mi
+    averageMemoryUtilization: 75
   createPodDisruptionBudget: true
 
 podAnnotations: {}

--- a/incubator/datadog-apm/templates/cluster-agent-deployment.yaml
+++ b/incubator/datadog-apm/templates/cluster-agent-deployment.yaml
@@ -11,7 +11,6 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
     app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 spec:
-  replicas: {{ .Values.clusterAgent.replicas }}
   strategy:
 {{- if .Values.clusterAgent.strategy }}
 {{ toYaml .Values.clusterAgent.strategy | indent 4 }}

--- a/incubator/datadog-apm/templates/cluster-agent-hpa.yaml
+++ b/incubator/datadog-apm/templates/cluster-agent-hpa.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.clusterAgent.hpa.enabled -}}
 ---
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "datadog-apm.fullname" . }}-hpa-mem

--- a/incubator/datadog-apm/templates/cluster-agent-hpa.yaml
+++ b/incubator/datadog-apm/templates/cluster-agent-hpa.yaml
@@ -17,5 +17,5 @@ spec:
       name: memory
       target:
         type: Utilization
-        averageValue: {{ .Values.clusterAgent.hpa.averageMemoryUtilization }}
+        targetAverageUtilization: {{ .Values.clusterAgent.hpa.averageMemoryUtilization }}
 {{- end }}

--- a/incubator/datadog-apm/templates/cluster-agent-hpa.yaml
+++ b/incubator/datadog-apm/templates/cluster-agent-hpa.yaml
@@ -15,7 +15,5 @@ spec:
   - type: Resource
     resource:
       name: memory
-      target:
-        type: Utilization
-        targetAverageUtilization: {{ .Values.clusterAgent.hpa.averageMemoryUtilization }}
+      targetAverageUtilization: {{ .Values.clusterAgent.hpa.averageMemoryUtilization }}
 {{- end }}

--- a/incubator/datadog-apm/values.yaml
+++ b/incubator/datadog-apm/values.yaml
@@ -13,7 +13,6 @@ datadog:
   site: datadoghq.com
 
 clusterAgent:
-  replicas: 2
   image:
     repository: datadog/agent
     pullPolicy: Always

--- a/incubator/datadog-apm/values.yaml
+++ b/incubator/datadog-apm/values.yaml
@@ -68,7 +68,7 @@ clusterAgent:
     enabled: true
     minReplicas: 1
     maxReplicas: 6
-    averageMemoryUtilization: 130Mi
+    averageMemoryUtilization: 75
   createPodDisruptionBudget: true
 
 podAnnotations: {}


### PR DESCRIPTION
**Why This PR?**
Update replicas such that it doesn't conflict with HPA. Modify hpa to use target memory percentage vs a value.

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
