### PR TITLE
[stable/polaris] Update cert-manager apiVersions

### DIFF
--- a/stable/polaris/Chart.yaml
+++ b/stable/polaris/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Validation of best practices in your Kubernetes clusters
 name: polaris
-version: 5.3.0
+version: 5.3.1
 appVersion: "7.0"
 icon: https://raw.githubusercontent.com/FairwindsOps/polaris/master/pkg/dashboard/assets/favicon-32x32.png
 maintainers:

--- a/stable/polaris/templates/webhook.cert.yaml
+++ b/stable/polaris/templates/webhook.cert.yaml
@@ -1,5 +1,11 @@
 {{- if and .Values.webhook.enable (not .Values.webhook.secretName) -}}
+{{- if .Capabilities.APIVersions.Has "cert-manager.io/v1" }}
+apiVersion: cert-manager.io/v1
+{{- else if .Capabilities.APIVersions.Has "cert-manager.io/v1alpha2" }}
 apiVersion: cert-manager.io/v1alpha2
+{{- else }}
+apiVersion: cert-manager.io/v1alpha1
+{{- end }}
 kind: Certificate
 metadata:
   name: {{ include "polaris.fullname" . }}-cert
@@ -20,7 +26,13 @@ spec:
     name: {{ include "polaris.fullname" . }}-selfsigned
   secretName: {{ include "polaris.fullname" . }}
 ---
+{{- if .Capabilities.APIVersions.Has "cert-manager.io/v1" }}
+apiVersion: cert-manager.io/v1
+{{- else if .Capabilities.APIVersions.Has "cert-manager.io/v1alpha2" }}
 apiVersion: cert-manager.io/v1alpha2
+{{- else }}
+apiVersion: cert-manager.io/v1alpha1
+{{- end }}
 kind: Issuer
 metadata:
   name: {{ include "polaris.fullname" . }}-selfsigned


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

cert-manager API versions were lagging behind

Fixes #

**Changes**
Changes proposed in this pull request:

* Detect and set the cert-manager API version
*

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [ ] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
