### PR TITLE
Allow setting additional annototions on the installReporter job

### DIFF
--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 1.17.17
+version: 1.17.18
 appVersion: 6.5.1
 maintainers:
   - name: rbren

--- a/stable/insights-agent/ci/test-values.yaml
+++ b/stable/insights-agent/ci/test-values.yaml
@@ -115,3 +115,8 @@ falco:
   resources:
     requests:
       cpu: 50m
+
+installReporter:
+  additionalAnnotations:
+    "argocd.argoproj.io/hook": PostSync
+    "argocd.argoproj.io/hook-delete-policy": HookSucceeded

--- a/stable/insights-agent/templates/install-reporter/job.yaml
+++ b/stable/insights-agent/templates/install-reporter/job.yaml
@@ -6,6 +6,9 @@ metadata:
     app: insights-agent
   annotations:
     "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+  {{- with .Values.installReporter.additionalAnnotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   ttlSecondsAfterFinished: 300
   backoffLimit: {{ .Values.cronjobs.backoffLimit }}

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -55,6 +55,7 @@ installReporter:
     requests:
       cpu: 100m
       memory: 128Mi
+  additionalAnnotations: {}
 
 polaris:
   enabled: false


### PR DESCRIPTION
**Why This PR?**
I need to add argocd annotations to the installReporter job in order to make it into a post-sync hook.

**Changes**
Changes proposed in this pull request:

* Add an empty-by-default map of annotations for the installReporter job
* Add some example annotations to the ci/test-values in order to test this change

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.