### PR TITLE
[stable/fairwinds-insights] Add option to disable report job

### DIFF
--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "9.6.0"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 0.5.42
+version: 0.5.43
 maintainers:
 - name: rbren
 - name: makoscafee

--- a/stable/fairwinds-insights/README.md
+++ b/stable/fairwinds-insights/README.md
@@ -170,6 +170,7 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | cronjobExecutor.resources.limits.memory | string | `"64Mi"` |  |
 | cronjobExecutor.resources.requests.cpu | string | `"1m"` |  |
 | cronjobExecutor.resources.requests.memory | string | `"3Mi"` |  |
+| reportjob.enabled | bool | `true` |  |
 | reportjob.pdb.enabled | bool | `true` |  |
 | reportjob.pdb.minReplicas | int | `1` |  |
 | reportjob.hpa.enabled | bool | `true` |  |

--- a/stable/fairwinds-insights/templates/deployment-report-job.yaml
+++ b/stable/fairwinds-insights/templates/deployment-report-job.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.reportJob.enabled }}
+{{- if .Values.reportjob.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/stable/fairwinds-insights/templates/deployment-report-job.yaml
+++ b/stable/fairwinds-insights/templates/deployment-report-job.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.reportJob.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -64,3 +65,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+{{- end }}

--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -545,6 +545,7 @@ cronjobExecutor:
       memory: 3Mi
 
 reportjob:
+  enabled: true
   pdb:
     enabled: true
     minReplicas: 1


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

This adds an option to disable the report job entirely

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
