### PR TITLE
[stable/aws-iam-authenticator] use the user/group we expect

### DIFF
--- a/stable/aws-iam-authenticator/Chart.yaml
+++ b/stable/aws-iam-authenticator/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: v0.5.9
 description: Install and configure aws-iam-authenticator on your cluster.
 name: aws-iam-authenticator
-version: v1.7.2
+version: v1.7.3
 maintainers:
   - name: sudermanjr

--- a/stable/aws-iam-authenticator/README.md
+++ b/stable/aws-iam-authenticator/README.md
@@ -12,6 +12,7 @@ In this version, due to updates for Kubernetes 1.16+, the labelSelector for the 
 |-----|------|---------|-------------|
 | image.repository | string | `"602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-iam-authenticator"` |  |
 | image.tag | string | `"v0.5.9"` |  |
+| priorityClassName | string | `"system-cluster-critical"` |  |
 | volumes.output.mountPath | string | `"/etc/kubernetes/aws-iam-authenticator/"` |  |
 | volumes.output.hostPath | string | `"/srv/kubernetes/kube-apiserver/aws-iam-authenticator/"` |  |
 | volumes.state.mountPath | string | `"/var/aws-iam-authenticator/"` |  |

--- a/stable/aws-iam-authenticator/templates/daemonset.yaml
+++ b/stable/aws-iam-authenticator/templates/daemonset.yaml
@@ -11,6 +11,9 @@ metadata:
   annotations:
     checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
 spec:
+  {{- if .Values.priorityClassName }}
+  priorityClassName: {{ .Values.priorityClassName }}
+  {{- end }}
   updateStrategy:
     type: RollingUpdate
   selector:
@@ -21,7 +24,6 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
-        scheduler.alpha.kubernetes.io/critical-pod: ""
       labels:
         app.kubernetes.io/name: {{ include "aws-iam-authenticator.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}

--- a/stable/aws-iam-authenticator/templates/daemonset.yaml
+++ b/stable/aws-iam-authenticator/templates/daemonset.yaml
@@ -11,9 +11,6 @@ metadata:
   annotations:
     checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
 spec:
-  {{- if .Values.priorityClassName }}
-  priorityClassName: {{ .Values.priorityClassName }}
-  {{- end }}
   updateStrategy:
     type: RollingUpdate
   selector:

--- a/stable/aws-iam-authenticator/templates/daemonset.yaml
+++ b/stable/aws-iam-authenticator/templates/daemonset.yaml
@@ -30,7 +30,9 @@ spec:
     spec:
       # run on the host network (don't depend on CNI)
       hostNetwork: true
-
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/stable/aws-iam-authenticator/templates/daemonset.yaml
+++ b/stable/aws-iam-authenticator/templates/daemonset.yaml
@@ -39,6 +39,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 
+      securityContext:
+        runAsUser: 10000
+        runAsGroup: 10000
+        fsGroup: 10000
       # run `aws-iam-authenticator server` with three volumes
       # - config (mounted from the ConfigMap at /etc/aws-iam-authenticator/config.yaml)
       # - state (persisted TLS certificate and keys, mounted from the host)

--- a/stable/aws-iam-authenticator/values.yaml
+++ b/stable/aws-iam-authenticator/values.yaml
@@ -4,6 +4,9 @@ image:
   # The image tag to use
   tag: v0.5.9
 
+## -- A priority class to assign to the pods
+priorityClassName: "system-cluster-critical"
+
 volumes:
   output:
     mountPath: /etc/kubernetes/aws-iam-authenticator/


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Align this with the old way we used to run it so we don't break everything when upgrading.


**Changes**
Changes proposed in this pull request:

* Add a security context to set the user and group

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.