### PR TITLE
[VPA] Add imagePullSecrets to certgen spec

### DIFF
--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 1.2.0
+version: 1.2.1
 appVersion: 0.10.0
 maintainers:
   - name: sudermanjr

--- a/stable/vpa/templates/admission-controller-certgen.yaml
+++ b/stable/vpa/templates/admission-controller-certgen.yaml
@@ -60,6 +60,10 @@ spec:
     spec:
       restartPolicy: Never
       serviceAccountName: {{ include "vpa.fullname" . }}-certgen
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: certgen
         image: "{{ .Values.admissionController.certGen.image.repository }}:{{ .Values.admissionController.certGen.image.tag | default .Chart.AppVersion }}"

--- a/stable/vpa/templates/admission-controller-cleanup.yaml
+++ b/stable/vpa/templates/admission-controller-cleanup.yaml
@@ -59,6 +59,10 @@ spec:
     spec:
       restartPolicy: Never
       serviceAccountName: {{ include "vpa.fullname" . }}-cleanup
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: cleanup
         image: {{ .Values.admissionController.cleanupOnDelete.image.repository }}:{{ .Values.admissionController.cleanupOnDelete.image.tag }}


### PR DESCRIPTION
**Why This PR?**
This PR allows admission-controller-certgen image to be pulled from a private registry, something that is not possible at the moment.

**Changes**
Changes proposed in this pull request:

Add imagePullSecrets to:
- vpa/templates/admission-controller-certgen.yaml
- vpa/templates/admission-controller-cleanup.yaml

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
