### PR TITLE
[stable/aws-iam-authenticator] Update to 0.5.9

### DIFF
--- a/stable/aws-iam-authenticator/Chart.yaml
+++ b/stable/aws-iam-authenticator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
-appVersion: v0.5.3
+appVersion: v0.5.9
 description: Install and configure aws-iam-authenticator on your cluster.
 name: aws-iam-authenticator
-version: v1.7.0
+version: v1.7.1
 maintainers:
   - name: sudermanjr

--- a/stable/aws-iam-authenticator/README.md
+++ b/stable/aws-iam-authenticator/README.md
@@ -11,7 +11,7 @@ In this version, due to updates for Kubernetes 1.16+, the labelSelector for the 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | image.repository | string | `"602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-iam-authenticator"` |  |
-| image.tag | string | `"v0.5.3-scratch"` |  |
+| image.tag | string | `"v0.5.9-scratch"` |  |
 | volumes.output.mountPath | string | `"/etc/kubernetes/aws-iam-authenticator/"` |  |
 | volumes.output.hostPath | string | `"/srv/kubernetes/kube-apiserver/aws-iam-authenticator/"` |  |
 | volumes.state.mountPath | string | `"/var/aws-iam-authenticator/"` |  |

--- a/stable/aws-iam-authenticator/values.yaml
+++ b/stable/aws-iam-authenticator/values.yaml
@@ -2,7 +2,7 @@ image:
   # The image repository to use
   repository: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-iam-authenticator
   # The image tag to use
-  tag: v0.5.3-scratch
+  tag: v0.5.9-scratch
 
 volumes:
   output:


### PR DESCRIPTION
Mitigates CVE-2022-2385 https://github.com/kubernetes-sigs/aws-iam-authenticator/issues/472

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.