### PR TITLE
[stable/insights-admission] add timeout option for webhook

### DIFF
--- a/stable/insights-admission/Chart.yaml
+++ b/stable/insights-admission/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: insights-admission
 description: A Validating Webhook Admission Controller that utilizes Fairwinds Insights.
 type: application
-version: 1.1.0
+version: 1.1.1
 appVersion: "1.1"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-admission/icon.png
 maintainers:

--- a/stable/insights-admission/README.md
+++ b/stable/insights-admission/README.md
@@ -49,6 +49,7 @@ rules:
 | insights.configmap.suffix | string | `"configmap"` | The suffix to add onto the release name to get the configmap that contains the host/organization/cluster |
 | webhookConfig.failurePolicy | string | `"Ignore"` | failurePolicy for the ValidatingWebhookConfiguration. This also informs whether the admission controller blocks validation requests on errors, such as while executing OPA policies. |
 | webhookConfig.matchPolicy | string | `"Exact"` | matchPolicy for the ValidatingWebhookConfiguration |
+| webhookConfig.timeoutSeconds | int | `30` | number of seconds to wait before failing the admission request (max is 30) |
 | webhookConfig.namespaceSelector | object | `{"matchExpressions":[{"key":"control-plane","operator":"DoesNotExist"}]}` | namespaceSelector for the ValidatingWebhookConfiguration |
 | webhookConfig.objectSelector | object | `{}` | objectSelector for the ValidatingWebhookConfiguration |
 | webhookConfig.rules | list | `[]` | An array of additional rules for the ValidatingWebhookConfiguration. Each requires a set of apiGroups, apiVersions, operations, resources, and a scope. Rules specified here may also be granted to the Insights OPA plugin, see also the insights-agent chart values for opa. |

--- a/stable/insights-admission/templates/configuration.yaml
+++ b/stable/insights-admission/templates/configuration.yaml
@@ -35,4 +35,4 @@ webhooks:
   rules:
   {{- concat .Values.webhookConfig.rules .Values.webhookConfig.defaultRules | toYaml | nindent 2 }}
   sideEffects: None
-  timeoutSeconds: 10
+  timeoutSeconds: {{ .Values.webhookConfig.timeoutSeconds }}

--- a/stable/insights-admission/values.yaml
+++ b/stable/insights-admission/values.yaml
@@ -29,6 +29,8 @@ webhookConfig:
   failurePolicy: Ignore
   # webhookConfig.matchPolicy -- matchPolicy for the ValidatingWebhookConfiguration
   matchPolicy: Exact
+  # webhookConfig.timeoutSeconds -- number of seconds to wait before failing the admission request (max is 30)
+  timeoutSeconds: 30
   # webhookConfig.namespaceSelector -- namespaceSelector for the ValidatingWebhookConfiguration
   namespaceSelector:
     matchExpressions:


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_
The webhook can timeout, especially if there is a 3rd party integration running.

**Changes**
Changes proposed in this pull request:
* add option for timeout
* increase timeout to 30s

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
