### PR TITLE
[stable/insights-agent] Allow disabling Open API ingress

### DIFF
--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "8.9.0"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 0.5.22
+version: 0.5.23
 maintainers:
 - name: rbren
 - name: makoscafee

--- a/stable/fairwinds-insights/README.md
+++ b/stable/fairwinds-insights/README.md
@@ -23,8 +23,8 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | migrationImage.tag | string | `nil` | Overrides tag for the migration image, defaults to image.tag |
 | cronjobImage.repository | string | `"quay.io/fairwinds/insights-cronjob"` | Docker image repository for maintenance CronJobs. |
 | cronjobImage.tag | string | `nil` | Overrides tag for the cronjob image, defaults to image.tag |
-| openApiImage.repository | string | `"swaggerapi/swagger-ui"` | Docker image repository for the openAPI server |
-| openApiImage.tag | string | `"v4.1.3"` | Overrides tag for the openAPI server, defaults to image.tag |
+| openApiImage.repository | string | `"swaggerapi/swagger-ui"` | Docker image repository for the Open API server |
+| openApiImage.tag | string | `"v4.1.3"` | Overrides tag for the Open API server, defaults to image.tag |
 | options.agentChartTargetVersion | string | `"2.2.4"` | Which version of the Insights Agent is supported by this version of Fairwinds Insights |
 | options.insightsSAASHost | string | `"https://insights.fairwinds.com"` | Do not change, this is the hostname that Fairwinds Insights will reach out to for license verification. |
 | options.allowHTTPCookies | bool | `false` | Allow cookies to work over HTTP instead of requiring HTTPS. This generally should not be changed. |
@@ -71,16 +71,18 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | api.nodeSelector | object | `{}` | Node Selector for the API server. |
 | api.tolerations | list | `[]` | Tolerations for the API server. |
 | api.securityContext.runAsUser | int | `10324` | The user ID to run the API server under. |
-| openApi.port | int | `8080` | Port for the openAPI server to listen on. |
-| openApi.pdb.enabled | bool | `false` | Create a pod disruption budget for the openAPI server. |
-| openApi.pdb.minReplicas | int | `1` | How many replicas should always exist for the openAPI server. |
-| openApi.hpa.enabled | bool | `false` | Create a horizontal pod autoscaler for the openAPI server. |
-| openApi.hpa.min | int | `1` | Minimum number of replicas for the openAPI server. |
-| openApi.hpa.max | int | `2` | Maximum number of replicas for the openAPI server. |
+| openApi.port | int | `8080` | Port for the Open API server to listen on. |
+| openApi.pdb.enabled | bool | `false` | Create a pod disruption budget for the Open API server. |
+| openApi.pdb.minReplicas | int | `1` | How many replicas should always exist for the Open API server. |
+| openApi.hpa.enabled | bool | `false` | Create a horizontal pod autoscaler for the Open API server. |
+| openApi.hpa.min | int | `1` | Minimum number of replicas for the Open API server. |
+| openApi.hpa.max | int | `2` | Maximum number of replicas for the Open API server. |
 | openApi.hpa.metrics | list | `[{"resource":{"name":"cpu","target":{"averageUtilization":75,"type":"Utilization"}},"type":"Resource"},{"resource":{"name":"memory","target":{"averageUtilization":75,"type":"Utilization"}},"type":"Resource"}]` | Scaling metrics |
-| openApi.resources | object | `{"limits":{"cpu":"256m","memory":"256Mi"},"requests":{"cpu":"100m","memory":"100Mi"}}` | Resources for the openAPI server. |
-| openApi.nodeSelector | object | `{}` | Node Selector for the openAPI server. |
-| openApi.tolerations | list | `[]` | Tolerations for the openApi server. |
+| openApi.resources | object | `{"limits":{"cpu":"256m","memory":"256Mi"},"requests":{"cpu":"100m","memory":"100Mi"}}` | Resources for the Open API server. |
+| openApi.nodeSelector | object | `{}` | Node Selector for the Open API server. |
+| openApi.tolerations | list | `[]` | Tolerations for the Open API server. |
+| openApi.ingress.enabled | bool | `true` | Enable the Open API ingress |
+| openApi.service.type | string | `nil` | Service type for Open API server |
 | dbMigration.resources | object | `{"limits":{"cpu":1,"memory":"1024Mi"},"requests":{"cpu":"80m","memory":"128Mi"}}` | Resources for the database migration job. |
 | dbMigration.securityContext.runAsUser | int | `10324` | The user ID to run the database migration job under. |
 | samlCronjob.resources | object | `{"limits":{"cpu":"500m","memory":"1024Mi"},"requests":{"cpu":"80m","memory":"128Mi"}}` | Resources for the SAML sync job. |

--- a/stable/fairwinds-insights/README.md
+++ b/stable/fairwinds-insights/README.md
@@ -71,6 +71,8 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | api.nodeSelector | object | `{}` | Node Selector for the API server. |
 | api.tolerations | list | `[]` | Tolerations for the API server. |
 | api.securityContext.runAsUser | int | `10324` | The user ID to run the API server under. |
+| api.ingress.enabled | bool | `true` | Enable the Open API ingress |
+| api.service.type | string | `nil` | Service type for Open API server |
 | openApi.port | int | `8080` | Port for the Open API server to listen on. |
 | openApi.pdb.enabled | bool | `false` | Create a pod disruption budget for the Open API server. |
 | openApi.pdb.minReplicas | int | `1` | How many replicas should always exist for the Open API server. |

--- a/stable/fairwinds-insights/templates/deployment-dashboard.yaml
+++ b/stable/fairwinds-insights/templates/deployment-dashboard.yaml
@@ -39,6 +39,7 @@ spec:
             mv -f {{ . }} ./config.js || exit 1
             {{ end -}}
             sed -i 's/SERVICE.NAMESPACE.svc/{{ include "fairwinds-insights.fullname" . }}-api.{{.Release.Namespace}}.svc/' /etc/nginx/nginx.conf
+            sed -i 's/SERVICE-OPEN-API.NAMESPACE.svc/{{ include "fairwinds-insights.fullname" . }}-open-api.{{.Release.Namespace}}.svc/' /etc/nginx/nginx.conf
             nginx -g "daemon off;"
           ports:
             - name: http

--- a/stable/fairwinds-insights/templates/ingress.yaml
+++ b/stable/fairwinds-insights/templates/ingress.yaml
@@ -36,10 +36,12 @@ spec:
           {{ with $.Values.ingress.extraPaths }}
           {{- toYaml . | nindent 10 }}
           {{ end }}
+          {{- if $.Values.openApi.ingress.enabled }}
           - path: {{ $.Values.ingress.starPaths | ternary "/swagger/*" "/swagger" }}
             backend:
               serviceName: {{ $fullName }}-open-api
               servicePort: http
+          {{- end }}
           - path: {{ $.Values.ingress.starPaths | ternary "/*" "/" }}
             backend:
               serviceName: {{ $fullName }}-dashboard
@@ -113,10 +115,12 @@ spec:
           {{ with $.Values.ingress.extraPaths }}
           {{- toYaml . | nindent 10 }}
           {{ end }}
+          {{- if $.Values.openApi.ingress.enabled }}
           - path: {{ $.Values.ingress.starPaths | ternary "/swagger/*" "/swagger" }}
             backend:
               serviceName: {{ $fullName }}-open-api
               servicePort: http
+          {{- end }}
           - path: {{ $.Values.ingress.starPaths | ternary "/*" "/" }}
             backend:
               serviceName: {{ $fullName }}-dashboard
@@ -152,6 +156,7 @@ spec:
           {{ with $.Values.ingress.extraPaths }}
           {{- toYaml . | nindent 10 }}
           {{ end }}
+          {{- if $.Values.openApi.ingress.enabled }}
           - path: {{ $.Values.ingress.starPaths | ternary "/swagger/*" "/swagger" }}
             pathType: Prefix
             backend:
@@ -159,6 +164,7 @@ spec:
                 name: {{ $fullName }}-open-api
                 port:
                   name: http
+          {{- end }}
           - path: {{ $.Values.ingress.starPaths | ternary "/v0/*" "/v0" }}
             pathType: Prefix
             backend:
@@ -245,6 +251,7 @@ spec:
           {{ with $.Values.ingress.extraPaths }}
           {{- toYaml . | nindent 10 }}
           {{ end }}
+          {{- if $.Values.openApi.ingress.enabled }}
           - path: {{ $.Values.ingress.starPaths | ternary "/swagger/*" "/swagger" }}
             pathType: Prefix
             backend:
@@ -252,6 +259,7 @@ spec:
                 name: {{ $fullName }}-open-api
                 port:
                   name: http
+          {{- end }}
           - path: {{ $.Values.ingress.starPaths | ternary "/*" "/" }}
             pathType: Prefix
             backend:

--- a/stable/fairwinds-insights/templates/ingress.yaml
+++ b/stable/fairwinds-insights/templates/ingress.yaml
@@ -23,6 +23,7 @@ spec:
 {{- end }}
   rules:
     {{- range .Values.ingress.hostedZones }}
+    {{- if $.Values.api.ingress.enabled }}
     - host: {{ include "fairwinds-insights.sanitizedPrefix" $ }}{{ . }}
       http:
         paths:
@@ -30,6 +31,7 @@ spec:
             backend:
               serviceName: {{ $fullName }}-api
               servicePort: http
+    {{- end }}
     - host: {{ include "fairwinds-insights.sanitizedPrefix" $ }}{{ . }}
       http:
         paths:
@@ -165,6 +167,7 @@ spec:
                 port:
                   name: http
           {{- end }}
+          {{- if $.Values.api.ingress.enabled }}
           - path: {{ $.Values.ingress.starPaths | ternary "/v0/*" "/v0" }}
             pathType: Prefix
             backend:
@@ -172,6 +175,7 @@ spec:
                 name: {{ $fullName }}-api
                 port:
                   name: http
+          {{- end }}
           - path: {{ $.Values.ingress.starPaths | ternary "/*" "/" }}
             pathType: Prefix
             backend:
@@ -181,6 +185,7 @@ spec:
                   name: http
     {{- end }}
 {{- else }}
+{{- if $.Values.api.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -218,6 +223,7 @@ spec:
                 port:
                   name: http
     {{- end }}
+{{- end }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/stable/fairwinds-insights/templates/service-api.yaml
+++ b/stable/fairwinds-insights/templates/service-api.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  type: {{ .Values.service.type }}
+  type: {{ default .Values.service.type .Values.api.service.type }}
   ports:
     - port: {{ .Values.service.port }}
       targetPort: http

--- a/stable/fairwinds-insights/templates/service-open-api.yaml
+++ b/stable/fairwinds-insights/templates/service-open-api.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  type: {{ default .Vaules.service.type .Values.openApi.service.type }}
+  type: {{ default .Values.service.type .Values.openApi.service.type }}
   ports:
     - port: {{ .Values.service.port }}
       targetPort: http

--- a/stable/fairwinds-insights/templates/service-open-api.yaml
+++ b/stable/fairwinds-insights/templates/service-open-api.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  type: {{ .Values.service.type }}
+  type: {{ default .Vaules.service.type .Values.openApi.service.type }}
   ports:
     - port: {{ .Values.service.port }}
       targetPort: http

--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -189,6 +189,12 @@ api:
   securityContext:
     # -- The user ID to run the API server under.
     runAsUser: 10324
+  ingress:
+    # -- Enable the Open API ingress
+    enabled: true
+  service:
+    # -- Service type for Open API server
+    type:
 
 openApi:
   # -- Port for the Open API server to listen on.

--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -231,6 +231,10 @@ openApi:
   nodeSelector: {}
   # -- Tolerations for the openApi server.
   tolerations: []
+  ingress:
+    enabled: true
+  service:
+    type:
 
 dbMigration:
   # -- Resources for the database migration job.

--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -38,9 +38,9 @@ cronjobImage:
   # -- Overrides tag for the cronjob image, defaults to image.tag
   tag:
 openApiImage:
-  # -- Docker image repository for the openAPI server
+  # -- Docker image repository for the Open API server
   repository: swaggerapi/swagger-ui
-  # -- Overrides tag for the openAPI server, defaults to image.tag
+  # -- Overrides tag for the Open API server, defaults to image.tag
   tag: v4.1.3  # NOTE: if you're changing this, be sure to look at templates/openapi-nginx-conf.yaml
 
 
@@ -191,19 +191,19 @@ api:
     runAsUser: 10324
 
 openApi:
-  # -- Port for the openAPI server to listen on.
+  # -- Port for the Open API server to listen on.
   port: 8080
   pdb:
-    # -- Create a pod disruption budget for the openAPI server.
+    # -- Create a pod disruption budget for the Open API server.
     enabled: false
-    # -- How many replicas should always exist for the openAPI server.
+    # -- How many replicas should always exist for the Open API server.
     minReplicas: 1
   hpa:
-    # -- Create a horizontal pod autoscaler for the openAPI server.
+    # -- Create a horizontal pod autoscaler for the Open API server.
     enabled: false
-    # -- Minimum number of replicas for the openAPI server.
+    # -- Minimum number of replicas for the Open API server.
     min: 1
-    # -- Maximum number of replicas for the openAPI server.
+    # -- Maximum number of replicas for the Open API server.
     max: 2
     # -- Scaling metrics
     metrics:
@@ -219,7 +219,7 @@ openApi:
         target:
           type: Utilization
           averageUtilization: 75
-  # -- Resources for the openAPI server.
+  # -- Resources for the Open API server.
   resources:
     limits:
       cpu: 256m
@@ -227,13 +227,15 @@ openApi:
     requests:
       cpu: 100m
       memory: 100Mi
-  # -- Node Selector for the openAPI server.
+  # -- Node Selector for the Open API server.
   nodeSelector: {}
-  # -- Tolerations for the openApi server.
+  # -- Tolerations for the Open API server.
   tolerations: []
   ingress:
+    # -- Enable the Open API ingress
     enabled: true
   service:
+    # -- Service type for Open API server
     type:
 
 dbMigration:


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
