### PR TITLE
[stable/insights-agent] Added proxy to the downloader

### DIFF
--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.0.3
+version: 2.0.4
 appVersion: 8.2.2
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:

--- a/stable/insights-agent/templates/_specs.yaml
+++ b/stable/insights-agent/templates/_specs.yaml
@@ -88,6 +88,30 @@ initContainers:
   - --file
   - /output/{{ .Label }}-config.yaml
   env:
+  {{- if .Values.proxy.https }}
+  - name: https_proxy
+    value: {{ .Values.proxy.https }}
+  - name: HTTPS_PROXY
+    value: {{ .Values.proxy.https }}
+  {{- end }}
+  {{- if .Values.proxy.http }}
+  - name: http_proxy
+    value: {{ .Values.proxy.http }}
+  - name: HTTP_PROXY
+    value: {{ .Values.proxy.http }}
+  {{- end }}
+  {{- if .Values.proxy.ftp }}
+  - name: ftp_proxy
+    value: {{ .Values.proxy.ftp }}
+  - name: FTP_PROXY
+    value: {{ .Values.proxy.ftp }}
+  {{- end }}
+  {{- if .Values.proxy.no_proxy }}
+  - name: no_proxy
+    value: {{ .Values.proxy.no_proxy }}
+  - name: NO_PROXY
+    value: {{ .Values.proxy.no_proxy }}
+  {{- end }}
   - name: FAIRWINDS_TOKEN
     valueFrom:
       secretKeyRef:


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_
Added proxy env variables to the config downloader init container
Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
