### PR TITLE
[stable/insights-agent] Use latest nova in insights-agent chart

### DIFF
--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.2.4
+version: 2.2.5
 appVersion: 8.6.0
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -212,7 +212,7 @@ nova:
   logLevel: 3
   image:
     repository: quay.io/fairwinds/nova
-    tag: "v3.0"
+    tag: "v3.2"
   resources:
     limits:
       cpu: 100m


### PR DESCRIPTION
Update to use the latest nova release to ensure the fix for https://github.com/FairwindsOps/nova/pull/115 is included in the insights-agent.

**Why This PR?**
We are hitting this issue in the default insights-agent install. https://github.com/FairwindsOps/nova/pull/115 

Fixes #

**Changes**
Changes proposed in this pull request:

* use latest nova
*

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
