### PR TITLE
[stable/insights-agent] fix securityContext for awscosts

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 2.6.7
+* Fix for how report-specific securityContexts are handled
+
 ## 2.6.6
 * Update nova version to 3.3
 

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.6.6
+version: 2.6.7
 appVersion: 9.2.1
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:

--- a/stable/insights-agent/README.md
+++ b/stable/insights-agent/README.md
@@ -89,6 +89,7 @@ Parameter | Description | Default
 `{report}.securityContext` | Additional securityContext field in the Pod specification(PodSecurityContext) for the report |
 `{report}.image.repository` | Repository to use for the report image |
 `{report}.image.tag` | Image tag to use for the report |
+`{report}.securityContext` | Pod securityContext for the CronJob | {}
 `{report}.containerSecurityContext` | Container securityContext for the CronJob | {}
 `polaris.config` | A custom [polaris configuration](https://polaris.docs.fairwinds.com/customization/configuration/)
 `polaris.extraArgs` | A string of custom arguments to pass to the polaris CLI, e.g. `--disallow-annotation-exemptions=true` | 

--- a/stable/insights-agent/README.md
+++ b/stable/insights-agent/README.md
@@ -89,6 +89,7 @@ Parameter | Description | Default
 `{report}.securityContext` | Additional securityContext field in the Pod specification(PodSecurityContext) for the report |
 `{report}.image.repository` | Repository to use for the report image |
 `{report}.image.tag` | Image tag to use for the report |
+`{report}.containerSecurityContext` | Container securityContext for the CronJob | {}
 `polaris.config` | A custom [polaris configuration](https://polaris.docs.fairwinds.com/customization/configuration/)
 `polaris.extraArgs` | A string of custom arguments to pass to the polaris CLI, e.g. `--disallow-annotation-exemptions=true` | 
 `kube-hunter.logLevel` | DEFAULT, INFO, or WARNING | `INFO`
@@ -128,7 +129,6 @@ Parameter | Description | Default
 `awscosts.tagkey` | Tag used to identify cluster nodes. Example: Kops uses 'kubernetes_cluster'.  | ""
 `awscosts.tagvalue` | Tag value used to identify a cluster given a tag key. | ""
 `awscosts.workgroup` | Athena work group that used to run the queries | ""
-`awscosts.containerSecurityContext` | Additional container securityContext items for the cronJob. | {}
 
 ## Breaking Changes
 

--- a/stable/insights-agent/ci/test-values.yaml
+++ b/stable/insights-agent/ci/test-values.yaml
@@ -70,6 +70,9 @@ trivy:
   resources:
     requests:
       cpu: 50m
+  containerSecurityContext:
+    fsGroup: 10324
+    readOnlyRootFilesystem: false
 
 prometheus-metrics:
   enabled: true

--- a/stable/insights-agent/ci/test-values.yaml
+++ b/stable/insights-agent/ci/test-values.yaml
@@ -70,8 +70,9 @@ trivy:
   resources:
     requests:
       cpu: 50m
-  containerSecurityContext:
+  securityContext:
     fsGroup: 10324
+  containerSecurityContext:
     readOnlyRootFilesystem: false
     allowPrivilegeEscalation: false
     privileged: false

--- a/stable/insights-agent/ci/test-values.yaml
+++ b/stable/insights-agent/ci/test-values.yaml
@@ -73,6 +73,13 @@ trivy:
   containerSecurityContext:
     fsGroup: 10324
     readOnlyRootFilesystem: false
+    allowPrivilegeEscalation: false
+    privileged: false
+    runAsNonRoot: true
+    runAsUser: 10324
+    capabilities:
+      drop:
+        - ALL
 
 prometheus-metrics:
   enabled: true

--- a/stable/insights-agent/templates/_specs.yaml
+++ b/stable/insights-agent/templates/_specs.yaml
@@ -154,6 +154,9 @@ initContainers:
 
 {{ define "security-context" }}
 securityContext:
+  {{- if .Config.containerSecurityContext }}
+  {{- toYaml .Config.containerSecurityContext | nindent 2 }}
+  {{- else }}
   readOnlyRootFilesystem: true
   allowPrivilegeEscalation: false
   privileged: false
@@ -162,6 +165,7 @@ securityContext:
   capabilities:
     drop:
       - ALL
+  {{- end }}
 {{- end }}
 
 {{ define "proxy-env-spec" }}

--- a/stable/insights-agent/templates/awscosts/cronjob.yaml
+++ b/stable/insights-agent/templates/awscosts/cronjob.yaml
@@ -50,11 +50,6 @@ spec:
               - {{ .Values.awscosts.tagvalue }}
               - --workgroup
               - {{ .Values.awscosts.workgroup }}
-            {{- if  (index .Values "awscosts" "containerSecurityContext") }}
-            securityContext:
-            {{- toYaml (index .Values "awscosts" "containerSecurityContext") | nindent 14 }}
-            {{- else }}
             {{ include "security-context" . | indent 12 | trim }}
-            {{- end }}
           {{ include "uploaderContainer" . | indent 10 | trim }}
   {{- end -}}

--- a/stable/insights-agent/templates/awscosts/cronjob.yaml
+++ b/stable/insights-agent/templates/awscosts/cronjob.yaml
@@ -50,9 +50,11 @@ spec:
               - {{ .Values.awscosts.tagvalue }}
               - --workgroup
               - {{ .Values.awscosts.workgroup }}
-            {{ include "security-context" . | indent 12 | trim }}
             {{- if  (index .Values "awscosts" "containerSecurityContext") }}
+            securityContext:
             {{- toYaml (index .Values "awscosts" "containerSecurityContext") | nindent 14 }}
+            {{- else }}
+            {{ include "security-context" . | indent 12 | trim }}
             {{- end }}
           {{ include "uploaderContainer" . | indent 10 | trim }}
   {{- end -}}


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_
Security context was getting overwritten


Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
