### PR TITLE
[stable/insights-agent] Add pod annotations to cronjobs

### DIFF
--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.1.0
+version: 2.2.0
 appVersion: 8.6.0
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:

--- a/stable/insights-agent/templates/_specs.yaml
+++ b/stable/insights-agent/templates/_specs.yaml
@@ -35,6 +35,12 @@ backoffLimit: {{ .Values.cronjobs.backoffLimit }}
 activeDeadlineSeconds: {{ mul .Config.timeout .Values.cronjobs.backoffLimit }}
 {{- end }}
 
+{{ define "job-spec-metadata" }}
+metadata:
+  annotations:
+    cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+{{- end }}
+
 {{ define "job-template-spec" }}
 restartPolicy: Never
 serviceAccountName: {{ include "insights-agent.fullname" . }}-{{ .Label }}

--- a/stable/insights-agent/templates/awscosts/cronjob.yaml
+++ b/stable/insights-agent/templates/awscosts/cronjob.yaml
@@ -30,24 +30,24 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.awscosts.secretName }}
-                  key: AWS_SECRET_ACCESS_KEY            
+                  key: AWS_SECRET_ACCESS_KEY
             - name: AWS_DEFAULT_REGION
               value: {{ .Values.awscosts.region }}
             {{ include "proxy-env-spec" . | indent 12 | trim }}
             command: ["./aws-costs.sh"]
             args:
-              - --database 
+              - --database
               - {{ .Values.awscosts.database }}
-              - --table 
+              - --table
               - {{ .Values.awscosts.table }}
-              - --catalog 
+              - --catalog
               - {{ .Values.awscosts.catalog }}
-              - --tagkey 
+              - --tagkey
               - {{ .Values.awscosts.tagkey }}
-              - --tagvalue 
+              - --tagvalue
               - {{ .Values.awscosts.tagvalue }}
-              - --workgroup 
-              - {{ .Values.awscosts.workgroup }}              
+              - --workgroup
+              - {{ .Values.awscosts.workgroup }}
             {{ include "security-context" . | indent 12 | trim }}
           {{ include "uploaderContainer" . | indent 10 | trim }}
   {{- end -}}

--- a/stable/insights-agent/templates/awscosts/cronjob.yaml
+++ b/stable/insights-agent/templates/awscosts/cronjob.yaml
@@ -15,6 +15,7 @@ spec:
     spec:
       {{ include "job-spec" . | nindent 6 | trim }}
       template:
+        {{ include "job-spec-metadata" . | nindent 8 | trim }}
         spec:
           {{ include "job-template-spec" . | indent 10 | trim }}
           containers:

--- a/stable/insights-agent/templates/falco/cronjob.yaml
+++ b/stable/insights-agent/templates/falco/cronjob.yaml
@@ -15,6 +15,7 @@ spec:
     spec:
       {{ include "job-spec" . | nindent 6 | trim }}
       template:
+        {{ include "job-spec-metadata" . | nindent 8 | trim }}
         spec:
           {{ include "job-template-spec" . | indent 10 | trim }}
           - name: tmp

--- a/stable/insights-agent/templates/falco/cronjob.yaml
+++ b/stable/insights-agent/templates/falco/cronjob.yaml
@@ -39,7 +39,7 @@ spec:
             args:
                 - -c
                 - |
-                  curl http://falco-agent:3031/output -o /tmp/falco.json && mv /tmp/falco.json /output/falco.json        
+                  curl http://falco-agent:3031/output -o /tmp/falco.json && mv /tmp/falco.json /output/falco.json
             env:
             {{ include "proxy-env-spec" . | indent 12 | trim }}
             {{ include "security-context" . | indent 12 | trim }}

--- a/stable/insights-agent/templates/goldilocks/cronjob.yaml
+++ b/stable/insights-agent/templates/goldilocks/cronjob.yaml
@@ -8,6 +8,7 @@ spec:
     spec:
       {{ include "job-spec" . | nindent 6 | trim }}
       template:
+        {{ include "job-spec-metadata" . | nindent 8 | trim }}
         spec:
           {{ include "job-template-spec" . | indent 10 | trim }}
           containers:

--- a/stable/insights-agent/templates/kube-bench/cronjob.yaml
+++ b/stable/insights-agent/templates/kube-bench/cronjob.yaml
@@ -14,6 +14,7 @@ spec:
     spec:
       {{ include "job-spec" . | nindent 6 | trim }}
       template:
+        {{ include "job-spec-metadata" . | nindent 8 | trim }}
         spec:
           {{ include "job-template-spec" . | indent 10 | trim }}
           {{- if or (eq (index .Values "kube-bench" "mode") "daemonsetMaster") (eq (index .Values "kube-bench" "mode") "daemonset") }}

--- a/stable/insights-agent/templates/kube-hunter/cronjob.yaml
+++ b/stable/insights-agent/templates/kube-hunter/cronjob.yaml
@@ -12,6 +12,7 @@ spec:
     spec:
       {{ include "job-spec" . | nindent 6 | trim }}
       template:
+        {{ include "job-spec-metadata" . | nindent 8 | trim }}
         spec:
           {{ include "job-template-spec" . | indent 10 | trim }}
           - name: tmp

--- a/stable/insights-agent/templates/nova/cronjob.yaml
+++ b/stable/insights-agent/templates/nova/cronjob.yaml
@@ -8,6 +8,7 @@ spec:
     spec:
       {{ include "job-spec" . | nindent 6 | trim }}
       template:
+        {{ include "job-spec-metadata" . | nindent 8 | trim }}
         spec:
           {{ include "job-template-spec" . | indent 10 | trim }}
           containers:

--- a/stable/insights-agent/templates/opa/cronjob.yaml
+++ b/stable/insights-agent/templates/opa/cronjob.yaml
@@ -8,6 +8,7 @@ spec:
     spec:
       {{ include "job-spec" . | nindent 6 | trim }}
       template:
+        {{ include "job-spec-metadata" . | nindent 8 | trim }}
         spec:
           {{ include "job-template-spec" . | indent 10 | trim }}
           containers:

--- a/stable/insights-agent/templates/pluto/cronjob.yaml
+++ b/stable/insights-agent/templates/pluto/cronjob.yaml
@@ -8,6 +8,7 @@ spec:
     spec:
       {{ include "job-spec" . | nindent 6 | trim }}
       template:
+        {{ include "job-spec-metadata" . | nindent 8 | trim }}
         spec:
           {{ include "job-template-spec" . | indent 10 | trim }}
           containers:

--- a/stable/insights-agent/templates/polaris/cronjob.yaml
+++ b/stable/insights-agent/templates/polaris/cronjob.yaml
@@ -8,6 +8,7 @@ spec:
     spec:
       {{ include "job-spec" . | nindent 6 | trim }}
       template:
+        {{ include "job-spec-metadata" . | nindent 8 | trim }}
         spec:
           {{ include "job-template-spec" . | indent 10 | trim }}
           {{ if .Values.polaris.config }}

--- a/stable/insights-agent/templates/prometheus-metrics/cronjob.yaml
+++ b/stable/insights-agent/templates/prometheus-metrics/cronjob.yaml
@@ -11,6 +11,7 @@ spec:
     spec:
       {{ include "job-spec" . | nindent 6 | trim }}
       template:
+        {{ include "job-spec-metadata" . | nindent 8 | trim }}
         spec:
           {{ include "job-template-spec" . | indent 10 | trim }}
           containers:

--- a/stable/insights-agent/templates/rbac-reporter/cronjob.yaml
+++ b/stable/insights-agent/templates/rbac-reporter/cronjob.yaml
@@ -11,6 +11,7 @@ spec:
     spec:
       {{ include "job-spec" . | nindent 6 | trim }}
       template:
+        {{ include "job-spec-metadata" . | nindent 8 | trim }}
         spec:
           {{ include "job-template-spec" . | indent 10 | trim }}
           containers:

--- a/stable/insights-agent/templates/right-sizer/agent-cronjob.yaml
+++ b/stable/insights-agent/templates/right-sizer/agent-cronjob.yaml
@@ -11,6 +11,7 @@ spec:
     spec:
       {{ include "job-spec" . | nindent 6 | trim }}
       template:
+        {{ include "job-spec-metadata" . | nindent 8 | trim }}
         spec:
           {{ include "job-template-spec" . | indent 10 | trim }}
           volumes:

--- a/stable/insights-agent/templates/trivy/cronjob.yaml
+++ b/stable/insights-agent/templates/trivy/cronjob.yaml
@@ -8,6 +8,7 @@ spec:
     spec:
       {{ include "job-spec" . | nindent 6 | trim }}
       template:
+        {{ include "job-spec-metadata" . | nindent 8 | trim }}
         spec:
           {{ include "job-template-spec" . | indent 10 | trim }}
           - name: tmp

--- a/stable/insights-agent/templates/workloads/cronjob.yaml
+++ b/stable/insights-agent/templates/workloads/cronjob.yaml
@@ -8,6 +8,7 @@ spec:
     spec:
       {{ include "job-spec" . | nindent 6 | trim }}
       template:
+        {{ include "job-spec-metadata" . | nindent 8 | trim }}
         spec:
           {{ include "job-template-spec" . | indent 10 | trim }}
           containers:


### PR DESCRIPTION
**Why This PR?**
In GCP several cronjob pods were identified as blocking scale down due to having local storage.

Fixes #
Fixes Pod is blocking scale down because it has local storage occurring in GCP

**Changes**
Changes proposed in this pull request:

* add metadata section to job-spec
* add job-spec-metadata to all cronjobs that could affect scale down.

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
