### PR TITLE
[stable/insights-agent] Fix Falco proxy indention and add proxy option for admission controller

### DIFF
--- a/stable/insights-admission/Chart.yaml
+++ b/stable/insights-admission/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: insights-admission
 description: A Validating Webhook Admission Controller that utilizes Fairwinds Insights.
 type: application
-version: 1.1.1
+version: 1.1.2
 appVersion: "1.1"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-admission/icon.png
 maintainers:

--- a/stable/insights-admission/README.md
+++ b/stable/insights-admission/README.md
@@ -37,6 +37,10 @@ rules:
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| global.proxy.http | string | `nil` | Annotations used to access the proxy servers(http). |
+| global.proxy.https | string | `nil` | Annotations used to access the proxy servers(https). |
+| global.proxy.ftp | string | `nil` | Annotations used to access the proxy servers(ftp). |
+| global.proxy.no_proxy | string | `nil` | Annotations to provides a way to exclude traffic destined to certain hosts from using the proxy. |
 | insights.organization | string | `""` | The name of your Organization from Fairwinds Insights |
 | insights.cluster | string | `""` | The name of your cluster from Fairwinds Insights |
 | insights.host | string | `"https://insights.fairwinds.com"` | Override the hostname for Fairwinds Insights |

--- a/stable/insights-admission/templates/_specs.yaml
+++ b/stable/insights-admission/templates/_specs.yaml
@@ -1,0 +1,27 @@
+
+{{ define "proxy-env-spec" }}
+{{- if .Values.global.proxy.https }}
+- name: https_proxy
+  value: {{ .Values.global.proxy.https }}
+- name: HTTPS_PROXY
+  value: {{ .Values.global.proxy.https }}
+{{- end }}
+{{- if .Values.global.proxy.http }}
+- name: http_proxy
+  value: {{ .Values.global.proxy.http }}
+- name: HTTP_PROXY
+  value: {{ .Values.global.proxy.http }}
+{{- end }}
+{{- if .Values.global.proxy.ftp }}
+- name: ftp_proxy
+  value: {{ .Values.global.proxy.ftp }}
+- name: FTP_PROXY
+  value: {{ .Values.global.proxy.ftp }}
+{{- end }}
+{{- if .Values.global.proxy.no_proxy }}
+- name: no_proxy
+  value: {{ .Values.global.proxy.no_proxy }}
+- name: NO_PROXY
+  value: {{ .Values.global.proxy.no_proxy }}
+{{- end }}
+{{- end }}

--- a/stable/insights-admission/templates/deployment.yaml
+++ b/stable/insights-admission/templates/deployment.yaml
@@ -88,6 +88,7 @@ spec:
               configMapKeyRef:
                 name: {{ include "insights-admission.configmapName" . }}
                 key: host
+          {{ include "proxy-env-spec" . | indent 10 | trim }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/stable/insights-admission/values.yaml
+++ b/stable/insights-admission/values.yaml
@@ -1,3 +1,14 @@
+global:
+  proxy:
+    # global.proxy.http -- Annotations used to access the proxy servers(http).
+    http:
+    # global.proxy.https -- Annotations used to access the proxy servers(https).
+    https:
+    # global.proxy.ftp -- Annotations used to access the proxy servers(ftp).
+    ftp:
+    # global.proxy.no_proxy -- Annotations to provides a way to exclude traffic destined to certain hosts from using the proxy.
+    no_proxy:
+
 insights:
   # insights.organization -- The name of your Organization from Fairwinds Insights
   organization: ""

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.0.5
-appVersion: 8.2.2
+version: 2.0.6
+appVersion: 8.6.0
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:
   - name: rbren

--- a/stable/insights-agent/README.md
+++ b/stable/insights-agent/README.md
@@ -61,11 +61,11 @@ Parameter | Description | Default
 `insights.host` | The location of the Insights server | https://insights.fairwinds.com
 `rbac.disabled` | Don't use any of the built-in RBAC | `false`
 `fleetInstall` | See Fleet Installation docs | `false`
+`global.proxy.http` | Annotations used to access the proxy servers(http) | ""
+`global.proxy.https` | Annotations used to access the proxy servers(https) | ""
+`global.proxy.ftp` | Annotations used to access the proxy servers(ftp) | ""
+`global.proxy.no_proxy` | Annotations to provides a way to exclude traffic destined to certain hosts from using the proxy | ""
 `insights.apiToken` | Only needed if `fleetInstall=true` | ""
-`proxy.http` | Annotations used to access the proxy servers(http) | ""
-`proxy.https` | Annotations used to access the proxy servers(https) | ""
-`proxy.ftp` | Annotations used to access the proxy servers(ftp) | ""
-`proxy.no_proxy` | Annotations to provides a way to exclude traffic destined to certain hosts from using the proxy | ""
 `uploader.image.repository`  | The repository to pull the uploader script from | quay.io/fairwinds/insights-uploader
 `uploader.image.tag` | The tag to use for the uploader script | 0.2
 `uploader.resources` | CPU/memory requests and limits for the uploader script |

--- a/stable/insights-agent/ci/test-values.yaml
+++ b/stable/insights-agent/ci/test-values.yaml
@@ -33,16 +33,7 @@ workloads:
 
 test:
   enabled: true
-  securityContext:
-    runAsUser: 1200
-    allowPrivilegeEscalation: false
-    privileged: false
-    readOnlyRootFilesystem: true
-    runAsNonRoot: true
-    capabilities:
-      drop:
-        - ALL
-
+  
 kube-bench:
   enabled: true
   resources:

--- a/stable/insights-agent/ci/test-values.yaml
+++ b/stable/insights-agent/ci/test-values.yaml
@@ -33,7 +33,7 @@ workloads:
 
 test:
   enabled: true
-  
+
 kube-bench:
   enabled: true
   resources:

--- a/stable/insights-agent/ci/test-values.yaml
+++ b/stable/insights-agent/ci/test-values.yaml
@@ -33,6 +33,15 @@ workloads:
 
 test:
   enabled: true
+  securityContext:
+    runAsUser: 1200
+    allowPrivilegeEscalation: false
+    privileged: false
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    capabilities:
+      drop:
+        - ALL
 
 kube-bench:
   enabled: true

--- a/stable/insights-agent/requirements.lock
+++ b/stable/insights-agent/requirements.lock
@@ -4,12 +4,12 @@ dependencies:
   version: 4.0.4
 - name: prometheus
   repository: https://prometheus-community.github.io/helm-charts
-  version: 15.5.2
+  version: 15.8.7
 - name: insights-admission
   repository: https://charts.fairwinds.com/stable
   version: 1.0.3
 - name: falco
   repository: https://falcosecurity.github.io/charts
   version: 1.17.0
-digest: sha256:acde64cf988329e08936d7eaa2a3ba477e7b66ae43b9b15d387a7476c3721b20
-generated: "2022-03-21T22:58:03.300959+03:00"
+digest: sha256:80d703eb7a96c8d6d1fcf05f24ca6eff3898a905a60be21d16c27c4c963ea6d5
+generated: "2022-05-19T18:48:02.312792+03:00"

--- a/stable/insights-agent/requirements.yaml
+++ b/stable/insights-agent/requirements.yaml
@@ -5,7 +5,7 @@ dependencies:
   condition: goldilocks.enabled
 - name: prometheus
   repository: https://prometheus-community.github.io/helm-charts
-  version: '15.5.2'
+  version: '15.8.7'
   condition: prometheus-metrics.installPrometheusServer
 - name: insights-admission
   repository: https://charts.fairwinds.com/stable

--- a/stable/insights-agent/templates/_specs.yaml
+++ b/stable/insights-agent/templates/_specs.yaml
@@ -88,29 +88,29 @@ initContainers:
   - --file
   - /output/{{ .Label }}-config.yaml
   env:
-  {{- if .Values.proxy.https }}
+  {{- if .Values.global.proxy.https }}
   - name: https_proxy
-    value: {{ .Values.proxy.https }}
+    value: {{ .Values.global.proxy.https }}
   - name: HTTPS_PROXY
-    value: {{ .Values.proxy.https }}
+    value: {{ .Values.global.proxy.https }}
   {{- end }}
-  {{- if .Values.proxy.http }}
+  {{- if .Values.global.proxy.http }}
   - name: http_proxy
-    value: {{ .Values.proxy.http }}
+    value: {{ .Values.global.proxy.http }}
   - name: HTTP_PROXY
-    value: {{ .Values.proxy.http }}
+    value: {{ .Values.global.proxy.http }}
   {{- end }}
-  {{- if .Values.proxy.ftp }}
+  {{- if .Values.global.proxy.ftp }}
   - name: ftp_proxy
-    value: {{ .Values.proxy.ftp }}
+    value: {{ .Values.global.proxy.ftp }}
   - name: FTP_PROXY
-    value: {{ .Values.proxy.ftp }}
+    value: {{ .Values.global.proxy.ftp }}
   {{- end }}
-  {{- if .Values.proxy.no_proxy }}
+  {{- if .Values.global.proxy.no_proxy }}
   - name: no_proxy
-    value: {{ .Values.proxy.no_proxy }}
+    value: {{ .Values.global.proxy.no_proxy }}
   - name: NO_PROXY
-    value: {{ .Values.proxy.no_proxy }}
+    value: {{ .Values.global.proxy.no_proxy }}
   {{- end }}
   - name: FAIRWINDS_TOKEN
     valueFrom:
@@ -153,28 +153,28 @@ securityContext:
 {{- end }}
 
 {{ define "proxy-env-spec" }}
-{{- if .Values.proxy.https }}
+{{- if .Values.global.proxy.https }}
 - name: https_proxy
-  value: {{ .Values.proxy.https }}
+  value: {{ .Values.global.proxy.https }}
 - name: HTTPS_PROXY
-  value: {{ .Values.proxy.https }}
+  value: {{ .Values.global.proxy.https }}
 {{- end }}
-{{- if .Values.proxy.http }}
+{{- if .Values.global.proxy.http }}
 - name: http_proxy
-  value: {{ .Values.proxy.http }}
+  value: {{ .Values.global.proxy.http }}
 - name: HTTP_PROXY
-  value: {{ .Values.proxy.http }}
+  value: {{ .Values.global.proxy.http }}
 {{- end }}
-{{- if .Values.proxy.ftp }}
+{{- if .Values.global.proxy.ftp }}
 - name: ftp_proxy
-  value: {{ .Values.proxy.ftp }}
+  value: {{ .Values.global.proxy.ftp }}
 - name: FTP_PROXY
-  value: {{ .Values.proxy.ftp }}
+  value: {{ .Values.global.proxy.ftp }}
 {{- end }}
-{{- if .Values.proxy.no_proxy }}
+{{- if .Values.global.proxy.no_proxy }}
 - name: no_proxy
-  value: {{ .Values.proxy.no_proxy }}
+  value: {{ .Values.global.proxy.no_proxy }}
 - name: NO_PROXY
-  value: {{ .Values.proxy.no_proxy }}
+  value: {{ .Values.global.proxy.no_proxy }}
 {{- end }}
 {{- end }}

--- a/stable/insights-agent/templates/falco/deployment.yaml
+++ b/stable/insights-agent/templates/falco/deployment.yaml
@@ -59,7 +59,7 @@ spec:
         - name: output-data
           mountPath: /output
         env:
-        {{ include "proxy-env-spec" . | indent 12 | trim }}
+        {{ include "proxy-env-spec" . | indent 8 | trim }}
       {{- if .Values.falco.securityContext }}
         securityContext:
           {{- toYaml .Values.falco.securityContext | nindent 12 }}

--- a/stable/insights-agent/templates/test/test-deployment.yaml
+++ b/stable/insights-agent/templates/test/test-deployment.yaml
@@ -24,7 +24,7 @@ spec:
           env:
           {{ include "proxy-env-spec" . | indent 10 | trim }}
           securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
+            {{- toYaml .Values.test.securityContext | nindent 12 }}
           image: "{{ .Values.test.image.repository }}:{{ .Values.test.image.tag }}"
           imagePullPolicy: {{ .Values.test.image.pullPolicy }}
           ports:

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -348,10 +348,6 @@ prometheus:
     persistentVolume:
       enabled: false
     retention: "1d"
-    deploymentAnnotations:
-      polaris.fairwinds.com/insecureCapabilities-exempt: "true"
-      polaris.fairwinds.com/privilegeEscalationAllowed-exempt: "true"
-      polaris.fairwinds.com/notReadOnlyRootFilesystem-exempt: "true"
     resources:
       limits:
         cpu: 500m
@@ -359,6 +355,12 @@ prometheus:
       requests:
         cpu: 250m
         memory: 2Gi
+    containerSecurityContext:
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      capabilities:
+        drop:
+          - ALL
   kube-state-metrics:
     image:
       pullPolicy: Always

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -401,6 +401,15 @@ test:
     repository: "python"
     tag: "3.6"
     pullPolicy: "Always"
+  securityContext:
+    runAsUser: 1200
+    allowPrivilegeEscalation: false
+    privileged: false
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    capabilities:
+      drop:
+        - ALL
 
 awscosts:
   enabled: false

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -5,15 +5,16 @@ insights:
   base64token: ""
   tokenSecretName: ""
 
-proxy:
-  # proxy.http -- Annotations used to access the proxy servers(http).
-  http:
-  # proxy.https -- Annotations used to access the proxy servers(https).
-  https:
-  # proxy.ftp -- Annotations used to access the proxy servers(ftp).
-  ftp:
-  # proxy.no_proxy -- Annotations to provides a way to exclude traffic destined to certain hosts from using the proxy.
-  no_proxy:
+global:
+  proxy:
+    # global.proxy.http -- Annotations used to access the proxy servers(http).
+    http:
+    # global.proxy.https -- Annotations used to access the proxy servers(https).
+    https:
+    # global.proxy.ftp -- Annotations used to access the proxy servers(ftp).
+    ftp:
+    # global.proxy.no_proxy -- Annotations to provides a way to exclude traffic destined to certain hosts from using the proxy.
+    no_proxy:
 
 rbac:
   disabled: false


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_
Fixes Falco proxy indention issue and adds a proxy option for admission controller

Fixes #817 

**Changes**
Changes proposed in this pull request:

* Change falco proxy indention from 12 to 8 to have valid yaml
* Added changed the proxy setting to global values so sub-charts can use them.
* Added proxy option to the admission controller.

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
