### PR TITLE
[stable/insights-agent] [WIP] Fix aws-costs label

### DIFF
--- a/stable/insights-agent/templates/awscosts/cronjob.yaml
+++ b/stable/insights-agent/templates/awscosts/cronjob.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.awscosts.enabled -}}
-{{- $_ := set . "Label" "awscosts" }}
+{{- $_ := set . "Label" "aws-costs" }}
 {{- $_ := set . "Config" .Values.awscosts }}
 {{- if not (.Capabilities.APIVersions.Has "batch/v1/CronJob") }}
 apiVersion: batch/v1beta1


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Something broke around aws-costs - this should fix it.

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [ ] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [ ] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
