### PR TITLE
[stable/fairwinds-insights] fix name length

### DIFF
--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "8.3.2"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 0.5.5
+version: 0.5.6
 maintainers:
 - name: rbren
 - name: makoscafee

--- a/stable/fairwinds-insights/ci/test-values.yaml
+++ b/stable/fairwinds-insights/ci/test-values.yaml
@@ -1,3 +1,7 @@
+rok8sCIRef: this-is-a-really-long-string-that-will-need-to-be-truncated
+sanitizedBranch: this-is-a-really-long-string-that-will-need-to-be-truncated
+fullnameOverride: this-is-a-really-long-string-that-will-need-to-be-truncated
+
 ingress:
   enabled: true
   hostedZones:

--- a/stable/fairwinds-insights/templates/_helpers.tpl
+++ b/stable/fairwinds-insights/templates/_helpers.tpl
@@ -13,13 +13,13 @@ If release name contains chart name it will be used as a full name.
 */}}
 {{- define "fairwinds-insights.fullname" -}}
 {{- if .Values.fullnameOverride -}}
-{{- .Values.fullnameOverride | trunc 52 | trimSuffix "-" -}}
+{{- .Values.fullnameOverride | trunc 27 | trimSuffix "-" -}}
 {{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 52 | trimSuffix "-" -}}
+{{- .Release.Name | trunc 27 | trimSuffix "-" -}}
 {{- else -}}
-{{- printf "%s" .Release.Name | trunc 52 | trimSuffix "-" -}}
+{{- printf "%s" .Release.Name | trunc 27 | trimSuffix "-" -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Fixes #

**Changes**
Changes proposed in this pull request:

* Enforce name lengths
*

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
