### PR TITLE
Fix insights-agent helm chart upgrade when fleetInstall=true

### DIFF
--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.0.6
+version: 2.0.7
 appVersion: 8.6.0
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:

--- a/stable/insights-agent/templates/fleet-installer/admin-secret.yaml
+++ b/stable/insights-agent/templates/fleet-installer/admin-secret.yaml
@@ -5,7 +5,7 @@ metadata:
   name:  {{ default ( printf "%s-api-token" (include "insights-agent.fullname" .) ) .Values.insights.apiTokenSecretName }}
   annotations:
     "helm.sh/hook-weight": "5"
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
 stringData:
   token: {{ .Values.insights.apiToken | quote }}

--- a/stable/insights-agent/templates/fleet-installer/rbac.yaml
+++ b/stable/insights-agent/templates/fleet-installer/rbac.yaml
@@ -7,7 +7,7 @@ metadata:
     app: insights-agent
   annotations:
     "helm.sh/hook-weight": "1"
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
 ---
 kind: Role
@@ -18,7 +18,7 @@ metadata:
     app: insights-agent
   annotations:
     "helm.sh/hook-weight": "2"
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
 rules:
 - apiGroups: [""]
@@ -33,7 +33,7 @@ metadata:
     app: insights-agent
   annotations:
     "helm.sh/hook-weight": "3"
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/stable/insights-agent/templates/test/test-deployment.yaml
+++ b/stable/insights-agent/templates/test/test-deployment.yaml
@@ -4,7 +4,7 @@ kind: Deployment
 metadata:
   name: {{ include "insights-agent.fullname" . }}-test
   annotations:
-    helm.sh/hook: pre-install
+    helm.sh/hook: pre-install,pre-upgrade
   labels:
     component: test
     app: insights-agent
@@ -66,7 +66,7 @@ kind: Service
 metadata:
   name: insights-agent-test
   annotations:
-    helm.sh/hook: pre-install
+    helm.sh/hook: pre-install,pre-upgrade
   labels:
     component: test
     app: insights-agent


### PR DESCRIPTION
**Why This PR?**
Support insights-agent helm chart upgrades when fleet install = true.

Fixes #822 

**Changes**
Changes proposed in this pull request:

* Ensure that helm pre-upgrade hook is set on fleet-install admin secret, job, serviceaccount, role, and rolebinding, otherwise necessary resources are not available and helm chart upgrade will fail.

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
