### PR TITLE
[stable/goldilocks] Version Bumps, probe fix when base path set

### DIFF
--- a/stable/goldilocks/Chart.yaml
+++ b/stable/goldilocks/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: "v4.3.3"
-version: 6.1.4
+appVersion: "v4.3.4"
+version: 6.1.5
 description: |
   A Helm chart for running Fairwinds Goldilocks. See https://github.com/FairwindsOps/goldilocks
 name: goldilocks

--- a/stable/goldilocks/templates/_helpers.tpl
+++ b/stable/goldilocks/templates/_helpers.tpl
@@ -30,3 +30,14 @@ Create chart name and version as used by the chart label.
 {{- define "goldilocks.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Make sure base path doesn't end in /
+*/}}
+{{- define "goldilocks.basePath" -}}
+{{- if .Values.dashboard.basePath -}}
+{{- printf "/%s" (.Values.dashboard.basePath | trimSuffix "/" | trimPrefix "/") -}}
+{{- else -}}
+{{- printf "%s" "" -}}
+{{- end -}}
+{{- end -}}

--- a/stable/goldilocks/templates/_helpers.tpl
+++ b/stable/goldilocks/templates/_helpers.tpl
@@ -30,14 +30,3 @@ Create chart name and version as used by the chart label.
 {{- define "goldilocks.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
-
-{{/*
-Make sure base path doesn't end in /
-*/}}
-{{- define "goldilocks.basePath" -}}
-{{- if .Values.dashboard.basePath -}}
-{{- printf "/%s" (.Values.dashboard.basePath | trimSuffix "/" | trimPrefix "/") -}}
-{{- else -}}
-{{- printf "%s" "" -}}
-{{- end -}}
-{{- end -}}

--- a/stable/goldilocks/templates/dashboard-deployment.yaml
+++ b/stable/goldilocks/templates/dashboard-deployment.yaml
@@ -74,11 +74,11 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: {{ include "goldilocks.basePath" . }}/health
+              path: {{ trimSuffix "/" .Values.dashboard.basePath }}/health
               port: http
           readinessProbe:
             httpGet:
-              path: {{ include "goldilocks.basePath" . }}/health
+              path: {{ trimSuffix "/" .Values.dashboard.basePath }}/health
               port: http
           resources:
             {{- toYaml .Values.dashboard.resources | nindent 12 }}

--- a/stable/goldilocks/templates/dashboard-deployment.yaml
+++ b/stable/goldilocks/templates/dashboard-deployment.yaml
@@ -74,11 +74,11 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: {{.Values.dashboard.basePath | default "/" }}health
+              path: {{ include "goldilocks.basePath" . }}/health
               port: http
           readinessProbe:
             httpGet:
-              path: {{.Values.dashboard.basePath | default "/" }}health
+              path: {{ include "goldilocks.basePath" . }}/health
               port: http
           resources:
             {{- toYaml .Values.dashboard.resources | nindent 12 }}


### PR DESCRIPTION
**Why This PR?**
1. The base path functionality for [#185](https://github.com/FairwindsOps/goldilocks/issues/185) hasn't been released yet, this assumed it will go out in 4.3.4, so this shouldn't be merged until then
2. The path to the probe was incorrect (my bad), this fixes previous PR #828 

**Changes**
Changes proposed in this pull request:
*Add logic to ensure the base path has correct formatting for health probe


**Checklist:**

* [ X ] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [ X ] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [ X ] Any new values are backwards compatible and/or have sensible default.
* [ X ] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
