### PR TITLE
[stable/insights-agent] increase kube-state-metrics resources

### DIFF
--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.5.1
+version: 2.5.2
 appVersion: 9.2.1
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -328,11 +328,11 @@ prometheus:
       pullPolicy: Always
     resources:
       limits:
+        cpu: 1000m
+        memory: 512Mi
+      requests:
         cpu: 100m
         memory: 64Mi
-      requests:
-        cpu: 10m
-        memory: 32Mi
     containerSecurityContext:
       allowPrivilegeEscalation: false
       readOnlyRootFilesystem: true


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Some folks getting OOMed here

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [ ] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [ ] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
