### PR TITLE
[stable/fairwinds-insights] Added truncate workload metrics job

### DIFF
--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "8.3.2"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 0.5.7
+version: 0.5.8
 maintainers:
 - name: rbren
 - name: makoscafee

--- a/stable/fairwinds-insights/README.md
+++ b/stable/fairwinds-insights/README.md
@@ -100,7 +100,7 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | databaseCleanupCronjob.securityContext.runAsUser | int | `10324` | The user ID to run the database cleanup job under. |
 | truncateWorkloadMetrics.enabled | bool | `false` | Enable truncating workload metrics false by default |
 | truncateWorkloadMetrics.resources | object | `{"limits":{"cpu":"250m","memory":"512Mi"},"requests":{"cpu":"40m","memory":"32Mi"}}` | Resources for the truncating workload metrics job. |
-| truncateWorkloadMetrics.schedules | list | `[{"cron":"0 */48 * * *","name":"truncate-workload"}]` | CRON schedules for the truncating workload metrics job. |
+| truncateWorkloadMetrics.schedules | list | `[]` | CRON schedules for the truncating workload metrics job. |
 | truncateWorkloadMetrics.securityContext.runAsUser | int | `10324` | The user ID to run the truncating workload metrics job under. |
 | service.port | int | `80` | Port to be used for the API and Dashboard services. |
 | service.type | string | `"ClusterIP"` | Service type for the API and Dashboard services |

--- a/stable/fairwinds-insights/README.md
+++ b/stable/fairwinds-insights/README.md
@@ -98,6 +98,10 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | databaseCleanupCronjob.resources | object | `{"limits":{"cpu":"500m","memory":"1024Mi"},"requests":{"cpu":"80m","memory":"128Mi"}}` | Resources for the database cleanup job. |
 | databaseCleanupCronjob.schedules | list | `[{"cron":"0 0 * * *","interval":"24h","name":"database-cleanup"}]` | CRON schedules for the database cleanup job. |
 | databaseCleanupCronjob.securityContext.runAsUser | int | `10324` | The user ID to run the database cleanup job under. |
+| truncateWorkloadMetrics.enabled | bool | `false` | Enable truncating workload metrics false by default |
+| truncateWorkloadMetrics.resources | object | `{"limits":{"cpu":"250m","memory":"512Mi"},"requests":{"cpu":"40m","memory":"32Mi"}}` | Resources for the truncating workload metrics job. |
+| truncateWorkloadMetrics.schedules | list | `[{"cron":"0 */48 * * *","name":"truncate-workload"}]` | CRON schedules for the truncating workload metrics job. |
+| truncateWorkloadMetrics.securityContext.runAsUser | int | `10324` | The user ID to run the truncating workload metrics job under. |
 | service.port | int | `80` | Port to be used for the API and Dashboard services. |
 | service.type | string | `"ClusterIP"` | Service type for the API and Dashboard services |
 | service.annotations | string | `nil` | Annotations for the services |

--- a/stable/fairwinds-insights/templates/truncate-workload-metrics-job.yaml
+++ b/stable/fairwinds-insights/templates/truncate-workload-metrics-job.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.truncateWorkloadMetrics.enabled }}
+{{ range .Values.truncateWorkloadMetrics.schedules }}
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {{ include "fairwinds-insights.fullname" $ }}-cronjob-{{ .name }}
+  labels:
+    {{- include "fairwinds-insights.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: action-items-cronjob-{{ .name }}
+spec:
+  concurrencyPolicy: Forbid
+  schedule: "{{ .cron }}"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          {{- with $.Values.image.pullSecret }}
+          imagePullSecrets:
+            - name: {{ . }}
+          {{- end }}
+          containers:
+            - name: fairwinds-insights
+              image: "{{ $.Values.cronjobImage.repository }}:{{ include "fairwinds-insights.cronjobImageTag" $ }}"
+              command: ["database_cleanup"]
+              {{- include "env" $ | indent 14 }}
+              imagePullPolicy: Always
+              resources:
+                {{- toYaml $.Values.truncateWorkloadMetrics.resources | nindent 16 }}
+              securityContext:
+                readOnlyRootFilesystem: true
+                allowPrivilegeEscalation: false
+                privileged: false
+                runAsNonRoot: true
+                runAsUser: {{ $.Values.truncateWorkloadMetrics.securityContext.runAsUser }}
+                capabilities:
+                  drop:
+                    - ALL
+{{ end }}
+{{- end }}

--- a/stable/fairwinds-insights/templates/truncate-workload-metrics-job.yaml
+++ b/stable/fairwinds-insights/templates/truncate-workload-metrics-job.yaml
@@ -23,7 +23,7 @@ spec:
           containers:
             - name: fairwinds-insights
               image: "{{ $.Values.cronjobImage.repository }}:{{ include "fairwinds-insights.cronjobImageTag" $ }}"
-              command: ["database_cleanup"]
+              command: ["truncate_workload_metrics"]
               {{- include "env" $ | indent 14 }}
               imagePullPolicy: Always
               resources:

--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -351,9 +351,7 @@ truncateWorkloadMetrics:
       cpu: 40m
       memory: 32Mi
   # -- CRON schedules for the truncating workload metrics job.
-  schedules:
-    - name: truncate-workload
-      cron: "0 */48 * * *"
+  schedules: []
   securityContext:
     # -- The user ID to run the truncating workload metrics job under.
     runAsUser: 10324

--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -339,6 +339,25 @@ databaseCleanupCronjob:
     # -- The user ID to run the database cleanup job under.
     runAsUser: 10324
 
+truncateWorkloadMetrics:
+  # -- Enable truncating workload metrics false by default
+  enabled: false
+  # -- Resources for the truncating workload metrics job.
+  resources:
+    limits:
+      cpu: 250m
+      memory: 512Mi
+    requests:
+      cpu: 40m
+      memory: 32Mi
+  # -- CRON schedules for the truncating workload metrics job.
+  schedules:
+    - name: truncate-workload
+      cron: "0 */48 * * *"
+  securityContext:
+    # -- The user ID to run the truncating workload metrics job under.
+    runAsUser: 10324
+
 service:
   # -- Port to be used for the API and Dashboard services.
   port: 80


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_
It adds the truncate workload metrics job
Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
