### PR TITLE
[stable/polaris] add mutation support to polaris webhook

### DIFF
--- a/stable/polaris/Chart.yaml
+++ b/stable/polaris/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Validation of best practices in your Kubernetes clusters
 name: polaris
-version: 5.1.0
-appVersion: "5.1"
+version: 5.2.0
+appVersion: "7.0"
 icon: https://raw.githubusercontent.com/FairwindsOps/polaris/master/pkg/dashboard/assets/favicon-32x32.png
 maintainers:
   - name: rbren

--- a/stable/polaris/Chart.yaml
+++ b/stable/polaris/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Validation of best practices in your Kubernetes clusters
 name: polaris
-version: 5.2.0
+version: 5.3.0
 appVersion: "7.0"
 icon: https://raw.githubusercontent.com/FairwindsOps/polaris/master/pkg/dashboard/assets/favicon-32x32.png
 maintainers:

--- a/stable/polaris/README.md
+++ b/stable/polaris/README.md
@@ -65,7 +65,9 @@ the 0.10.0 version of this chart will only work on kubernetes 1.14.0+
 | dashboard.disallowExemptions | bool | `false` | Disallow any exemption |
 | dashboard.disallowConfigExemptions | bool | `false` | Disallow exemptions that are configured in the config file |
 | dashboard.disallowAnnotationExemptions | bool | `false` | Disallow exemptions that are configured via annotations |
-| webhook.enable | bool | `false` | Whether to run the Validating Webhook |
+| webhook.enable | bool | `false` | Whether to run the webhook |
+| webhook.validate | bool | `true` | Enables the Validating Webhook, to reject resources with issues |
+| webhook.mutate | bool | `false` | Enables the Mutating Webhook, to modify resources with issues |
 | webhook.replicas | int | `2` | Number of replicas |
 | webhook.nodeSelector | object | `{}` | Webhook pod nodeSelector |
 | webhook.tolerations | list | `[]` | Webhook pod tolerations |

--- a/stable/polaris/templates/webhook.deployment.yaml
+++ b/stable/polaris/templates/webhook.deployment.yaml
@@ -46,6 +46,8 @@ spec:
             {{- if .Values.webhook.disallowAnnotationExemptions }}
             - --disallow-annotation-exemptions
             {{- end }}
+            - --validate={{ .Values.webhook.validate }}
+            - --mutate={{ .Values.webhook.mutate }}
           image: '{{.Values.image.repository}}:{{.Values.image.tag | default .Chart.AppVersion }}'
           imagePullPolicy: '{{.Values.image.pullPolicy}}'
           ports:

--- a/stable/polaris/values.yaml
+++ b/stable/polaris/values.yaml
@@ -77,8 +77,12 @@ dashboard:
   disallowAnnotationExemptions: false
 
 webhook:
-  # webhook.enable -- Whether to run the Validating Webhook
+  # webhook.enable -- Whether to run the webhook
   enable: false
+  # webhook.validate -- Enables the Validating Webhook, to reject resources with issues
+  validate: true
+  # webhook.mutate -- Enables the Mutating Webhook, to modify resources with issues
+  mutate: false
   # webhook.replicas -- Number of replicas
   replicas: 2
   # webhook.nodeSelector -- Webhook pod nodeSelector


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_
Adds mutation support to the Polaris chart

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
