### PR TITLE
FWI-1597 - [insights-admission] Pass the `webhook.failurePolicy` value also to the Admission-controller binary

### DIFF
--- a/stable/insights-admission/Chart.yaml
+++ b/stable/insights-admission/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: insights-admission
 description: A Validating Webhook Admission Controller that utilizes Fairwinds Insights.
 type: application
-version: 1.0.4
+version: 1.0.5
 appVersion: "1.1"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-admission/icon.png
 maintainers:

--- a/stable/insights-admission/README.md
+++ b/stable/insights-admission/README.md
@@ -47,7 +47,7 @@ rules:
 | insights.configmap.create | bool | `true` | Create a config map with Insights configuration |
 | insights.configmap.nameOverride | string | `nil` | The name of the configmap to use. |
 | insights.configmap.suffix | string | `"configmap"` | The suffix to add onto the release name to get the configmap that contains the host/organization/cluster |
-| webhookConfig.failurePolicy | string | `"Ignore"` | failurePolicy for the ValidatingWebhookConfiguration |
+| webhookConfig.failurePolicy | string | `"Ignore"` | failurePolicy for the ValidatingWebhookConfiguration. This also informs whether the admission controller blocks validation requests on errors, such as while executing OPA policies. |
 | webhookConfig.matchPolicy | string | `"Exact"` | matchPolicy for the ValidatingWebhookConfiguration |
 | webhookConfig.namespaceSelector | object | `{"matchExpressions":[{"key":"control-plane","operator":"DoesNotExist"}]}` | namespaceSelector for the ValidatingWebhookConfiguration |
 | webhookConfig.objectSelector | object | `{}` | objectSelector for the ValidatingWebhookConfiguration |

--- a/stable/insights-admission/templates/deployment.yaml
+++ b/stable/insights-admission/templates/deployment.yaml
@@ -62,6 +62,8 @@ spec:
             mountPath: /opt/cert/
             readOnly: true
           env:
+          - name: WEBHOOK_FAILURE_POLICY
+            value: {{ .Values.webhookConfig.failurePolicy }}
           {{- if .Values.service.usePod443 }}
           - name: WEBHOOK_PORT
             value: "443"

--- a/stable/insights-admission/values.yaml
+++ b/stable/insights-admission/values.yaml
@@ -23,7 +23,9 @@ insights:
     suffix: "configmap"
 
 webhookConfig:
-  # webhookConfig.failurePolicy -- failurePolicy for the ValidatingWebhookConfiguration
+  # webhookConfig.failurePolicy -- failurePolicy for the ValidatingWebhookConfiguration.
+  # This also informs whether the admission controller blocks validation requests
+  # on errors, such as while executing OPA policies.
   failurePolicy: Ignore
   # webhookConfig.matchPolicy -- matchPolicy for the ValidatingWebhookConfiguration
   matchPolicy: Exact


### PR DESCRIPTION
**Why This PR?**
Pass the `WebHooks.failurePolicy` to the Admission-controller binary, which now uses it so determine whether validation requests should be denied when errors occur (such as OPA rego execution failures).


**Checklist:**

* [] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.


[Internal Ticket FWI-1597](https://fairwinds.myjetbrains.com/youtrack/issue/FWI-1597)