### PR TITLE
[stable/aws-iam-authenticator] support kops 1.22

### DIFF
--- a/stable/aws-iam-authenticator/Chart.yaml
+++ b/stable/aws-iam-authenticator/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: v0.5.3
 description: Install and configure aws-iam-authenticator on your cluster.
 name: aws-iam-authenticator
-version: v1.6.0
+version: v1.7.0
 maintainers:
   - name: sudermanjr

--- a/stable/aws-iam-authenticator/README.md
+++ b/stable/aws-iam-authenticator/README.md
@@ -13,9 +13,9 @@ In this version, due to updates for Kubernetes 1.16+, the labelSelector for the 
 | image.repository | string | `"602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-iam-authenticator"` |  |
 | image.tag | string | `"v0.5.3-scratch"` |  |
 | volumes.output.mountPath | string | `"/etc/kubernetes/aws-iam-authenticator/"` |  |
-| volumes.output.hostPath | string | `"/srv/kubernetes/aws-iam-authenticator/"` |  |
+| volumes.output.hostPath | string | `"/srv/kubernetes/kube-apiserver/aws-iam-authenticator/"` |  |
 | volumes.state.mountPath | string | `"/var/aws-iam-authenticator/"` |  |
-| volumes.state.hostPath | string | `"/srv/kubernetes/aws-iam-authenticator/"` |  |
+| volumes.state.hostPath | string | `"/srv/kubernetes/kube-apiserver/aws-iam-authenticator/"` |  |
 | volumes.config.mountPath | string | `"/etc/aws-iam-authenticator/"` |  |
 | nodeSelector | object | `{"node-role.kubernetes.io/master":""}` | Node selection constraint |
 | tolerations | list | Tolerate node-role.kubernetes.io/master and CriticalAddonsOnly | Taint tolerations |

--- a/stable/aws-iam-authenticator/values.yaml
+++ b/stable/aws-iam-authenticator/values.yaml
@@ -7,10 +7,10 @@ image:
 volumes:
   output:
     mountPath: /etc/kubernetes/aws-iam-authenticator/
-    hostPath: /srv/kubernetes/aws-iam-authenticator/
+    hostPath: /srv/kubernetes/kube-apiserver/aws-iam-authenticator/
   state:
     mountPath: /var/aws-iam-authenticator/
-    hostPath: /srv/kubernetes/aws-iam-authenticator/
+    hostPath: /srv/kubernetes/kube-apiserver/aws-iam-authenticator/
   config:
     mountPath: /etc/aws-iam-authenticator/
 


### PR DESCRIPTION
**Why This PR?**

upgrading kops to 1.22 moves the location of the files aws-iam-auth needs

**Changes**
Changes proposed in this pull request:

* move to `kube-apiserver` subdir

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
