### PR TITLE
feat: add controller.deployment.podAnnotations

### DIFF
--- a/stable/goldilocks/Chart.yaml
+++ b/stable/goldilocks/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 appVersion: "v4.1.0"
-version: 5.2.0
+version: 5.3.0
 description: |
   A Helm chart for running Fairwinds Goldilocks. See https://github.com/FairwindsOps/goldilocks
 name: goldilocks

--- a/stable/goldilocks/README.md
+++ b/stable/goldilocks/README.md
@@ -83,9 +83,9 @@ This will completely remove the VPA and then re-install it using the new method.
 | controller.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":10324}` | The container securityContext for the controller container |
 | controller.deployment.extraVolumeMounts | list | `[]` | Extra volume mounts for the controller container |
 | controller.deployment.extraVolumes | list | `[]` | Extra volumes for the controller pod |
-| controller.deployment.podAnnotations | object | `{}` | Extra annotations for the controller pod |
 | controller.deployment.annotations | object | `{}` | Extra annotations for the controller deployment |
 | controller.deployment.additionalLabels | object | `{}` | Extra labels for the controller deployment |
+| controller.deployment.podAnnotations | object | `{}` | Extra annotations for the controller pod |
 | dashboard.enabled | bool | `true` | If true, the dashboard component will be installed |
 | dashboard.replicaCount | int | `2` | Number of dashboard pods to run |
 | dashboard.service.type | string | `"ClusterIP"` | The type of the dashboard service |

--- a/stable/goldilocks/README.md
+++ b/stable/goldilocks/README.md
@@ -83,7 +83,7 @@ This will completely remove the VPA and then re-install it using the new method.
 | controller.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":10324}` | The container securityContext for the controller container |
 | controller.deployment.extraVolumeMounts | list | `[]` | Extra volume mounts for the controller container |
 | controller.deployment.extraVolumes | list | `[]` | Extra volumes for the controller pod |
-| controller.deployment.podAnnotations | object | `{}` | Extra annotations for the controller pod 
+| controller.deployment.podAnnotations | object | `{}` | Extra annotations for the controller pod |
 | controller.deployment.annotations | object | `{}` | Extra annotations for the controller deployment |
 | controller.deployment.additionalLabels | object | `{}` | Extra labels for the controller deployment |
 | dashboard.enabled | bool | `true` | If true, the dashboard component will be installed |

--- a/stable/goldilocks/README.md
+++ b/stable/goldilocks/README.md
@@ -83,6 +83,7 @@ This will completely remove the VPA and then re-install it using the new method.
 | controller.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":10324}` | The container securityContext for the controller container |
 | controller.deployment.extraVolumeMounts | list | `[]` | Extra volume mounts for the controller container |
 | controller.deployment.extraVolumes | list | `[]` | Extra volumes for the controller pod |
+| controller.deployment.podAnnotations | object | `{}` | Extra annotations for the controller pod 
 | controller.deployment.annotations | object | `{}` | Extra annotations for the controller deployment |
 | controller.deployment.additionalLabels | object | `{}` | Extra labels for the controller deployment |
 | dashboard.enabled | bool | `true` | If true, the dashboard component will be installed |

--- a/stable/goldilocks/ci/test-values.yaml
+++ b/stable/goldilocks/ci/test-values.yaml
@@ -15,6 +15,8 @@ controller:
   deployment:
     additionalLabels:
       test: value
+    podAnnotations:
+      foo: bar
   rbac:
     extraRules:
       - apiGroups:

--- a/stable/goldilocks/templates/controller-deployment.yaml
+++ b/stable/goldilocks/templates/controller-deployment.yaml
@@ -32,6 +32,10 @@ spec:
         {{- if .Values.controller.deployment.additionalLabels }}
         {{ toYaml .Values.controller.deployment.additionalLabels | nindent 8 }}
         {{- end }}
+      {{- with .Values.controller.deployment.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/stable/goldilocks/values.yaml
+++ b/stable/goldilocks/values.yaml
@@ -85,6 +85,9 @@ controller:
     # controller.deployment.additionalLabels -- Extra labels for the controller deployment
     additionalLabels: {}
 
+    # controller.deployment.podAnnotations -- Extra annotations for the controller pod
+    podAnnotations: {}
+
 dashboard:
   # dashboard.enabled -- If true, the dashboard component will be installed
   enabled: true


### PR DESCRIPTION
**Why This PR?**
Need a way to add custom labels to all pods and/or specific component pods

Fixes #715

**Changes**
Changes proposed in this pull request:

* controller.deployment.podLabels added to values.yaml

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
