### PR TITLE
[stable/insights-agent] added trivy tls verify option

### DIFF
--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.0.0-rc.1
+version: 2.0.0-rc.2
 appVersion: 6.5.1
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.0.0-rc.2
-appVersion: 6.5.1
+version: 2.0.1
+appVersion: 8.1.1
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:
   - name: rbren

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.0.1
+version: 2.0.2
 appVersion: 8.1.1
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:

--- a/stable/insights-agent/README.md
+++ b/stable/insights-agent/README.md
@@ -88,6 +88,7 @@ Parameter | Description | Default
 `kube-bench.mode` | Changes the way this plugin is deployed, either `cronjob` where it will run a single pod on the `schedule` that will pull the data necessary from a single node and report that back to Insights. `daemonset` which deploys a daemonset to the cluster which gathers data then a cronjob will gather data from each of those pods. `daemonsetMaster`  is the same as `daemonset` except the daemonset can also run on masters. | `cronjob`
 `kube-bench.hourInterval` | If running in `daemonset` or `daemonsetMaster` this configuration changes how often the daemonset pods will rescan the node they are running on | 2
 `kube-bench.aggregator` | contains `resources` and `image.repository` and `image.tag`, this controls the pod scheduled via a CronJob that aggregates from the daemonset in `daemonset` or `daemonsetMaster` deployment modes. |
+`trivy.dockerTLSVerify` | When set Docker uses TLS and verifies the remote, used both by the docker CLI and the dockerd daemon | nil
 `trivy.ignoreUnfixed` | Adds `--ignore-unfixed` trivy flag | false
 `trivy.privateImages.dockerConfigSecret` | Name of a secret containing a docker `config.json` | ""
 `trivy.maxConcurrentScans` | Maximum number of scans to run concurrently | 1

--- a/stable/insights-agent/README.md
+++ b/stable/insights-agent/README.md
@@ -88,8 +88,8 @@ Parameter | Description | Default
 `kube-bench.mode` | Changes the way this plugin is deployed, either `cronjob` where it will run a single pod on the `schedule` that will pull the data necessary from a single node and report that back to Insights. `daemonset` which deploys a daemonset to the cluster which gathers data then a cronjob will gather data from each of those pods. `daemonsetMaster`  is the same as `daemonset` except the daemonset can also run on masters. | `cronjob`
 `kube-bench.hourInterval` | If running in `daemonset` or `daemonsetMaster` this configuration changes how often the daemonset pods will rescan the node they are running on | 2
 `kube-bench.aggregator` | contains `resources` and `image.repository` and `image.tag`, this controls the pod scheduled via a CronJob that aggregates from the daemonset in `daemonset` or `daemonsetMaster` deployment modes. |
-`trivy.dockerTLSVerify` | When set Docker uses TLS and verifies the remote, used both by the docker CLI and the dockerd daemon | nil
 `trivy.ignoreUnfixed` | Adds `--ignore-unfixed` trivy flag | false
+`trivy.insecureSSL` | Can be used to allow insecure connections to a container registry when using SSL. | `false`
 `trivy.privateImages.dockerConfigSecret` | Name of a secret containing a docker `config.json` | ""
 `trivy.maxConcurrentScans` | Maximum number of scans to run concurrently | 1
 `trivy.maxScansPerRun` | Maximum number of images to scan on a single run | 20

--- a/stable/insights-agent/templates/trivy/cronjob.yaml
+++ b/stable/insights-agent/templates/trivy/cronjob.yaml
@@ -47,9 +47,9 @@ spec:
                     name: {{ include "insights-agent.fullname" . }}-token
                     {{ end -}}
                     key: token
-              {{ if .Values.trivy.dockerTLSVerify }}
-              - name: DOCKER_TLS_VERIFY
-                value: 1
+              {{ if .Values.trivy.insecureSSL }}
+              - name: TRIVY_INSECURE
+                value: true
               {{ end }}
               - name: TRIVY_CACHE_DIR
                 value: /var/tmp

--- a/stable/insights-agent/templates/trivy/cronjob.yaml
+++ b/stable/insights-agent/templates/trivy/cronjob.yaml
@@ -47,6 +47,10 @@ spec:
                     name: {{ include "insights-agent.fullname" . }}-token
                     {{ end -}}
                     key: token
+              {{ if .Values.trivy.dockerTLSVerify }}
+              - name: DOCKER_TLS_VERIFY
+                value: 1
+              {{ end }}
               - name: TRIVY_CACHE_DIR
                 value: /var/tmp
               - name: MAX_SCANS

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -271,6 +271,7 @@ trivy:
   maxConcurrentScans: 1
   maxScansPerRun: 20
   timeout: 2400
+  dockerTLSVerify: false
   image:
     repository: quay.io/fairwinds/fw-trivy
     tag: "0.18"

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -271,7 +271,7 @@ trivy:
   maxConcurrentScans: 1
   maxScansPerRun: 20
   timeout: 2400
-  dockerTLSVerify: false
+  insecureSSL: false
   image:
     repository: quay.io/fairwinds/fw-trivy
     tag: "0.18"


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_
Added `DOCKER_TLS_VERIFY` option to trivy.
Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [ ] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [ ] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
