### PR TITLE
[Incubator/stackdriver-metrics-adapter]Bump rbac apiVersion for 1.22 support

### DIFF
--- a/incubator/stackdriver-metrics-adapter/Chart.yaml
+++ b/incubator/stackdriver-metrics-adapter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.12.0-gke.0"
 description: The stackdriver metrics adapter
 name: stackdriver-metrics-adapter
-version: 0.2.1
+version: 0.2.2
 maintainers:
   - name: lucasreed
     email: luke@fairwinds.com

--- a/incubator/stackdriver-metrics-adapter/templates/rbac.yaml
+++ b/incubator/stackdriver-metrics-adapter/templates/rbac.yaml
@@ -49,7 +49,7 @@ subjects:
   name: {{ include "stackdriver-metrics-adapter.fullname" . }}
   namespace: {{ .Release.Namespace }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "stackdriver-metrics-adapter.fullname" . }}-resource-reader


### PR DESCRIPTION
**Why This PR?**
This bumps the rbac.authorization apiVersion to support upgrades to k8s 1.22 for the stackdriver-metrics-adapter chart.

Fixes #

**Changes**
Changes proposed in this pull request:

*Change the rbac.authorization apiVersion for the clusterrolebinding.
*

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
