### PR TITLE
[stable/insights-agent] update admission controller 

### DIFF
--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.0.6
+version: 2.0.7
 appVersion: 8.6.0
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:

--- a/stable/insights-agent/requirements.lock
+++ b/stable/insights-agent/requirements.lock
@@ -7,9 +7,9 @@ dependencies:
   version: 15.8.7
 - name: insights-admission
   repository: https://charts.fairwinds.com/stable
-  version: 1.0.3
+  version: 1.1.2
 - name: falco
   repository: https://falcosecurity.github.io/charts
   version: 1.17.0
-digest: sha256:80d703eb7a96c8d6d1fcf05f24ca6eff3898a905a60be21d16c27c4c963ea6d5
-generated: "2022-05-19T18:48:02.312792+03:00"
+digest: sha256:5c77c5ff24744098c6c26983f4726059222df2d2e3a6ae835659bda09864b516
+generated: "2022-05-20T21:53:35.297507+03:00"

--- a/stable/insights-agent/requirements.yaml
+++ b/stable/insights-agent/requirements.yaml
@@ -9,7 +9,7 @@ dependencies:
   condition: prometheus-metrics.installPrometheusServer
 - name: insights-admission
   repository: https://charts.fairwinds.com/stable
-  version: '1.0.*'
+  version: '1.1.*'
   condition: admission.enabled
 - name: falco
   repository: https://falcosecurity.github.io/charts


### PR DESCRIPTION


**Why This PR?**
_a short description of why this PR is needed_
Updates admission controller sub chart to take advantage of the `global.proxy` configuration on the latest chart.
Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
