### PR TITLE
[stable/polaris] consolidate mutation values

### DIFF
--- a/stable/polaris/Chart.yaml
+++ b/stable/polaris/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Validation of best practices in your Kubernetes clusters
 name: polaris
-version: 5.4.0
+version: 5.4.1
 appVersion: "7.0"
 icon: https://raw.githubusercontent.com/FairwindsOps/polaris/master/pkg/dashboard/assets/favicon-32x32.png
 maintainers:

--- a/stable/polaris/README.md
+++ b/stable/polaris/README.md
@@ -87,7 +87,6 @@ the 0.10.0 version of this chart will only work on kubernetes 1.14.0+
 | webhook.disallowExemptions | bool | `false` | Disallow any exemption |
 | webhook.disallowConfigExemptions | bool | `false` | Disallow exemptions that are configured in the config file |
 | webhook.disallowAnnotationExemptions | bool | `false` | Disallow exemptions that are configured via annotations |
-| webhook.enableMutation | bool | `false` | Whether to run the Mutation Webhook |
 | audit.enable | bool | `false` | Runs a one-time audit. This is used internally at Fairwinds, and may not be useful for others. |
 | audit.cleanup | bool | `false` | Whether to delete the namespace once the audit is finished. |
 | audit.outputURL | string | `""` | A URL which will receive a POST request with audit results. |

--- a/stable/polaris/ci/test-values.yaml
+++ b/stable/polaris/ci/test-values.yaml
@@ -6,4 +6,4 @@ dashboard:
     - foo.com
 webhook:
   enabled: true
-  enableMutation: true
+  mutate: true

--- a/stable/polaris/templates/mutate-webhook.configuration.yaml
+++ b/stable/polaris/templates/mutate-webhook.configuration.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.webhook.enable .Values.webhook.enableMutation -}}
+{{- if and .Values.webhook.enable .Values.webhook.mutate -}}
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:

--- a/stable/polaris/templates/validate-webhook.configuration.yaml
+++ b/stable/polaris/templates/validate-webhook.configuration.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.webhook.enable -}}
+{{- if and .Values.webhook.enable .Values.webhook.validate -}}
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:

--- a/stable/polaris/values.yaml
+++ b/stable/polaris/values.yaml
@@ -167,8 +167,6 @@ webhook:
   disallowConfigExemptions: false
   # webhook.disallowAnnotationExemptions -- Disallow exemptions that are configured via annotations
   disallowAnnotationExemptions: false
-  # webhook.enableMutation -- Whether to run the Mutation Webhook
-  enableMutation: false
 
 audit:
   # audit.enable -- Runs a one-time audit. This is used internally at Fairwinds, and may not be useful for others.


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_
Consolidates mutation values for Polaris

Fixes #

**Changes**
Changes proposed in this pull request:
* remove `webhook.enableMutations` in favor of `webhook.mutate`
* check `webhook.validate` for the validating webhook config

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
