### PR TITLE
[stable/insights-admission] Allow custom annotations on the webhook config

### DIFF
--- a/stable/insights-admission/Chart.yaml
+++ b/stable/insights-admission/Chart.yaml
@@ -2,10 +2,9 @@ apiVersion: v2
 name: insights-admission
 description: A Validating Webhook Admission Controller that utilizes Fairwinds Insights.
 type: application
-version: 1.1.3
+version: 1.2.0
 appVersion: "1.3"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-admission/icon.png
 maintainers:
 - name: rbren
 - name: makoscafee
-- name: baderbuddy

--- a/stable/insights-admission/README.md
+++ b/stable/insights-admission/README.md
@@ -55,6 +55,7 @@ rules:
 | webhookConfig.matchPolicy | string | `"Exact"` | matchPolicy for the ValidatingWebhookConfiguration |
 | webhookConfig.timeoutSeconds | int | `30` | number of seconds to wait before failing the admission request (max is 30) |
 | webhookConfig.namespaceSelector | object | `{"matchExpressions":[{"key":"control-plane","operator":"DoesNotExist"}]}` | namespaceSelector for the ValidatingWebhookConfiguration |
+| webhookConfig.annotations | object | `{}` | Annotations to add to the ValidatingWebhookConfiguration |
 | webhookConfig.objectSelector | object | `{}` | objectSelector for the ValidatingWebhookConfiguration |
 | webhookConfig.rules | list | `[]` | An array of additional rules for the ValidatingWebhookConfiguration. Each requires a set of apiGroups, apiVersions, operations, resources, and a scope. Rules specified here may also be granted to the Insights OPA plugin, see also the insights-agent chart values for opa. |
 | webhookConfig.defaultRules | list | `[{"apiGroups":["apps"],"apiVersions":["v1","v1beta1","v1beta2"],"operations":["CREATE","UPDATE"],"resources":["daemonsets","deployments","statefulsets"],"scope":"Namespaced"},{"apiGroups":["batch"],"apiVersions":["v1","v1beta1"],"operations":["CREATE","UPDATE"],"resources":["jobs","cronjobs"],"scope":"Namespaced"},{"apiGroups":[""],"apiVersions":["v1"],"operations":["CREATE","UPDATE"],"resources":["pods","replicationcontrollers"],"scope":"Namespaced"}]` | An array of rules for commons types for the ValidatingWebhookConfiguration |

--- a/stable/insights-admission/ci/test-values.yaml
+++ b/stable/insights-admission/ci/test-values.yaml
@@ -18,3 +18,6 @@ serviceAccount:
       verbs:
       - get
       - list
+webhookConfig:
+  annotations:
+    "test-annotation": "test-annotation-value"

--- a/stable/insights-admission/templates/configuration.yaml
+++ b/stable/insights-admission/templates/configuration.yaml
@@ -10,6 +10,9 @@ metadata:
     {{- if not .Values.secretName }}
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "insights-admission.fullname" . }}-cert
     {{- end }}
+    {{- with .Values.webhookConfig.annotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 webhooks:
 - admissionReviewVersions:
 {{- if .Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1" }}

--- a/stable/insights-admission/values.yaml
+++ b/stable/insights-admission/values.yaml
@@ -47,6 +47,8 @@ webhookConfig:
     matchExpressions:
     - key: control-plane
       operator: DoesNotExist
+  # -- Annotations to add to the ValidatingWebhookConfiguration
+  annotations: {}
   # webhookConfig.objectSelector -- objectSelector for the ValidatingWebhookConfiguration
   objectSelector: {}
   # webhookConfig.rules -- An array of additional rules for the ValidatingWebhookConfiguration. Each requires a set of apiGroups, apiVersions, operations, resources, and a scope.


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_
I want to provide my own certificate and annotate the webhook config manually

**Changes**
Changes proposed in this pull request:

* Add a webhookConfig.annotations to the values and use it in the webhookConfig template

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.