### PR TITLE
[stable/insights-agent] Add support for proxy variables

### DIFF
--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.0.1
-appVersion: 8.1.1
+version: 2.0.2
+appVersion: 8.2.2
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:
   - name: rbren

--- a/stable/insights-agent/README.md
+++ b/stable/insights-agent/README.md
@@ -62,6 +62,9 @@ Parameter | Description | Default
 `rbac.disabled` | Don't use any of the built-in RBAC | `false`
 `fleetInstall` | See Fleet Installation docs | `false`
 `insights.apiToken` | Only needed if `fleetInstall=true` | ""
+`proxy.http` | Annotations used to access the proxy servers(http) | ""
+`proxy.https` | Annotations used to access the proxy servers(https) | ""
+`proxy.no_proxy` | Annotations to provides a way to exclude traffic destined to certain hosts from using the proxy | ""
 `uploader.image.repository`  | The repository to pull the uploader script from | quay.io/fairwinds/insights-uploader
 `uploader.image.tag` | The tag to use for the uploader script | 0.2
 `uploader.resources` | CPU/memory requests and limits for the uploader script |

--- a/stable/insights-agent/README.md
+++ b/stable/insights-agent/README.md
@@ -64,6 +64,7 @@ Parameter | Description | Default
 `insights.apiToken` | Only needed if `fleetInstall=true` | ""
 `proxy.http` | Annotations used to access the proxy servers(http) | ""
 `proxy.https` | Annotations used to access the proxy servers(https) | ""
+`proxy.ftp` | Annotations used to access the proxy servers(ftp) | ""
 `proxy.no_proxy` | Annotations to provides a way to exclude traffic destined to certain hosts from using the proxy | ""
 `uploader.image.repository`  | The repository to pull the uploader script from | quay.io/fairwinds/insights-uploader
 `uploader.image.tag` | The tag to use for the uploader script | 0.2

--- a/stable/insights-agent/templates/_specs.yaml
+++ b/stable/insights-agent/templates/_specs.yaml
@@ -132,13 +132,24 @@ securityContext:
 {{- if .Values.proxy.https }}
 - name: https_proxy
   value: {{ .Values.proxy.https }}
+- name: HTTPS_PROXY
+  value: {{ .Values.proxy.https }}
 {{- end }}
 {{- if .Values.proxy.http }}
 - name: http_proxy
   value: {{ .Values.proxy.http }}
+- name: HTTP_PROXY
+  value: {{ .Values.proxy.http }}
 {{- end }}
+{{- if .Values.proxy.ftp }}
+- name: ftp_proxy
+  value: {{ .Values.proxy.ftp }}
+- name: FTP_PROXY
+  value: {{ .Values.proxy.ftp }}
 {{- if .Values.proxy.no_proxy }}
 - name: no_proxy
+  value: {{ .Values.proxy.no_proxy }}
+- name: NO_PROXY
   value: {{ .Values.proxy.no_proxy }}
 {{- end }}
 {{- end }}

--- a/stable/insights-agent/templates/_specs.yaml
+++ b/stable/insights-agent/templates/_specs.yaml
@@ -146,6 +146,7 @@ securityContext:
   value: {{ .Values.proxy.ftp }}
 - name: FTP_PROXY
   value: {{ .Values.proxy.ftp }}
+{{- end }}
 {{- if .Values.proxy.no_proxy }}
 - name: no_proxy
   value: {{ .Values.proxy.no_proxy }}

--- a/stable/insights-agent/templates/_specs.yaml
+++ b/stable/insights-agent/templates/_specs.yaml
@@ -127,3 +127,18 @@ securityContext:
     drop:
       - ALL
 {{- end }}
+
+{{ define "proxy-env-spec" }}
+{{- if .Values.proxy.https }}
+- name: https_proxy
+  value: {{ .Values.proxy.https }}
+{{- end }}
+{{- if .Values.proxy.http }}
+- name: http_proxy
+  value: {{ .Values.proxy.http }}
+{{- end }}
+{{- if .Values.proxy.no_proxy }}
+- name: no_proxy
+  value: {{ .Values.proxy.no_proxy }}
+{{- end }}
+{{- end }}

--- a/stable/insights-agent/templates/_uploader.yaml
+++ b/stable/insights-agent/templates/_uploader.yaml
@@ -43,6 +43,7 @@
   {{- with .Values.uploader.env }}
   {{- toYaml . | nindent 2 }}
   {{- end }}
+  {{ include "proxy-env-spec" . | indent 2 | trim }}
   volumeMounts:
   - name: output
     mountPath: /output

--- a/stable/insights-agent/templates/awscosts/cronjob.yaml
+++ b/stable/insights-agent/templates/awscosts/cronjob.yaml
@@ -32,6 +32,7 @@ spec:
                   key: AWS_SECRET_ACCESS_KEY            
             - name: AWS_DEFAULT_REGION
               value: {{ .Values.awscosts.region }}
+            {{ include "proxy-env-spec" . | indent 12 | trim }}
             command: ["./aws-costs.sh"]
             args:
               - --database 

--- a/stable/insights-agent/templates/cronjob-executor/job.yaml
+++ b/stable/insights-agent/templates/cronjob-executor/job.yaml
@@ -32,6 +32,8 @@ spec:
 
         resources:
           {{- toYaml .Values.cronjobExecutor.resources | nindent 10 }}
+        env:
+          {{ include "proxy-env-spec" . | indent 10 | trim }}
         volumeMounts:
         - name: tmp
           mountPath: /tmp

--- a/stable/insights-agent/templates/falco/cronjob.yaml
+++ b/stable/insights-agent/templates/falco/cronjob.yaml
@@ -39,6 +39,8 @@ spec:
                 - -c
                 - |
                   curl http://falco-agent:3031/output -o /tmp/falco.json && mv /tmp/falco.json /output/falco.json        
+            env:
+            {{ include "proxy-env-spec" . | indent 12 | trim }}
             {{ include "security-context" . | indent 12 | trim }}
           {{ include "uploaderContainer" . | indent 10 | trim }}
   {{- end -}}

--- a/stable/insights-agent/templates/falco/deployment.yaml
+++ b/stable/insights-agent/templates/falco/deployment.yaml
@@ -58,6 +58,8 @@ spec:
         volumeMounts:
         - name: output-data
           mountPath: /output
+        env:
+        {{ include "proxy-env-spec" . | indent 12 | trim }}
       {{- if .Values.falco.securityContext }}
         securityContext:
           {{- toYaml .Values.falco.securityContext | nindent 12 }}

--- a/stable/insights-agent/templates/fleet-installer/job.yaml
+++ b/stable/insights-agent/templates/fleet-installer/job.yaml
@@ -48,11 +48,12 @@ spec:
         resources:
           {{- toYaml .Values.cronjobExecutor.resources | nindent 10 }}
         env:
-          - name: ADMIN_TOKEN
-            valueFrom:
-              secretKeyRef:
-                name:  {{ default ( printf "%s-api-token" (include "insights-agent.fullname" .) ) .Values.insights.apiTokenSecretName }}
-                key: token
+        {{ include "proxy-env-spec" . | indent 8 | trim }}
+        - name: ADMIN_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name:  {{ default ( printf "%s-api-token" (include "insights-agent.fullname" .) ) .Values.insights.apiTokenSecretName }}
+              key: token
         volumeMounts:
         - name: tmp
           mountPath: /tmp

--- a/stable/insights-agent/templates/goldilocks/cronjob.yaml
+++ b/stable/insights-agent/templates/goldilocks/cronjob.yaml
@@ -13,6 +13,8 @@ spec:
           containers:
           - {{ include "container-spec" . | indent 12 | trim }}
             command: ["/goldilocks", "summary", "--output-file", "/output/goldilocks.json"]
+            env:
+            {{ include "proxy-env-spec" . | indent 12 | trim }}
             {{ include "security-context" . | indent 12 | trim }}
           {{ include "uploaderContainer" . | indent 10 | trim }}
 {{- end -}}

--- a/stable/insights-agent/templates/install-reporter/job.yaml
+++ b/stable/insights-agent/templates/install-reporter/job.yaml
@@ -57,6 +57,7 @@ spec:
               name: {{ include "insights-agent.fullname" . }}-token
               {{ end -}}
               key: token
+        {{ include "proxy-env-spec" . | indent 8 | trim }}
       volumes:
       - name: values
         configMap:

--- a/stable/insights-agent/templates/kube-bench/_container.yaml
+++ b/stable/insights-agent/templates/kube-bench/_container.yaml
@@ -35,6 +35,7 @@ containers:
     valueFrom:
       fieldRef:
         fieldPath: spec.nodeName
+  {{ include "proxy-env-spec" . | indent 2 | trim }}
   {{- if eq (index .Values "kube-bench" "mode") "cronjob" }}
   - name: RUN_ONCE
     value: "true"

--- a/stable/insights-agent/templates/kube-bench/cronjob.yaml
+++ b/stable/insights-agent/templates/kube-bench/cronjob.yaml
@@ -27,6 +27,7 @@ spec:
             env:
             - name: DAEMONSET_SERVICE
               value: {{ include "insights-agent.fullname" . }}-kube-bench-svc
+            {{ include "proxy-env-spec" . | indent 12 | trim }}
             resources:
               {{- toYaml (index .Values "kube-bench" "aggregator" "resources") | nindent 14 }}
             volumeMounts:

--- a/stable/insights-agent/templates/kube-hunter/cronjob.yaml
+++ b/stable/insights-agent/templates/kube-hunter/cronjob.yaml
@@ -36,5 +36,7 @@ spec:
               readOnlyRootFilesystem: true
               allowPrivilegeEscalation: false
               privileged: false
+            env:
+            {{ include "proxy-env-spec" . | indent 12 | trim }}
           {{ include "uploaderContainer" . | indent 10 | trim }}
 {{- end -}}

--- a/stable/insights-agent/templates/nova/cronjob.yaml
+++ b/stable/insights-agent/templates/nova/cronjob.yaml
@@ -28,6 +28,8 @@ spec:
               - find
               - --config={{ .Config.configLocation }}
               - -v{{ .Config.logLevel }}
+            env:
+            {{ include "proxy-env-spec" . | indent 12 | trim }}
             {{ include "security-context" . | indent 12 | trim }}
           {{ include "uploaderContainer" . | indent 10 | trim }}
           volumes:

--- a/stable/insights-agent/templates/opa/cronjob.yaml
+++ b/stable/insights-agent/templates/opa/cronjob.yaml
@@ -47,6 +47,7 @@ spec:
               value: {{ .Values.insights.organization | quote  }}
             - name: FAIRWINDS_CLUSTER
               value: {{ .Values.insights.cluster | quote }}
+            {{ include "proxy-env-spec" . | indent 12 | trim }}
             {{ include "security-context" . | indent 12 | trim }}
           {{ include "uploaderContainer" . | indent 10 | trim }}
 {{- end -}}

--- a/stable/insights-agent/templates/pluto/cronjob.yaml
+++ b/stable/insights-agent/templates/pluto/cronjob.yaml
@@ -19,6 +19,8 @@ spec:
               /pluto detect-helm -ojson --target-versions {{ $.Values.pluto.targetVersions | default (printf "k8s=v%s.%s.0" .Capabilities.KubeVersion.Major (trimSuffix "+" .Capabilities.KubeVersion.Minor)) }} > /output/pluto-tmp.json
               cat /output/pluto-tmp.json
               mv /output/pluto-tmp.json /output/pluto.json
+            env:
+            {{ include "proxy-env-spec" . | indent 12 | trim }}
             {{ include "security-context" . | indent 12 | trim }}
           {{ include "uploaderContainer" . | indent 10 | trim }}
 {{- end -}}

--- a/stable/insights-agent/templates/polaris/cronjob.yaml
+++ b/stable/insights-agent/templates/polaris/cronjob.yaml
@@ -38,6 +38,8 @@ spec:
                 CONFIG='--config /opt/app/config.yaml'
               fi
               polaris audit --output-file /output/polaris.json --format json --display-name {{ .Values.insights.cluster }} {{ .Values.polaris.extraArgs }} $CONFIG
+            env:
+            {{ include "proxy-env-spec" . | indent 12 | trim }}
             {{ include "security-context" . | indent 12 | trim }}
           {{ include "uploaderContainer" . | indent 10 | trim }}
 {{- end -}}

--- a/stable/insights-agent/templates/prometheus-metrics/cronjob.yaml
+++ b/stable/insights-agent/templates/prometheus-metrics/cronjob.yaml
@@ -20,6 +20,7 @@ spec:
             env:
             - name: PROMETHEUS_ADDRESS
               value: {{ (index .Values "prometheus-metrics"  "address") | quote }}
+            {{ include "proxy-env-spec" . | indent 12 | trim }}
             {{ include "security-context" . | indent 12 | trim }}
           {{ include "uploaderContainer" . | indent 10 | trim }}
 {{- end -}}

--- a/stable/insights-agent/templates/rbac-reporter/cronjob.yaml
+++ b/stable/insights-agent/templates/rbac-reporter/cronjob.yaml
@@ -16,6 +16,8 @@ spec:
           containers:
           - {{ include "container-spec" . | indent 12 | trim }}
             command: ["rbac-reporter", "--output-file", "/output/rbac-reporter.json"]
+            env:
+            {{ include "proxy-env-spec" . | indent 12 | trim }}
             {{ include "security-context" . | indent 12 | trim }}
           {{ include "uploaderContainer" . | indent 10 | trim }}
 {{- end -}}

--- a/stable/insights-agent/templates/right-sizer/controller-deployment.yaml
+++ b/stable/insights-agent/templates/right-sizer/controller-deployment.yaml
@@ -29,6 +29,8 @@ spec:
         - name: {{ .Chart.Name }}-right-sizer-controller
           ports:
           - containerPort: 8080
+          env:
+          {{ include "proxy-env-spec" . | indent 12 | trim }}
           securityContext:
             {{- toYaml (index .Values "right-sizer" "containerSecurityContext") | nindent 12 }}
           image: "{{ (index .Values "right-sizer" "image" "repository") }}:{{ (index .Values "right-sizer" "image" "tag") }}"

--- a/stable/insights-agent/templates/test/test-deployment.yaml
+++ b/stable/insights-agent/templates/test/test-deployment.yaml
@@ -21,6 +21,8 @@ spec:
     spec:
       containers:
         - name: {{ .Chart.Name }}
+          env:
+          {{ include "proxy-env-spec" . | indent 10 | trim }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.test.image.repository }}:{{ .Values.test.image.tag }}"

--- a/stable/insights-agent/templates/trivy/cronjob.yaml
+++ b/stable/insights-agent/templates/trivy/cronjob.yaml
@@ -32,33 +32,34 @@ spec:
             command:
               - "./report.sh"
             env:
-              - name: FAIRWINDS_INSIGHTS_HOST
-                value: {{ .Values.insights.host | quote }}
-              - name: FAIRWINDS_ORG
-                value: {{ .Values.insights.organization | quote }}
-              - name: FAIRWINDS_CLUSTER
-                value: {{ .Values.insights.cluster | quote }}
-              - name: FAIRWINDS_TOKEN
-                valueFrom:
-                  secretKeyRef:
-                    {{ if .Values.insights.tokenSecretName -}}
-                    name: {{ .Values.insights.tokenSecretName }}
-                    {{ else -}}
-                    name: {{ include "insights-agent.fullname" . }}-token
-                    {{ end -}}
-                    key: token
-              - name: TRIVY_CACHE_DIR
-                value: /var/tmp
-              - name: MAX_SCANS
-                value: {{ .Values.trivy.maxScansPerRun | quote }}
-              - name: IGNORE_UNFIXED
-                value: {{ .Values.trivy.ignoreUnfixed | quote }}
-              - name: MAX_CONCURRENT_SCANS
-                value: {{ .Values.trivy.maxConcurrentScans | quote }}
-              {{ if .Values.trivy.namespaceBlacklist }}
-              - name: NAMESPACE_BLACKLIST
-                value: {{ join "," .Values.trivy.namespaceBlacklist | lower }}
-              {{ end }}
+            {{ include "proxy-env-spec" . | indent 12 | trim }}
+            - name: FAIRWINDS_INSIGHTS_HOST
+              value: {{ .Values.insights.host | quote }}
+            - name: FAIRWINDS_ORG
+              value: {{ .Values.insights.organization | quote }}
+            - name: FAIRWINDS_CLUSTER
+              value: {{ .Values.insights.cluster | quote }}
+            - name: FAIRWINDS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  {{ if .Values.insights.tokenSecretName -}}
+                  name: {{ .Values.insights.tokenSecretName }}
+                  {{ else -}}
+                  name: {{ include "insights-agent.fullname" . }}-token
+                  {{ end -}}
+                  key: token
+            - name: TRIVY_CACHE_DIR
+              value: /var/tmp
+            - name: MAX_SCANS
+              value: {{ .Values.trivy.maxScansPerRun | quote }}
+            - name: IGNORE_UNFIXED
+              value: {{ .Values.trivy.ignoreUnfixed | quote }}
+            - name: MAX_CONCURRENT_SCANS
+              value: {{ .Values.trivy.maxConcurrentScans | quote }}
+            {{ if .Values.trivy.namespaceBlacklist }}
+            - name: NAMESPACE_BLACKLIST
+              value: {{ join "," .Values.trivy.namespaceBlacklist | lower }}
+            {{ end }}
             {{ include "security-context" . | indent 12 | trim }}
           {{ include "uploaderContainer" . | indent 10 | trim }}
 {{- end -}}

--- a/stable/insights-agent/templates/workloads/cronjob.yaml
+++ b/stable/insights-agent/templates/workloads/cronjob.yaml
@@ -14,5 +14,7 @@ spec:
           - {{ include "container-spec" . | indent 12 | trim }}
             command: ["workload", "--output-file", "/output/workloads.json"]
             {{ include "security-context" . | indent 12 | trim }}
+            env:
+            {{ include "proxy-env-spec" . | indent 12 | trim }}
           {{ include "uploaderContainer" . | indent 10 | trim }}
 {{- end -}}

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -5,6 +5,14 @@ insights:
   base64token: ""
   tokenSecretName: ""
 
+proxy:
+  # proxy.http -- Annotations used to access the proxy servers(http).
+  http:
+  # proxy.https -- Annotations used to access the proxy servers(https).
+  https:
+  # proxy.no_proxy -- Annotations to provides a way to exclude traffic destined to certain hosts from using the proxy.
+  no_proxy:
+
 rbac:
   disabled: false
 

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -11,7 +11,7 @@ proxy:
   # proxy.https -- Annotations used to access the proxy servers(https).
   https:
   # proxy.ftp -- Annotations used to access the proxy servers(ftp).
-  ftp: 
+  ftp:
   # proxy.no_proxy -- Annotations to provides a way to exclude traffic destined to certain hosts from using the proxy.
   no_proxy:
 

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -10,6 +10,8 @@ proxy:
   http:
   # proxy.https -- Annotations used to access the proxy servers(https).
   https:
+  # proxy.ftp -- Annotations used to access the proxy servers(ftp).
+  ftp: 
   # proxy.no_proxy -- Annotations to provides a way to exclude traffic destined to certain hosts from using the proxy.
   no_proxy:
 


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_
not sure if we need `HTTP_PROXY`,`HTTPS_PROXY`, `NO_PROXY` the lower case alternative covers these and more.
Fixes #

**Changes**
Changes proposed in this pull request:

* Added `https_proxy`, `http_proxy`, `no_proxy` env variable
*

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
