### PR TITLE
[insights-agent] Fix cronjob capabilities detection

### DIFF
--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 1.17.20
+version: 1.17.21
 appVersion: 6.5.1
 maintainers:
   - name: rbren

--- a/stable/insights-agent/templates/_specs.yaml
+++ b/stable/insights-agent/templates/_specs.yaml
@@ -10,7 +10,7 @@
 {{- end }}
 
 {{ define "cronjob" }}
-{{- if not (.Capabilities.APIVersions.Has "batch/v1/CronJob") }}
+{{- if not (.Capabilities.APIVersions.Has "batch/v1") }}
 apiVersion: batch/v1beta1
 {{- else }}
 apiVersion: batch/v1


### PR DESCRIPTION
**Why This PR?**
The current implementation of the cronjob template does not correctly detect if batch/v1 is appropriate for cronjobs.

In the current version of the chart:

```
▶ helm template fairwinds-stable/insights-agent --version=1.17.* --api-versions=cert-manager.io/v1,batch/v1 --set insights.base64token=foo --set insights.cluster=foo --set insights.organization=foo --set trivy.enabled=true --set opa.enabled=true --set nova.enabled=true | grep batch -B1
              "wavefront": {
                "batchsize": 10000,
--
                "apiGroups": [
                  "batch"
--
  verbs: ["get", "list"]
- apiGroups: ["batch"]
--
  verbs: ["get", "list"]
- apiGroups: ["batch"]
--
# Source: insights-agent/templates/install-reporter/job.yaml
apiVersion: batch/v1
--
# Source: insights-agent/templates/nova/cronjob.yaml
apiVersion: batch/v1beta1
--
# Source: insights-agent/templates/opa/cronjob.yaml
apiVersion: batch/v1beta1
--
# Source: insights-agent/templates/trivy/cronjob.yaml
apiVersion: batch/v1beta1
--
# Source: insights-agent/templates/workloads/cronjob.yaml
apiVersion: batch/v1beta1
--
# Source: insights-agent/templates/cronjob-executor/job.yaml
apiVersion: batch/v1
--
```

In this PR:
```
▶ helm template ~/repos/fairwindsops/charts/stable/insights-agent --api-versions=cert-manager.io/v1,batch/v1 --set insights.base64token=foo --set insights.cluster=foo --set insights.organization=foo --set trivy.enabled=true --set opa.enabled=true --set nova.enabled=true | grep batch -B1
              "wavefront": {
                "batchsize": 10000,
--
                "apiGroups": [
                  "batch"
--
  verbs: ["get", "list"]
- apiGroups: ["batch"]
--
  verbs: ["get", "list"]
- apiGroups: ["batch"]
--
# Source: insights-agent/templates/install-reporter/job.yaml
apiVersion: batch/v1
--
# Source: insights-agent/templates/nova/cronjob.yaml
apiVersion: batch/v1
--
# Source: insights-agent/templates/opa/cronjob.yaml
apiVersion: batch/v1
--
# Source: insights-agent/templates/trivy/cronjob.yaml
apiVersion: batch/v1
--
# Source: insights-agent/templates/workloads/cronjob.yaml
apiVersion: batch/v1
--
# Source: insights-agent/templates/cronjob-executor/job.yaml
apiVersion: batch/v1
--
```

**Changes**
Changes proposed in this pull request:

* Update the if statement in the cronjob template

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.