### PR TITLE
[WIP] [insights-agent] Add support for Trivy cache volume

### DIFF
--- a/stable/insights-agent/README.md
+++ b/stable/insights-agent/README.md
@@ -92,6 +92,7 @@ Parameter | Description | Default
 `trivy.maxConcurrentScans` | Maximum number of scans to run concurrently | 1
 `trivy.maxScansPerRun` | Maximum number of images to scan on a single run | 20
 `trivy.namespaceBlacklist` | Specifies which namespaces to not scan, takes an array of namespaces for example: `--set trivy.namespaceBlacklist="{kube-system,default}"` | nil
+`trivy.pullRefReplacements` | Modify references to docker images, in the format `quay.io/foo,docker.io/foo;quay.io/bar,docker.io/bar` | ""
 `opa.role` | Specifies which ClusterRole to grant the OPA agent access to | view
 `opa.additionalAccess` | Specifies additional access to grant the OPA agent. This should contain an array of objects with each having an array of apiGroups, an array of resources, and an array of verbs. Just like a RoleBinding. | null
 `opa.installCRDs` | Specifies whether to install the `customcheckinstances.insights.fairwinds.com` CRD. If you are installing the `insights-agent` chart twice you will want to set this flag to `false` on *one* of the installs, doesn't matter which. | true

--- a/stable/insights-agent/ci/test-values.yaml
+++ b/stable/insights-agent/ci/test-values.yaml
@@ -77,6 +77,12 @@ trivy:
   resources:
     requests:
       cpu: 50m
+  extraVolumes:
+  - volume:
+      name: certificate
+      secret:
+        secretName: docker-cert
+    mountPath: /etc/containers/certs.d
 
 resourcemetrics:
   enabled: true

--- a/stable/insights-agent/templates/trivy/cronjob.yaml
+++ b/stable/insights-agent/templates/trivy/cronjob.yaml
@@ -59,6 +59,10 @@ spec:
                 value: {{ .Values.trivy.ignoreUnfixed | quote }}
               - name: MAX_CONCURRENT_SCANS
                 value: {{ .Values.trivy.maxConcurrentScans | quote }}
+              {{- if .Values.trivy.offline }}
+              - name: OFFLINE
+                value: "true"
+              {{- end }}
               {{ if .Values.trivy.namespaceBlacklist }}
               - name: NAMESPACE_BLACKLIST
                 value: {{ join "," .Values.trivy.namespaceBlacklist | lower }}

--- a/stable/insights-agent/templates/trivy/cronjob.yaml
+++ b/stable/insights-agent/templates/trivy/cronjob.yaml
@@ -23,6 +23,9 @@ spec:
             secret:
               secretName: {{ . }}
           {{- end }}
+          {{- range .Values.trivy.extraVolumes }}
+            {{ -toYaml .volume }}
+          {{- end }}
           containers:
           - {{ include "container-spec" . | indent 12 | trim }}
             - name: vartmp
@@ -33,6 +36,10 @@ spec:
             - name: dockerconfig
               mountPath: /.docker/
             {{ end }}
+            {{- range .Values.trivy.extraVolumes }}
+            - name: .volume.name
+              mountPath: .mountPath
+            {{- end }}
             command:
               - "./report.sh"
             env:

--- a/stable/insights-agent/templates/trivy/cronjob.yaml
+++ b/stable/insights-agent/templates/trivy/cronjob.yaml
@@ -13,16 +13,16 @@ spec:
           - name: tmp
             emptyDir: {}
           - name: vartmp
-          {{ if .Values.trivy.cacheVolume }}
-            {{ toYaml .Values.trivy.cacheVolume | nindent 8 }}
-          {{ else }}
+          {{- if .Values.trivy.cacheVolume }}
+            {{- toYaml .Values.trivy.cacheVolume | nindent 12 }}
+          {{- else }}
             emptyDir: {}
-          {{ end }}
-          {{ with .Values.trivy.privateImages.dockerConfigSecret }}
+          {{- end }}
+          {{- with .Values.trivy.privateImages.dockerConfigSecret }}
           - name: dockerconfig
             secret:
               secretName: {{ . }}
-          {{ end }}
+          {{- end }}
           containers:
           - {{ include "container-spec" . | indent 12 | trim }}
             - name: vartmp

--- a/stable/insights-agent/templates/trivy/cronjob.yaml
+++ b/stable/insights-agent/templates/trivy/cronjob.yaml
@@ -59,6 +59,8 @@ spec:
                 value: {{ .Values.trivy.ignoreUnfixed | quote }}
               - name: MAX_CONCURRENT_SCANS
                 value: {{ .Values.trivy.maxConcurrentScans | quote }}
+              - name: PULL_REF_REPLACEMENTS
+                value: {{ .Values.trivy.pullRefReplacements }}
               {{- if .Values.trivy.offline }}
               - name: OFFLINE
                 value: "true"

--- a/stable/insights-agent/templates/trivy/cronjob.yaml
+++ b/stable/insights-agent/templates/trivy/cronjob.yaml
@@ -13,7 +13,11 @@ spec:
           - name: tmp
             emptyDir: {}
           - name: vartmp
+          {{ if .Values.trivy.cacheVolume }}
+            {{ toYaml .Values.trivy.cacheVolume | nindent 8 }}
+          {{ else }}
             emptyDir: {}
+          {{ end }}
           {{ with .Values.trivy.privateImages.dockerConfigSecret }}
           - name: dockerconfig
             secret:

--- a/stable/insights-agent/templates/trivy/cronjob.yaml
+++ b/stable/insights-agent/templates/trivy/cronjob.yaml
@@ -24,7 +24,7 @@ spec:
               secretName: {{ . }}
           {{- end }}
           {{- range .Values.trivy.extraVolumes }}
-            {{ -toYaml .volume }}
+          - {{- toYaml .volume | nindent 12 }}
           {{- end }}
           containers:
           - {{ include "container-spec" . | indent 12 | trim }}
@@ -37,8 +37,8 @@ spec:
               mountPath: /.docker/
             {{ end }}
             {{- range .Values.trivy.extraVolumes }}
-            - name: .volume.name
-              mountPath: .mountPath
+            - name: {{ .volume.name }}
+              mountPath: {{ .mountPath }}
             {{- end }}
             command:
               - "./report.sh"


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [ ] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
