### PR TITLE
[stable/insights-agent] Exempt replicas for goldilocks controller deployment

### DIFF
--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.0.1
+version: 2.0.2
 appVersion: 8.1.1
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -95,6 +95,7 @@ goldilocks:
   vpa:
     enabled: true
     recommender:
+      replicaCount: 2
       securityContext:
         allowPrivilegeEscalation: false
         readOnlyRootFilesystem: true

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -108,6 +108,9 @@ goldilocks:
     repository: quay.io/fairwinds/goldilocks
     tag: "v2.2.0"
   controller:
+    deployment:
+      annotations:
+        polaris.fairwinds.com/deploymentMissingReplicas-exempt: "true"
     flags:
       on-by-default: true
       exclude-namespaces: "kube-system"


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_
This adds exemption to the number of minimum replicas needed. Polaris rule requires at least 2 replicas.
Fixes #

**Changes**
Changes proposed in this pull request:

* Add replica count to 2 for vpa by default
* add rule to exempt replicas for goldilocks controller.

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
