### PR TITLE
[stable/insights-agent] FWI-2286- Remove resource limits for kube-state-metrics

### DIFF
--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.5.0
+version: 2.5.1
 appVersion: 9.2.1
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -119,13 +119,13 @@ goldilocks:
         memory: 545Mi
   dashboard:
     enabled: false
-  resources:
-    requests:
-      cpu: 100m
-      memory: 128Mi
-    limits:
-      cpu: 250m
-      memory: 512Mi
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 250m
+        memory: 512Mi
 
 opa:
   enabled: false
@@ -326,9 +326,6 @@ prometheus:
     image:
       pullPolicy: Always
     resources:
-      limits:
-        cpu: 100m
-        memory: 64Mi
       requests:
         cpu: 10m
         memory: 32Mi


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
