### PR TITLE
[stable/insights-agent] Add back resources limits for goldilocks

### DIFF
--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.4.6
-appVersion: 8.6.0
+version: 2.4.7
+appVersion: 9.0.1
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:
   - name: rbren

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -115,8 +115,8 @@ goldilocks:
         cpu: 25m
         memory: 262Mi
       limits:
-        cpu: null
-        memory: null
+        cpu: 250m
+        memory: 545Mi
   dashboard:
     enabled: false
   resources:


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [ ] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [ ] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
