### PR TITLE
[VPA] Update to vpa 0.10.0

### DIFF
--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 1.0.0
-appVersion: 0.9.2
+version: 1.1.0
+appVersion: 0.10.0
 maintainers:
   - name: sudermanjr


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_
https://github.com/kubernetes/autoscaler/releases/tag/vertical-pod-autoscaler-0.10.0

Fixes #

**Changes**
Changes proposed in this pull request:

* Bump image version of vpa

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.