### PR TITLE
[stable/vpa] disable admission controller cleanup if admission controller disabled

### DIFF
--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 1.2.1
+version: 1.2.2
 appVersion: 0.10.0
 maintainers:
   - name: sudermanjr

--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 1.2.0
+version: 1.2.1
 appVersion: 0.10.0
 maintainers:
   - name: sudermanjr

--- a/stable/vpa/templates/admission-controller-cleanup.yaml
+++ b/stable/vpa/templates/admission-controller-cleanup.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.admissionController.cleanupOnDelete.enabled }}
+{{- if and .Values.admissionController.cleanupOnDelete.enabled .Values.admissionController.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}


### PR DESCRIPTION
Fixes #722

**Changes**
Changes proposed in this pull request:

* Add a check for admission controller enabled to the cleanup job conditional

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.