### PR TITLE
[stable/polaris] Add ability to add extra containers

### DIFF
--- a/stable/polaris/Chart.yaml
+++ b/stable/polaris/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Validation of best practices in your Kubernetes clusters
 name: polaris
-version: 5.4.1
+version: 5.4.2
 appVersion: "7.0"
 icon: https://raw.githubusercontent.com/FairwindsOps/polaris/master/pkg/dashboard/assets/favicon-32x32.png
 maintainers:

--- a/stable/polaris/README.md
+++ b/stable/polaris/README.md
@@ -35,58 +35,60 @@ the 0.10.0 version of this chart will only work on kubernetes 1.14.0+
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| audit.cleanup | bool | `false` | Whether to delete the namespace once the audit is finished. |
+| audit.enable | bool | `false` | Runs a one-time audit. This is used internally at Fairwinds, and may not be useful for others. |
+| audit.outputURL | string | `""` | A URL which will receive a POST request with audit results. |
 | config | string | `nil` | The [polaris configuration](https://github.com/FairwindsOps/polaris#configuration). If not provided then the [default](https://github.com/FairwindsOps/polaris/blob/master/examples/config.yaml) config from Polaris is used. |
-| image.repository | string | `"quay.io/fairwinds/polaris"` | Image repo |
-| image.tag | string | `""` | The Polaris Image tag to use. Defaults to the Chart's AppVersion |
+| dashboard.affinity | object | `{}` | Dashboard pods affinity |
+| dashboard.basePath | string | `nil` | Path on which the dashboard is served. Defaults to `/` |
+| dashboard.disallowAnnotationExemptions | bool | `false` | Disallow exemptions that are configured via annotations |
+| dashboard.disallowConfigExemptions | bool | `false` | Disallow exemptions that are configured in the config file |
+| dashboard.disallowExemptions | bool | `false` | Disallow any exemption |
+| dashboard.enable | bool | `true` | Whether to run the dashboard. |
+| dashboard.extraContainers | list | `[]` | allows injecting additional containers. |
+| dashboard.ingress.annotations | object | `{}` | Web ingress annotations |
+| dashboard.ingress.enabled | bool | `false` | Whether to enable ingress to the dashboard |
+| dashboard.ingress.hosts | list | `[]` | Web ingress hostnames |
+| dashboard.ingress.ingressClassName | string | `nil` | From Kubernetes 1.18+ this field is supported in case your ingress controller supports it. When set, you do not need to add the ingress class as annotation. |
+| dashboard.ingress.tls | list | `[]` | Ingress TLS configuration |
+| dashboard.listeningAddress | string | `nil` | Dashboard listerning address. |
+| dashboard.nodeSelector | object | `{}` | Dashboard pod nodeSelector |
+| dashboard.podAdditionalLabels | object | `{}` | Custom additional labels on dashboard pods. |
+| dashboard.port | int | `8080` | Port that the dashboard will run from. |
+| dashboard.priorityClassName | string | `nil` | Priority Class name to be used in deployment if provided. |
+| dashboard.replicas | int | `2` | Number of replicas to run. |
+| dashboard.resources | object | `{"limits":{"cpu":"150m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | Requests and limits for the dashboard |
+| dashboard.service.annotations | object | `{}` | Service annotations |
+| dashboard.service.targetPort | int | `8080` | Service targetport |
+| dashboard.service.type | string | `"ClusterIP"` | Service Type |
+| dashboard.tolerations | list | `[]` | Dashboard pod tolerations |
 | image.pullPolicy | string | `"Always"` | Image pull policy |
 | image.pullSecrets | list | `[]` | Image pull secrets |
+| image.repository | string | `"quay.io/fairwinds/polaris"` | Image repo |
+| image.tag | string | `""` | The Polaris Image tag to use. Defaults to the Chart's AppVersion |
 | rbac.enabled | bool | `true` | Whether RBAC resources (ClusterRole, ClusterRolebinding) should be created |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `nil` | The name of the service account to use. |
 | templateOnly | bool | `false` | Outputs Namespace names, used with `helm template` |
-| dashboard.basePath | string | `nil` | Path on which the dashboard is served. Defaults to `/` |
-| dashboard.enable | bool | `true` | Whether to run the dashboard. |
-| dashboard.port | int | `8080` | Port that the dashboard will run from. |
-| dashboard.listeningAddress | string | `nil` | Dashboard listerning address. |
-| dashboard.replicas | int | `2` | Number of replicas to run. |
-| dashboard.podAdditionalLabels | object | `{}` | Custom additional labels on dashboard pods. |
-| dashboard.resources | object | `{"limits":{"cpu":"150m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | Requests and limits for the dashboard |
-| dashboard.service.type | string | `"ClusterIP"` | Service Type |
-| dashboard.service.annotations | object | `{}` | Service annotations |
-| dashboard.nodeSelector | object | `{}` | Dashboard pod nodeSelector |
-| dashboard.tolerations | list | `[]` | Dashboard pod tolerations |
-| dashboard.affinity | object | `{}` | Dashboard pods affinity |
-| dashboard.ingress.enabled | bool | `false` | Whether to enable ingress to the dashboard |
-| dashboard.ingress.ingressClassName | string | `nil` | From Kubernetes 1.18+ this field is supported in case your ingress controller supports it. When set, you do not need to add the ingress class as annotation. |
-| dashboard.ingress.hosts | list | `[]` | Web ingress hostnames |
-| dashboard.ingress.annotations | object | `{}` | Web ingress annotations |
-| dashboard.ingress.tls | list | `[]` | Ingress TLS configuration |
-| dashboard.priorityClassName | string | `nil` | Priority Class name to be used in deployment if provided. |
-| dashboard.disallowExemptions | bool | `false` | Disallow any exemption |
-| dashboard.disallowConfigExemptions | bool | `false` | Disallow exemptions that are configured in the config file |
-| dashboard.disallowAnnotationExemptions | bool | `false` | Disallow exemptions that are configured via annotations |
-| webhook.enable | bool | `false` | Whether to run the webhook |
-| webhook.validate | bool | `true` | Enables the Validating Webhook, to reject resources with issues |
-| webhook.mutate | bool | `false` | Enables the Mutating Webhook, to modify resources with issues |
-| webhook.replicas | int | `2` | Number of replicas |
-| webhook.nodeSelector | object | `{}` | Webhook pod nodeSelector |
-| webhook.tolerations | list | `[]` | Webhook pod tolerations |
 | webhook.affinity | object | `{}` | Webhook pods affinity |
 | webhook.caBundle | string | `nil` | CA Bundle to use for Validating Webhook instead of cert-manager |
-| webhook.secretName | string | `nil` | Name of the secret containing a TLS certificate to use if cert-manager is not used. |
+| webhook.defaultRules | list | `[{"apiGroups":["apps"],"apiVersions":["v1","v1beta1","v1beta2"],"operations":["CREATE","UPDATE"],"resources":["daemonsets","deployments","statefulsets"],"scope":"Namespaced"},{"apiGroups":["batch"],"apiVersions":["v1","v1beta1"],"operations":["CREATE","UPDATE"],"resources":["jobs","cronjobs"],"scope":"Namespaced"},{"apiGroups":[""],"apiVersions":["v1"],"operations":["CREATE","UPDATE"],"resources":["pods","replicationcontrollers"],"scope":"Namespaced"}]` | An array of rules for common types for the ValidatingWebhookConfiguration |
+| webhook.disallowAnnotationExemptions | bool | `false` | Disallow exemptions that are configured via annotations |
+| webhook.disallowConfigExemptions | bool | `false` | Disallow exemptions that are configured in the config file |
+| webhook.disallowExemptions | bool | `false` | Disallow any exemption |
+| webhook.enable | bool | `false` | Whether to run the webhook |
 | webhook.failurePolicy | string | `"Fail"` | failurePolicy for the ValidatingWebhookConfiguration |
 | webhook.matchPolicy | string | `"Exact"` | matchPolicy for the ValidatingWebhookConfiguration |
-| webhook.namespaceSelector | object | `{"matchExpressions":[{"key":"control-plane","operator":"DoesNotExist"}]}` | namespaceSelector for the ValidatingWebhookConfiguration |
-| webhook.objectSelector | object | `{}` | objectSelector for the ValidatingWebhookConfiguration |
-| webhook.rules | list | `[]` | An array of additional rules for the ValidatingWebhookConfiguration. Each requires a set of apiGroups, apiVersions, operations, resources, and a scope. |
+| webhook.mutate | bool | `false` | Enables the Mutating Webhook, to modify resources with issues |
 | webhook.mutatingRules | list | `[]` | An array of additional rules for the MutatingWebhookConfiguration. Each requires a set of apiGroups, apiVersions, operations, resources, and a scope. |
-| webhook.defaultRules | list | `[{"apiGroups":["apps"],"apiVersions":["v1","v1beta1","v1beta2"],"operations":["CREATE","UPDATE"],"resources":["daemonsets","deployments","statefulsets"],"scope":"Namespaced"},{"apiGroups":["batch"],"apiVersions":["v1","v1beta1"],"operations":["CREATE","UPDATE"],"resources":["jobs","cronjobs"],"scope":"Namespaced"},{"apiGroups":[""],"apiVersions":["v1"],"operations":["CREATE","UPDATE"],"resources":["pods","replicationcontrollers"],"scope":"Namespaced"}]` | An array of rules for common types for the ValidatingWebhookConfiguration |
+| webhook.namespaceSelector | object | `{"matchExpressions":[{"key":"control-plane","operator":"DoesNotExist"}]}` | namespaceSelector for the ValidatingWebhookConfiguration |
+| webhook.nodeSelector | object | `{}` | Webhook pod nodeSelector |
+| webhook.objectSelector | object | `{}` | objectSelector for the ValidatingWebhookConfiguration |
 | webhook.podAdditionalLabels | object | `{}` | Custom additional labels on webhook pods. |
-| webhook.resources | object | `{"limits":{"cpu":"100m","memory":"128Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | Requests and limits for the webhook. |
 | webhook.priorityClassName | string | `nil` | Priority Class name to be used in deployment if provided. |
-| webhook.disallowExemptions | bool | `false` | Disallow any exemption |
-| webhook.disallowConfigExemptions | bool | `false` | Disallow exemptions that are configured in the config file |
-| webhook.disallowAnnotationExemptions | bool | `false` | Disallow exemptions that are configured via annotations |
-| audit.enable | bool | `false` | Runs a one-time audit. This is used internally at Fairwinds, and may not be useful for others. |
-| audit.cleanup | bool | `false` | Whether to delete the namespace once the audit is finished. |
-| audit.outputURL | string | `""` | A URL which will receive a POST request with audit results. |
+| webhook.replicas | int | `2` | Number of replicas |
+| webhook.resources | object | `{"limits":{"cpu":"100m","memory":"128Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | Requests and limits for the webhook. |
+| webhook.rules | list | `[]` | An array of additional rules for the ValidatingWebhookConfiguration. Each requires a set of apiGroups, apiVersions, operations, resources, and a scope. |
+| webhook.secretName | string | `nil` | Name of the secret containing a TLS certificate to use if cert-manager is not used. |
+| webhook.tolerations | list | `[]` | Webhook pod tolerations |
+| webhook.validate | bool | `true` | Enables the Validating Webhook, to reject resources with issues |

--- a/stable/polaris/README.md
+++ b/stable/polaris/README.md
@@ -35,60 +35,60 @@ the 0.10.0 version of this chart will only work on kubernetes 1.14.0+
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| audit.cleanup | bool | `false` | Whether to delete the namespace once the audit is finished. |
-| audit.enable | bool | `false` | Runs a one-time audit. This is used internally at Fairwinds, and may not be useful for others. |
-| audit.outputURL | string | `""` | A URL which will receive a POST request with audit results. |
 | config | string | `nil` | The [polaris configuration](https://github.com/FairwindsOps/polaris#configuration). If not provided then the [default](https://github.com/FairwindsOps/polaris/blob/master/examples/config.yaml) config from Polaris is used. |
-| dashboard.affinity | object | `{}` | Dashboard pods affinity |
-| dashboard.basePath | string | `nil` | Path on which the dashboard is served. Defaults to `/` |
-| dashboard.disallowAnnotationExemptions | bool | `false` | Disallow exemptions that are configured via annotations |
-| dashboard.disallowConfigExemptions | bool | `false` | Disallow exemptions that are configured in the config file |
-| dashboard.disallowExemptions | bool | `false` | Disallow any exemption |
-| dashboard.enable | bool | `true` | Whether to run the dashboard. |
-| dashboard.extraContainers | list | `[]` | allows injecting additional containers. |
-| dashboard.ingress.annotations | object | `{}` | Web ingress annotations |
-| dashboard.ingress.enabled | bool | `false` | Whether to enable ingress to the dashboard |
-| dashboard.ingress.hosts | list | `[]` | Web ingress hostnames |
-| dashboard.ingress.ingressClassName | string | `nil` | From Kubernetes 1.18+ this field is supported in case your ingress controller supports it. When set, you do not need to add the ingress class as annotation. |
-| dashboard.ingress.tls | list | `[]` | Ingress TLS configuration |
-| dashboard.listeningAddress | string | `nil` | Dashboard listerning address. |
-| dashboard.nodeSelector | object | `{}` | Dashboard pod nodeSelector |
-| dashboard.podAdditionalLabels | object | `{}` | Custom additional labels on dashboard pods. |
-| dashboard.port | int | `8080` | Port that the dashboard will run from. |
-| dashboard.priorityClassName | string | `nil` | Priority Class name to be used in deployment if provided. |
-| dashboard.replicas | int | `2` | Number of replicas to run. |
-| dashboard.resources | object | `{"limits":{"cpu":"150m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | Requests and limits for the dashboard |
-| dashboard.service.annotations | object | `{}` | Service annotations |
-| dashboard.service.targetPort | string | `nil` | Service targetport, defaults to dashboard.port |
-| dashboard.service.type | string | `"ClusterIP"` | Service Type |
-| dashboard.tolerations | list | `[]` | Dashboard pod tolerations |
-| image.pullPolicy | string | `"Always"` | Image pull policy |
-| image.pullSecrets | list | `[]` | Image pull secrets |
 | image.repository | string | `"quay.io/fairwinds/polaris"` | Image repo |
 | image.tag | string | `""` | The Polaris Image tag to use. Defaults to the Chart's AppVersion |
+| image.pullPolicy | string | `"Always"` | Image pull policy |
+| image.pullSecrets | list | `[]` | Image pull secrets |
 | rbac.enabled | bool | `true` | Whether RBAC resources (ClusterRole, ClusterRolebinding) should be created |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `nil` | The name of the service account to use. |
 | templateOnly | bool | `false` | Outputs Namespace names, used with `helm template` |
+| dashboard.basePath | string | `nil` | Path on which the dashboard is served. Defaults to `/` |
+| dashboard.enable | bool | `true` | Whether to run the dashboard. |
+| dashboard.port | int | `8080` | Port that the dashboard will run from. |
+| dashboard.listeningAddress | string | `nil` | Dashboard listerning address. |
+| dashboard.replicas | int | `2` | Number of replicas to run. |
+| dashboard.podAdditionalLabels | object | `{}` | Custom additional labels on dashboard pods. |
+| dashboard.resources | object | `{"limits":{"cpu":"150m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | Requests and limits for the dashboard |
+| dashboard.extraContainers | list | `[]` | allows injecting additional containers. |
+| dashboard.service.type | string | `"ClusterIP"` | Service Type |
+| dashboard.service.annotations | object | `{}` | Service annotations |
+| dashboard.service.targetPort | string | `nil` | Service targetport, defaults to dashboard.port |
+| dashboard.nodeSelector | object | `{}` | Dashboard pod nodeSelector |
+| dashboard.tolerations | list | `[]` | Dashboard pod tolerations |
+| dashboard.affinity | object | `{}` | Dashboard pods affinity |
+| dashboard.ingress.enabled | bool | `false` | Whether to enable ingress to the dashboard |
+| dashboard.ingress.ingressClassName | string | `nil` | From Kubernetes 1.18+ this field is supported in case your ingress controller supports it. When set, you do not need to add the ingress class as annotation. |
+| dashboard.ingress.hosts | list | `[]` | Web ingress hostnames |
+| dashboard.ingress.annotations | object | `{}` | Web ingress annotations |
+| dashboard.ingress.tls | list | `[]` | Ingress TLS configuration |
+| dashboard.priorityClassName | string | `nil` | Priority Class name to be used in deployment if provided. |
+| dashboard.disallowExemptions | bool | `false` | Disallow any exemption |
+| dashboard.disallowConfigExemptions | bool | `false` | Disallow exemptions that are configured in the config file |
+| dashboard.disallowAnnotationExemptions | bool | `false` | Disallow exemptions that are configured via annotations |
+| webhook.enable | bool | `false` | Whether to run the webhook |
+| webhook.validate | bool | `true` | Enables the Validating Webhook, to reject resources with issues |
+| webhook.mutate | bool | `false` | Enables the Mutating Webhook, to modify resources with issues |
+| webhook.replicas | int | `2` | Number of replicas |
+| webhook.nodeSelector | object | `{}` | Webhook pod nodeSelector |
+| webhook.tolerations | list | `[]` | Webhook pod tolerations |
 | webhook.affinity | object | `{}` | Webhook pods affinity |
 | webhook.caBundle | string | `nil` | CA Bundle to use for Validating Webhook instead of cert-manager |
-| webhook.defaultRules | list | `[{"apiGroups":["apps"],"apiVersions":["v1","v1beta1","v1beta2"],"operations":["CREATE","UPDATE"],"resources":["daemonsets","deployments","statefulsets"],"scope":"Namespaced"},{"apiGroups":["batch"],"apiVersions":["v1","v1beta1"],"operations":["CREATE","UPDATE"],"resources":["jobs","cronjobs"],"scope":"Namespaced"},{"apiGroups":[""],"apiVersions":["v1"],"operations":["CREATE","UPDATE"],"resources":["pods","replicationcontrollers"],"scope":"Namespaced"}]` | An array of rules for common types for the ValidatingWebhookConfiguration |
-| webhook.disallowAnnotationExemptions | bool | `false` | Disallow exemptions that are configured via annotations |
-| webhook.disallowConfigExemptions | bool | `false` | Disallow exemptions that are configured in the config file |
-| webhook.disallowExemptions | bool | `false` | Disallow any exemption |
-| webhook.enable | bool | `false` | Whether to run the webhook |
+| webhook.secretName | string | `nil` | Name of the secret containing a TLS certificate to use if cert-manager is not used. |
 | webhook.failurePolicy | string | `"Fail"` | failurePolicy for the ValidatingWebhookConfiguration |
 | webhook.matchPolicy | string | `"Exact"` | matchPolicy for the ValidatingWebhookConfiguration |
-| webhook.mutate | bool | `false` | Enables the Mutating Webhook, to modify resources with issues |
-| webhook.mutatingRules | list | `[]` | An array of additional rules for the MutatingWebhookConfiguration. Each requires a set of apiGroups, apiVersions, operations, resources, and a scope. |
 | webhook.namespaceSelector | object | `{"matchExpressions":[{"key":"control-plane","operator":"DoesNotExist"}]}` | namespaceSelector for the ValidatingWebhookConfiguration |
-| webhook.nodeSelector | object | `{}` | Webhook pod nodeSelector |
 | webhook.objectSelector | object | `{}` | objectSelector for the ValidatingWebhookConfiguration |
-| webhook.podAdditionalLabels | object | `{}` | Custom additional labels on webhook pods. |
-| webhook.priorityClassName | string | `nil` | Priority Class name to be used in deployment if provided. |
-| webhook.replicas | int | `2` | Number of replicas |
-| webhook.resources | object | `{"limits":{"cpu":"100m","memory":"128Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | Requests and limits for the webhook. |
 | webhook.rules | list | `[]` | An array of additional rules for the ValidatingWebhookConfiguration. Each requires a set of apiGroups, apiVersions, operations, resources, and a scope. |
-| webhook.secretName | string | `nil` | Name of the secret containing a TLS certificate to use if cert-manager is not used. |
-| webhook.tolerations | list | `[]` | Webhook pod tolerations |
-| webhook.validate | bool | `true` | Enables the Validating Webhook, to reject resources with issues |
+| webhook.mutatingRules | list | `[]` | An array of additional rules for the MutatingWebhookConfiguration. Each requires a set of apiGroups, apiVersions, operations, resources, and a scope. |
+| webhook.defaultRules | list | `[{"apiGroups":["apps"],"apiVersions":["v1","v1beta1","v1beta2"],"operations":["CREATE","UPDATE"],"resources":["daemonsets","deployments","statefulsets"],"scope":"Namespaced"},{"apiGroups":["batch"],"apiVersions":["v1","v1beta1"],"operations":["CREATE","UPDATE"],"resources":["jobs","cronjobs"],"scope":"Namespaced"},{"apiGroups":[""],"apiVersions":["v1"],"operations":["CREATE","UPDATE"],"resources":["pods","replicationcontrollers"],"scope":"Namespaced"}]` | An array of rules for common types for the ValidatingWebhookConfiguration |
+| webhook.podAdditionalLabels | object | `{}` | Custom additional labels on webhook pods. |
+| webhook.resources | object | `{"limits":{"cpu":"100m","memory":"128Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | Requests and limits for the webhook. |
+| webhook.priorityClassName | string | `nil` | Priority Class name to be used in deployment if provided. |
+| webhook.disallowExemptions | bool | `false` | Disallow any exemption |
+| webhook.disallowConfigExemptions | bool | `false` | Disallow exemptions that are configured in the config file |
+| webhook.disallowAnnotationExemptions | bool | `false` | Disallow exemptions that are configured via annotations |
+| audit.enable | bool | `false` | Runs a one-time audit. This is used internally at Fairwinds, and may not be useful for others. |
+| audit.cleanup | bool | `false` | Whether to delete the namespace once the audit is finished. |
+| audit.outputURL | string | `""` | A URL which will receive a POST request with audit results. |

--- a/stable/polaris/README.md
+++ b/stable/polaris/README.md
@@ -59,7 +59,7 @@ the 0.10.0 version of this chart will only work on kubernetes 1.14.0+
 | dashboard.replicas | int | `2` | Number of replicas to run. |
 | dashboard.resources | object | `{"limits":{"cpu":"150m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | Requests and limits for the dashboard |
 | dashboard.service.annotations | object | `{}` | Service annotations |
-| dashboard.service.targetPort | int | `8080` | Service targetport |
+| dashboard.service.targetPort | string | `nil` | Service targetport, defaults to dashboard.port |
 | dashboard.service.type | string | `"ClusterIP"` | Service Type |
 | dashboard.tolerations | list | `[]` | Dashboard pod tolerations |
 | image.pullPolicy | string | `"Always"` | Image pull policy |

--- a/stable/polaris/templates/dashboard.deployment.yaml
+++ b/stable/polaris/templates/dashboard.deployment.yaml
@@ -100,6 +100,9 @@ spec:
           subPath: config.yaml
           readOnly: true
         {{- end }}
+      {{- with .Values.dashboard.extraContainers }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
       serviceAccountName: {{ template "polaris.serviceAccountName" . }}
       nodeSelector:
       {{- with .Values.dashboard.nodeSelector }}

--- a/stable/polaris/templates/dashboard.service.yaml
+++ b/stable/polaris/templates/dashboard.service.yaml
@@ -17,7 +17,7 @@ spec:
   - name: http-dashboard
     port: 80
     protocol: TCP
-    targetPort: {{ .Values.dashboard.service.targetPort }}
+    targetPort: {{ .Values.dashboard.service.targetPort | default .Values.dashboard.port }}
   selector:
     {{- include "polaris.selectors" . | nindent 4 }}
     component: dashboard

--- a/stable/polaris/templates/dashboard.service.yaml
+++ b/stable/polaris/templates/dashboard.service.yaml
@@ -17,7 +17,7 @@ spec:
   - name: http-dashboard
     port: 80
     protocol: TCP
-    targetPort: {{ .Values.dashboard.port }}
+    targetPort: {{ .Values.dashboard.service.targetPort }}
   selector:
     {{- include "polaris.selectors" . | nindent 4 }}
     component: dashboard

--- a/stable/polaris/values.yaml
+++ b/stable/polaris/values.yaml
@@ -45,11 +45,26 @@ dashboard:
     limits:
       cpu: 150m
       memory: 512Mi
+  # dashboard.extraContainers -- allows injecting additional containers.
+  extraContainers: []
+  # extraContainers:
+  #   - name: oauth-proxy
+  #     image: quay.io/oauth2-proxy/oauth2-proxy:v7.3.0
+  #     args:
+  #       - --upstream=http://127.0.0.1:8080
+  #       - --http-address=0.0.0.0:8081
+  #     ports:
+  #     - containerPort: 8081
+  #       name: oauth-proxy
+  #       protocol: TCP
+  #    resources: {}
   service:
     # dashboard.service.type -- Service Type
     type: ClusterIP
     # dashboard.service.annotations -- Service annotations
     annotations: {}
+    # dashboard.service.targetPort -- Service targetport
+    targetPort: 8080
   # dashboard.nodeSelector -- Dashboard pod nodeSelector
   nodeSelector: {}
   # dashboard.tolerations -- Dashboard pod tolerations

--- a/stable/polaris/values.yaml
+++ b/stable/polaris/values.yaml
@@ -63,8 +63,8 @@ dashboard:
     type: ClusterIP
     # dashboard.service.annotations -- Service annotations
     annotations: {}
-    # dashboard.service.targetPort -- Service targetport
-    targetPort: 8080
+    # dashboard.service.targetPort -- Service targetport, defaults to dashboard.port
+    targetPort:
   # dashboard.nodeSelector -- Dashboard pod nodeSelector
   nodeSelector: {}
   # dashboard.tolerations -- Dashboard pod tolerations


### PR DESCRIPTION
**Why This PR?**
Possibility to add an auth container for example

Fixes #

**Changes**
Changes proposed in this pull request:

* Update version
* Add extraContainer in deployment
* Add targetPort to service

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
