### PR TITLE
[insights-agent] Mount /tmp folder for Trivy

### DIFF
--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 1.17.18
+version: 1.17.19
 appVersion: 6.5.1
 maintainers:
   - name: rbren

--- a/stable/insights-agent/templates/trivy/cronjob.yaml
+++ b/stable/insights-agent/templates/trivy/cronjob.yaml
@@ -12,6 +12,8 @@ spec:
           {{ include "job-template-spec" . | indent 10 | trim }}
           - name: tmp
             emptyDir: {}
+          - name: vartmp
+            emptyDir: {}
           {{ with .Values.trivy.privateImages.dockerConfigSecret }}
           - name: dockerconfig
             secret:
@@ -19,8 +21,10 @@ spec:
           {{ end }}
           containers:
           - {{ include "container-spec" . | indent 12 | trim }}
-            - name: tmp
+            - name: vartmp
               mountPath: /var/tmp
+            - name: tmp
+              mountPath: /tmp
             {{ with .Values.trivy.privateImages.dockerConfigSecret }}
             - name: dockerconfig
               mountPath: /.docker/


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_
Version `0.23.0` of trivy `download-db-only ` transient stores the downloaded db to path like `/tmp/artifact-3449307507.tar.gz` currently it is throwing this error
`DB error: failed to download vulnerability DB: database download error: failed to create a temp file: open /tmp/artifact-3449307507.tar.gz: read-only file system\n"`

Fixes #

**Changes**
Changes proposed in this pull request:

* Mount /tmp folder
*

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
