### PR TITLE
[ci] Move to auto-discovery instead of the script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,24 +96,6 @@ jobs:
             git fetch ro master
             ct lint --config scripts/ct.yaml --chart-yaml-schema scripts/schema.yaml --debug
 
-  insights:
-    executor: ci-images
-    steps:
-      - checkout
-      - setup_remote_docker
-      - rok8s11/get_vault_env:
-          vault_path: repo/global/env
-      - run:
-          name: Run Insights Checks
-          command: |
-            if [[ -z $CIRCLE_PR_NUMBER ]]; then
-              curl -L https://insights.fairwinds.com/v0/insights-ci-2.0.0.sh > insights-ci.sh
-              echo "0ee9fd3c580cd008e493568f05607ff32d8866fec53ecd08a0320f86de481317 *insights-ci.sh" | shasum -a 256 --check
-              chmod +x insights-ci.sh
-              ./insights-ci.sh
-            else
-              echo "Skipping Insights tests for forked PR"
-            fi
 
   sync:
     docker:
@@ -137,7 +119,6 @@ workflows:
       - check-helm-docs
       - lint-scripts
       - lint-charts
-      - insights
       - rok8s11/kubernetes_e2e_tests:
           name: "End-To-End Kubernetes 1.19"
           kind_node_image: "kindest/node:v1.19.11@sha256:07db187ae84b4b7de440a73886f008cf903fcf5764ba8106a9fd5243d6f32729"


### PR DESCRIPTION
**Why This PR?**
This way we won't need a token anymore.


**Changes**
Changes proposed in this pull request:

* remove insights step from the CI

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.