### PR TITLE
[stable/fairwinds-insights] FWI-2628 - Add rbac permissions to be able to read pod logs

### DIFF
--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "9.7.0"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 0.6.0
+version: 0.6.1
 maintainers:
 - name: rbren
 - name: makoscafee

--- a/stable/fairwinds-insights/templates/rbac-repo-scan-job.yaml
+++ b/stable/fairwinds-insights/templates/rbac-repo-scan-job.yaml
@@ -16,6 +16,9 @@ rules:
 - apiGroups: ["batch"]
   resources: ["jobs"]
   verbs: ["get", "create", "delete"]
+- apiGroups: [""]
+  resources: ["pods/log"]
+  verbs: ["get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
**Why This PR?**
Includes role to read log/pods on repo-scan-job

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.


[Internal Ticket FWI-2628](https://fairwinds.myjetbrains.com/youtrack/issue/FWI-2628)