### PR TITLE
[insights-agent] increase default memory for prometheus and falco

### DIFF
--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 1.17.20
+version: 1.17.21
 appVersion: 6.5.1
 maintainers:
   - name: rbren

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -520,11 +520,11 @@ falcosecurity:
   fullnameOverride: insights-agent
   resources:
     requests:
-      cpu: 50m
-      memory: 128Mi
+      cpu: 100m
+      memory: 512Mi
     limits:
-      cpu: 50m
-      memory: 128Mi
+      cpu: 100m
+      memory: 512Mi
   falco:
     jsonOutput: true
   ebpf:

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -330,9 +330,9 @@ prometheus:
     resources:
       limits:
         cpu: 500m
-        memory: 2Gi
+        memory: 3Gi
       requests:
-        cpu: 500m
+        cpu: 250m
         memory: 2Gi
   kube-state-metrics:
     image:

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -330,10 +330,10 @@ prometheus:
     resources:
       limits:
         cpu: 500m
-        memory: 512Mi
+        memory: 2Gi
       requests:
         cpu: 500m
-        memory: 512Mi
+        memory: 2Gi
   kube-state-metrics:
     image:
       pullPolicy: Always

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -521,9 +521,9 @@ falcosecurity:
   resources:
     requests:
       cpu: 100m
-      memory: 512Mi
+      memory: 256Mi
     limits:
-      cpu: 100m
+      cpu: 200m
       memory: 512Mi
   falco:
     jsonOutput: true


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_
P8s seems to crash in many clusters with the existing defaults


Fixes #

**Changes**
Changes proposed in this pull request:

* bump memory requests/limits to 2Gi (typical usage in normal clusters based on some basic research)

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
