### PR TITLE
[stable/vpa] Allow specifying custom key/paths for the vpa-tls-cert

### DIFF
--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 1.3.2
+version: 1.3.0
 appVersion: 0.10.0
 maintainers:
   - name: sudermanjr

--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 1.2.2
+version: 1.3.2
 appVersion: 0.10.0
 maintainers:
   - name: sudermanjr

--- a/stable/vpa/README.md
+++ b/stable/vpa/README.md
@@ -124,6 +124,7 @@ recommender:
 | admissionController.podSecurityContext.runAsUser | int | `65534` |  |
 | admissionController.securityContext | object | `{}` | The security context for the containers inside the admission controller pod |
 | admissionController.resources | object | `{"limits":{"cpu":"200m","memory":"500Mi"},"requests":{"cpu":"50m","memory":"200Mi"}}` | The resources block for the admission controller pod |
+| admissionController.tlsSecretKeys | list | `[]` | The keys in the vpa-tls-certs secret to map in to the admission controller |
 | admissionController.nodeSelector | object | `{}` |  |
 | admissionController.tolerations | list | `[]` |  |
 | admissionController.affinity | object | `{}` |  |

--- a/stable/vpa/templates/admission-controller-deployment.yaml
+++ b/stable/vpa/templates/admission-controller-deployment.yaml
@@ -81,6 +81,10 @@ spec:
         - name: tls-certs
           secret:
             secretName: vpa-tls-certs
+            {{- with .Values.admissionController.tlsSecretKeys }}
+            items:
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
       {{- with .Values.admissionController.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/stable/vpa/values.yaml
+++ b/stable/vpa/values.yaml
@@ -159,6 +159,14 @@ admissionController:
     requests:
       cpu: 50m
       memory: 200Mi
+  # admissionController.tlsSecretKeys -- The keys in the vpa-tls-certs secret to map in to the admission controller
+  tlsSecretKeys: []
+    # - key: ca.crt
+    #   path: caCert.pem
+    # - key: tls.crt
+    #   path: serverCert.pem
+    # - key: tls.key
+    #   path: serverKey.pem
   nodeSelector: {}
   tolerations: []
   affinity: {}


### PR DESCRIPTION
Closes #751 

**Why This PR?**
See #751 for the full details.

This PR allows certificates created by means other than the admission-controllers [certgen](https://github.com/FairwindsOps/charts/blob/master/stable/vpa/templates/admission-controller-certgen.yaml) job to be mapped into the admission-controller pod. As it stands, any secret not following the format created by certgen will not be usable. This includes the official [kubernetes/tls-secret](https://kubernetes.io/docs/concepts/configuration/secret/#tls-secrets) format. 

**Changes**
Changes proposed in this pull request:

* Add a `tlsSecretKeys` field to allow mapping secret keys to their correct paths within the container. 
* Include the example commented out, a common practice in helm charts, that shows what the correct paths are. 
* Default this new field to empty to maintain backwards-compatibility.

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
