### PR TITLE
FWI-1451 - Pass 'ignore unfixed' flag into Trivy via Insights Agent

### DIFF
--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 1.17.25
+version: 1.17.26
 appVersion: 6.5.1
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:

--- a/stable/insights-agent/README.md
+++ b/stable/insights-agent/README.md
@@ -87,6 +87,7 @@ Parameter | Description | Default
 `kubebench.mode` | Changes the way this plugin is deployed, either `cronjob` where it will run a single pod on the `schedule` that will pull the data necessary from a single node and report that back to Insights. `daemonset` which deploys a daemonset to the cluster which gathers data then a cronjob will gather data from each of those pods. `daemonsetMaster`  is the same as `daemonset` except the daemonset can also run on masters. | `cronjob`
 `kubebench.hourInterval` | If running in `daemonset` or `daemonsetMaster` this configuration changes how often the daemonset pods will rescan the node they are running on | 2
 `kubebench.aggregator` | contains `resources` and `image.repository` and `image.tag`, this controls the pod scheduled via a CronJob that aggregates from the daemonset in `daemonset` or `daemonsetMaster` deployment modes. |
+`trivy.ignoreUnfixed` | Adds `--ignore-unfixed` trivy flag | false
 `trivy.privateImages.dockerConfigSecret` | Name of a secret containing a docker `config.json` | ""
 `trivy.maxConcurrentScans` | Maximum number of scans to run concurrently | 1
 `trivy.maxScansPerRun` | Maximum number of images to scan on a single run | 20

--- a/stable/insights-agent/templates/trivy/cronjob.yaml
+++ b/stable/insights-agent/templates/trivy/cronjob.yaml
@@ -51,6 +51,8 @@ spec:
                 value: /var/tmp
               - name: MAX_SCANS
                 value: {{ .Values.trivy.maxScansPerRun | quote }}
+              - name: IGNORE_UNFIXED
+                value: {{ .Values.trivy.ignoreUnfixed | quote }}
               - name: MAX_CONCURRENT_SCANS
                 value: {{ .Values.trivy.maxConcurrentScans | quote }}
               {{ if .Values.trivy.namespaceBlacklist }}

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -252,6 +252,7 @@ kubebench:
 trivy:
   enabled: false
   namespaceBlacklist: []
+  ignoreUnfixed: false
   schedule: "rand * * * *"
   privateImages:
     dockerConfigSecret: ""
@@ -260,7 +261,7 @@ trivy:
   timeout: 2400
   image:
     repository: quay.io/fairwinds/fw-trivy
-    tag: "0.14"
+    tag: "0.16"
   resources:
     limits:
       cpu: 250m


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_
This PR adds the env variable that will add `--ignore-unfixed` flag to trivy
Fixes #

**Changes**
Changes proposed in this pull request:

* Added check to values.yaml to enable or disable `ignore-unfixed` flag
*Added env variable that will be passed to trivy plugin to either add the flag or not

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.


[Internal Ticket FWI-1451](https://fairwinds.myjetbrains.com/youtrack/issue/FWI-1451)