### PR TITLE
[stable/vpa] Add extraArgs to Admission Controller

### DIFF
--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 1.3.0
+version: 1.3.1
 appVersion: 0.10.0
 maintainers:
   - name: sudermanjr

--- a/stable/vpa/README.md
+++ b/stable/vpa/README.md
@@ -104,6 +104,7 @@ recommender:
 | updater.tolerations | list | `[]` |  |
 | updater.affinity | object | `{}` |  |
 | admissionController.enabled | bool | `false` | If true, will install the admission-controller component of vpa |
+| admissionController.extraArgs | object | `{}` | A key-value map of flags to pass to the admissionController |
 | admissionController.generateCertificate | bool | `true` | If true and admissionController is enabled, a pre-install hook will run to create the certificate for the webhook |
 | admissionController.certGen.image.repository | string | `"quay.io/reactiveops/ci-images"` | An image that contains certgen for creating certificates. Only used if admissionController.generateCertificate is true |
 | admissionController.certGen.image.tag | string | `"v11-alpine"` | An image tag for the admissionController.certGen.image.repository image. Only used if admissionController.generateCertificate is true |

--- a/stable/vpa/ci/test-values.yaml
+++ b/stable/vpa/ci/test-values.yaml
@@ -11,6 +11,8 @@ updater:
     foo: bar
 admissionController:
   enabled: true
+  extraArgs:
+    v: "4"
   generateCertificate: true
   certGen:
     env:

--- a/stable/vpa/templates/admission-controller-deployment.yaml
+++ b/stable/vpa/templates/admission-controller-deployment.yaml
@@ -41,6 +41,12 @@ spec:
             {{- toYaml .Values.admissionController.securityContext | nindent 12 }}
           image: "{{ .Values.admissionController.image.repository }}:{{ .Values.admissionController.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.admissionController.image.pullPolicy }}
+          {{- if .Values.admissionController.extraArgs }}
+          args:
+          {{- range $key, $value := .Values.admissionController.extraArgs }}
+            - --{{ $key }}={{ $value }}
+          {{- end }}
+          {{- end }}
           volumeMounts:
             - name: tls-certs
               mountPath: "/etc/tls-certs"

--- a/stable/vpa/values.yaml
+++ b/stable/vpa/values.yaml
@@ -108,6 +108,8 @@ updater:
 admissionController:
   # admissionController.enabled -- If true, will install the admission-controller component of vpa
   enabled: false
+  # admissionController.extraArgs -- A key-value map of flags to pass to the admissionController
+  extraArgs: {}
   # admissionController.generateCertificate -- If true and admissionController is enabled, a pre-install hook will run to create the certificate for the webhook
   generateCertificate: true
   certGen:


### PR DESCRIPTION
**Why This PR?**
This PR allows extra arguments to be specified in admission-controller deployment.

**Changes**
Changes proposed in this pull request:

Add `extraArgs` to:
* vpa/templates/admission-controller-deployment.yaml

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
