### PR TITLE
[stable/fairwinds-insights] Add openapi hpa template

### DIFF
--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "9.3.1"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 0.5.37
+version: 0.5.38
 maintainers:
 - name: rbren
 - name: makoscafee

--- a/stable/fairwinds-insights/README.md
+++ b/stable/fairwinds-insights/README.md
@@ -77,8 +77,8 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | openApi.pdb.enabled | bool | `false` | Create a pod disruption budget for the Open API server. |
 | openApi.pdb.minReplicas | int | `1` | How many replicas should always exist for the Open API server. |
 | openApi.hpa.enabled | bool | `false` | Create a horizontal pod autoscaler for the Open API server. |
-| openApi.hpa.min | int | `1` | Minimum number of replicas for the Open API server. |
-| openApi.hpa.max | int | `2` | Maximum number of replicas for the Open API server. |
+| openApi.hpa.min | int | `2` | Minimum number of replicas for the Open API server. |
+| openApi.hpa.max | int | `3` | Maximum number of replicas for the Open API server. |
 | openApi.hpa.metrics | list | `[{"resource":{"name":"cpu","target":{"averageUtilization":75,"type":"Utilization"}},"type":"Resource"},{"resource":{"name":"memory","target":{"averageUtilization":75,"type":"Utilization"}},"type":"Resource"}]` | Scaling metrics |
 | openApi.resources | object | `{"limits":{"cpu":"256m","memory":"256Mi"},"requests":{"cpu":"100m","memory":"100Mi"}}` | Resources for the Open API server. |
 | openApi.nodeSelector | object | `{}` | Node Selector for the Open API server. |

--- a/stable/fairwinds-insights/templates/hpa-open-api.yaml
+++ b/stable/fairwinds-insights/templates/hpa-open-api.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.openApi.hpa.enabled }}
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "fairwinds-insights.fullname" . }}-open-api-hpa
+  labels:
+    {{- include "fairwinds-insights.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: open-api
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "fairwinds-insights.fullname" . }}-open-api
+  minReplicas: {{ .Values.openApi.hpa.min }}
+  maxReplicas: {{ .Values.openApi.hpa.max }}
+  metrics:
+  {{- toYaml .Values.openApi.hpa.metrics | nindent 4 }}
+{{- end }}

--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -208,9 +208,9 @@ openApi:
     # -- Create a horizontal pod autoscaler for the Open API server.
     enabled: false
     # -- Minimum number of replicas for the Open API server.
-    min: 1
+    min: 2
     # -- Maximum number of replicas for the Open API server.
-    max: 2
+    max: 3
     # -- Scaling metrics
     metrics:
     - type: Resource


### PR DESCRIPTION
**Why This PR?**
Adds an hpa template so hpa's are created when it is enabled in the values file.

Fixes #

**Changes**
Changes proposed in this pull request:

*adds open-api hpa
*sets open-api default hpa values to values that won't cause pdb to block rolling node updates 

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
