### PR TITLE
[stable/insights-agent] FWI-2284 - Agent 2.4.4 fails install on goldilocks

### DIFF
--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.4.5
+version: 2.4.6
 appVersion: 8.6.0
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -115,8 +115,8 @@ goldilocks:
         cpu: 25m
         memory: 262Mi
       limits:
-        cpu:
-        memory:
+        cpu: ""
+        memory: ""
   dashboard:
     enabled: false
   resources:

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -115,8 +115,8 @@ goldilocks:
         cpu: 25m
         memory: 262Mi
       limits:
-        cpu: ""
-        memory: ""
+        cpu: null
+        memory: null
   dashboard:
     enabled: false
   resources:


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [ ] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [ ] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.


[Internal Ticket FWI-2284](https://fairwinds.myjetbrains.com/youtrack/issue/FWI-2284)