### PR TITLE
[stable/insights-agent]: Add `awscosts.containerSecurityContext`

### DIFF
--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.2.1
+version: 2.2.2
 appVersion: 8.6.0
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.1.0
+version: 2.1.1
 appVersion: 8.6.0
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:

--- a/stable/insights-agent/README.md
+++ b/stable/insights-agent/README.md
@@ -125,6 +125,7 @@ Parameter | Description | Default
 `awscosts.tagkey` | Tag used to identify cluster nodes. Example: Kops uses 'kubernetes_cluster'.  | ""
 `awscosts.tagvalue` | Tag value used to identify a cluster given a tag key. | ""
 `awscosts.workgroup` | Athena work group that used to run the queries | ""
+`awscosts.containerSecurityContext` | Additional container securityContext items for the cronJob. | {}
 
 ## Breaking Changes
 

--- a/stable/insights-agent/templates/awscosts/cronjob.yaml
+++ b/stable/insights-agent/templates/awscosts/cronjob.yaml
@@ -48,5 +48,8 @@ spec:
               - --workgroup 
               - {{ .Values.awscosts.workgroup }}              
             {{ include "security-context" . | indent 12 | trim }}
+            {{- if  (index .Values "awscosts" "containerSecurityContext") }}
+            {{- toYaml (index .Values "awscosts" "containerSecurityContext") | nindent 14 }}
+            {{- end }}
           {{ include "uploaderContainer" . | indent 10 | trim }}
   {{- end -}}

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -427,6 +427,8 @@ awscosts:
     requests:
       cpu: 100m
       memory: 128Mi
+  # awscosts.containerSecurityContext -- Additional container securityContext items for the cronJob.
+  containerSecurityContext: {}
 
 right-sizer:
   enabled: false


### PR DESCRIPTION
**Why This PR?**
Add the `awscosts.containerSecurityContext` value to the insights-agent chart, to allow adding awscost-specific container securityContext, such as `fsGroup`.


**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
