### PR TITLE
Remove alpha indication from chart README

### DIFF
--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "7.9.0"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 0.3.23
+version: 0.3.24
 maintainers:
 - name: rbren
 - name: makoscafee

--- a/stable/fairwinds-insights/README.md
+++ b/stable/fairwinds-insights/README.md
@@ -2,10 +2,9 @@
 
 [Fairwinds Insights](https://insights.fairwinds.com) - Software to automate, monitor, and enforce Kubernetes best practices.
 
-> The self-hosted version of Fairwinds Insights is currently in alpha.
-> The documentation is incomplete, and it is subject to breaking changes.
+> The documentation may be incomplete, and it is subject to breaking changes.
 
-See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/self-hosted/installation/) for complete documentation.
+See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-details/self-hosted/installation/) for complete documentation.
 
 ## Values
 

--- a/stable/fairwinds-insights/README.md.gotmpl
+++ b/stable/fairwinds-insights/README.md.gotmpl
@@ -2,9 +2,8 @@
 
 [Fairwinds Insights](https://insights.fairwinds.com) - Software to automate, monitor, and enforce Kubernetes best practices.
 
-> The self-hosted version of Fairwinds Insights is currently in alpha.
-> The documentation is incomplete, and it is subject to breaking changes.
+> The documentation may be incomplete, and it is subject to breaking changes.
 
-See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/self-hosted/installation/) for complete documentation.
+See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-details/self-hosted/installation/) for complete documentation.
 
 {{ template "chart.valuesSection" . }}


### PR DESCRIPTION
**Why This PR?**
Remove alpha indication from chart README

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [ ] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
