### PR TITLE
[skopeo-sync] Add the ability to pass additional args

### DIFF
--- a/incubator/skopeo-sync/Chart.yaml
+++ b/incubator/skopeo-sync/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: skopeo-sync
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: "v1.5.2"
 maintainers:
   - name: sudermanjr

--- a/incubator/skopeo-sync/README.md
+++ b/incubator/skopeo-sync/README.md
@@ -1,6 +1,6 @@
 # skopeo-sync
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.5.2](https://img.shields.io/badge/AppVersion-v1.5.2-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.5.2](https://img.shields.io/badge/AppVersion-v1.5.2-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -22,6 +22,7 @@ A Helm chart for Kubernetes
 | syncs[0].srcCred | string | `"gcr"` |  |
 | syncs[0].src | string | `"us-docker.pkg.dev/registry/fargle"` |  |
 | syncs[0].dst | string | `"quay.io/company/fargle"` |  |
+| syncs[0].additionalArgs[0] | string | `"--remove-signatures"` |  |
 | syncs[1].name | string | `"bargle"` |  |
 | syncs[1].schedule | string | `"2 6 * * *"` |  |
 | syncs[1].dstCred | string | `"gcr"` |  |

--- a/incubator/skopeo-sync/templates/cronjob.yaml
+++ b/incubator/skopeo-sync/templates/cronjob.yaml
@@ -28,6 +28,9 @@ spec:
             imagePullPolicy: Always
             args:
             - sync
+            {{- if .additionalArgs }}
+            {{- .additionalArgs | toYaml | nindent 12 }}
+            {{- end }}
             - --src={{ default "docker" .srcType }}
             - --dest={{ default "docker" .dstType }}
             {{- if .dstCred }}

--- a/incubator/skopeo-sync/values.yaml
+++ b/incubator/skopeo-sync/values.yaml
@@ -14,6 +14,8 @@ syncs:
     srcCred: gcr
     src: us-docker.pkg.dev/registry/fargle
     dst: quay.io/company/fargle
+    additionalArgs:
+      - --remove-signatures
   - name: bargle
     schedule: "2 6 * * *"
     dstCred: gcr


### PR DESCRIPTION
**Why This PR?**
I needed to pass the --remove-signatures flag for syncing to quay

**Changes**
Changes proposed in this pull request:

* add additionalArgs flag option to the sync config

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.