### PR TITLE
FWI-2025 - Remove ttlSecondsAfterFinished for the migration job

### DIFF
--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "8.5.1"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 0.5.13
+version: 0.5.14
 maintainers:
 - name: rbren
 - name: makoscafee

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "8.6.0"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 0.5.14
+version: 0.5.15
 maintainers:
 - name: rbren
 - name: makoscafee

--- a/stable/fairwinds-insights/templates/migrate-db-job.yaml
+++ b/stable/fairwinds-insights/templates/migrate-db-job.yaml
@@ -13,7 +13,6 @@ metadata:
     {{- include "fairwinds-insights.labels" . | nindent 4 }}
     app.kubernetes.io/component: migrate-db
 spec:
-  ttlSecondsAfterFinished: 100
   backoffLimit: 5
   template:
     spec:


### PR DESCRIPTION
**Why This PR?**
Removes `ttlSecondsAfterFinished` for migration job

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.


[Internal Ticket FWI-2025](https://fairwinds.myjetbrains.com/youtrack/issue/FWI-2025)