### PR TITLE
FWI-2286: [stable/insights-agent] FWI-2286 - Remove limits from kube-state-metrics

### DIFF
--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.5.1
+version: 2.6.0
 appVersion: 9.2.1
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -327,9 +327,6 @@ prometheus:
     image:
       pullPolicy: Always
     resources:
-      limits:
-        cpu: 100m
-        memory: 64Mi
       requests:
         cpu: 10m
         memory: 32Mi


### PR DESCRIPTION
**Why This PR?**
Remove Prometheus -> kube-state-metrics resource limits to match previous removal of other chart-specified limits.

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.

### Testing

Using insights-agent values:
```
prometheus-metrics:
  enabled: true
  installPrometheusServer: true
```

The insights-agent-prometheus-kube-state-metrics pod has our requests, but no limits.

The upstream prometheus chart, and its upstream kube-state-metrics chart, does not define kube-state-metrics limits. :)

[Internal Ticket FWI-2286](https://fairwinds.myjetbrains.com/youtrack/issue/FWI-2286)