### PR TITLE
[incubator/basic-demo] adjusting ingress values

### DIFF
--- a/incubator/basic-demo/Chart.yaml
+++ b/incubator/basic-demo/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Basic Kubernetes Demo Chart
 name: basic-demo
-version: 0.5.0
+version: 0.5.1
 maintainers:
   - name: sudermanjr

--- a/incubator/basic-demo/templates/ingress.yaml
+++ b/incubator/basic-demo/templates/ingress.yaml
@@ -35,9 +35,12 @@ spec:
         paths:
   {{- range $ingressPaths }}
           - path: {{ . }}
+            pathType: ImplementationSpecific
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: http
+              service:
+                name: {{ $fullName }}
+                port:
+                  name: http
   {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
**Why This PR?**
Several properties in the basic-demo ingress object must be adjusted for the `networking.k8s.io/v1` apiVersion.

Fixes #

**Changes**
Changes proposed in this pull request:

* Add a `pathType: ImplementationSpecific` property to the Ingress template rules path section.
* Change `serviceName` to `service.name` in the Ingress template rules path section.
* Change `servicePort` to `service.port.name` in the Ingress template rules path section.

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
