### PR TITLE
[stable/fairwinds-insights] FWI-2577 - Disable health_scores cron job

### DIFF
--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "9.6.0"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 0.5.45
+version: 0.5.46
 maintainers:
 - name: rbren
 - name: makoscafee

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "9.7.0"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 0.5.46
+version: 0.5.47
 maintainers:
 - name: rbren
 - name: makoscafee

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "9.7.0"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 0.5.47
+version: 0.6.0
 maintainers:
 - name: rbren
 - name: makoscafee

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "9.6.0"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 0.5.44
+version: 0.5.45
 maintainers:
 - name: rbren
 - name: makoscafee

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "9.6.0"
+appVersion: "9.7.0"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
 version: 0.5.46

--- a/stable/fairwinds-insights/README.md
+++ b/stable/fairwinds-insights/README.md
@@ -32,7 +32,7 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | options.adminEmail | string | `nil` | An email address for the first admin user. This account will get created automatically but without a known password. You must initiate a password reset in order to login to this account. |
 | options.organizationName | string | `nil` | The name of your organization. This will pre-populate Insights with an organization. |
 | options.autogenerateKeys | bool | `false` | Autogenerate keys for session tracking. For testing/demo purposes only |
-| options.migrateHealthScore | bool | `true` | Run the job to migrate health scores to a new format |
+| options.migrateHealthScore | bool | `false` | Run the job to migrate health scores to a new format |
 | options.secretName | string | `"fwinsights-secrets"` | Name of the secret where session keys and other secrets are stored |
 | options.overprovisioning.enabled | bool | `false` |  |
 | options.overprovisioning.memory | string | `"1Gi"` |  |

--- a/stable/fairwinds-insights/README.md
+++ b/stable/fairwinds-insights/README.md
@@ -130,6 +130,7 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | postgresql.persistence.enabled | bool | `true` | Create Persistent Volume with Postgres |
 | postgresql.replication.enabled | bool | `false` | Replicate Postgres data |
 | postgresql.resources | object | `{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":"75m","memory":"256Mi"}}` | Resources section for Postgres |
+| encryption.aes.cypherKey | string | `nil` |  |
 | timescale.replicaCount | int | `1` |  |
 | timescale.clusterName | string | `"timescale"` |  |
 | timescale.ephemeral | bool | `true` | Use the ephemeral Timescale chart by default |

--- a/stable/fairwinds-insights/ci/test-values.yaml
+++ b/stable/fairwinds-insights/ci/test-values.yaml
@@ -10,7 +10,6 @@ ingress:
 options:
   insightsSAASHost: "https://staging.k8s.insights.fairwinds.com"
   autogenerateKeys: true
-  migrateHealthScore: false
 
 deployments:
   additionalLabels:

--- a/stable/fairwinds-insights/templates/secret.yml
+++ b/stable/fairwinds-insights/templates/secret.yml
@@ -5,6 +5,7 @@ data:
     COOKIE_BLOCK_KEY: {{ randAlphaNum 32 | b64enc }}
     SESSION_AUTH_KEY: {{ randAlphaNum 64 | b64enc }}
     SESSION_ENCRYPTION_KEY: {{ randAlphaNum 32 | b64enc }}
+    AES_BASE64_CYPHER_KEY: {{ default (randAlphaNum 32) .Values.encryption.aes.cypherKey | b64enc }}
 kind: Secret
 metadata:
     name: {{ .Values.options.secretName }}

--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -444,6 +444,10 @@ postgresql:
       cpu: 75m
       memory: 256Mi
 
+encryption:
+  aes:
+    cypherKey:
+
 timescale:
   replicaCount: 1
   clusterName: timescale

--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -60,7 +60,7 @@ options:
   # -- Autogenerate keys for session tracking. For testing/demo purposes only
   autogenerateKeys: false
   # -- Run the job to migrate health scores to a new format
-  migrateHealthScore: true
+  migrateHealthScore: false
   # -- Name of the secret where session keys and other secrets are stored
   secretName: fwinsights-secrets
 


### PR DESCRIPTION
**Why This PR?**
Disable health_scores job by default

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.


[Internal Ticket FWI-2577](https://fairwinds.myjetbrains.com/youtrack/issue/FWI-2577)