### PR TITLE
[stable/polaris] Add logging level configuration for Dashboard

### DIFF
--- a/stable/polaris/Chart.yaml
+++ b/stable/polaris/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Validation of best practices in your Kubernetes clusters
 name: polaris
-version: 5.4.1
+version: 5.4.2
 appVersion: "7.0"
 icon: https://raw.githubusercontent.com/FairwindsOps/polaris/master/pkg/dashboard/assets/favicon-32x32.png
 maintainers:

--- a/stable/polaris/README.md
+++ b/stable/polaris/README.md
@@ -49,7 +49,7 @@ the 0.10.0 version of this chart will only work on kubernetes 1.14.0+
 | dashboard.port | int | `8080` | Port that the dashboard will run from. |
 | dashboard.listeningAddress | string | `nil` | Dashboard listerning address. |
 | dashboard.replicas | int | `2` | Number of replicas to run. |
-| dashboard.logLevel | string | `Info` | Set the logging level. |
+| dashboard.logLevel | string | `"Info"` | Set the logging level for the Dashboard command |
 | dashboard.podAdditionalLabels | object | `{}` | Custom additional labels on dashboard pods. |
 | dashboard.resources | object | `{"limits":{"cpu":"150m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | Requests and limits for the dashboard |
 | dashboard.service.type | string | `"ClusterIP"` | Service Type |

--- a/stable/polaris/README.md
+++ b/stable/polaris/README.md
@@ -49,6 +49,7 @@ the 0.10.0 version of this chart will only work on kubernetes 1.14.0+
 | dashboard.port | int | `8080` | Port that the dashboard will run from. |
 | dashboard.listeningAddress | string | `nil` | Dashboard listerning address. |
 | dashboard.replicas | int | `2` | Number of replicas to run. |
+| dashboard.logLevel | string | `Info` | Set the logging level. |
 | dashboard.podAdditionalLabels | object | `{}` | Custom additional labels on dashboard pods. |
 | dashboard.resources | object | `{"limits":{"cpu":"150m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | Requests and limits for the dashboard |
 | dashboard.service.type | string | `"ClusterIP"` | Service Type |

--- a/stable/polaris/templates/dashboard.deployment.yaml
+++ b/stable/polaris/templates/dashboard.deployment.yaml
@@ -66,6 +66,10 @@ spec:
         {{- if .Values.dashboard.disallowAnnotationExemptions }}
         - --disallow-annotation-exemptions
         {{- end }}
+        {{- if .Values.dashboard.logLevel }}
+        - --log-level
+        - {{ .Values.dashboard.logLevel | quote }}
+        {{- end }}
         image: '{{.Values.image.repository}}:{{.Values.image.tag | default .Chart.AppVersion }}'
         imagePullPolicy: '{{.Values.image.pullPolicy}}'
         name: dashboard
@@ -112,5 +116,5 @@ spec:
 {{- if .Values.dashboard.affinity }}
       affinity:
 {{ toYaml .Values.dashboard.affinity | indent 8 }}
-{{- end }}      
+{{- end }}
 {{- end -}}

--- a/stable/polaris/values.yaml
+++ b/stable/polaris/values.yaml
@@ -35,6 +35,8 @@ dashboard:
   listeningAddress:
   # dashboard.replicas -- Number of replicas to run.
   replicas: 2
+  # Set the logging level for the Dashboard command
+  logLevel: Fatal
   # dashboard.podAdditionalLabels -- Custom additional labels on dashboard pods.
   podAdditionalLabels: {}
   # dashboard.resources -- Requests and limits for the dashboard
@@ -75,8 +77,6 @@ dashboard:
   disallowConfigExemptions: false
   # dashboard.disallowAnnotationExemptions -- Disallow exemptions that are configured via annotations
   disallowAnnotationExemptions: false
-  # Additional command line arguments
-  extraArgs: []
 
 webhook:
   # webhook.enable -- Whether to run the webhook

--- a/stable/polaris/values.yaml
+++ b/stable/polaris/values.yaml
@@ -75,6 +75,8 @@ dashboard:
   disallowConfigExemptions: false
   # dashboard.disallowAnnotationExemptions -- Disallow exemptions that are configured via annotations
   disallowAnnotationExemptions: false
+  # Additional command line arguments
+  extraArgs: []
 
 webhook:
   # webhook.enable -- Whether to run the webhook

--- a/stable/polaris/values.yaml
+++ b/stable/polaris/values.yaml
@@ -35,8 +35,8 @@ dashboard:
   listeningAddress:
   # dashboard.replicas -- Number of replicas to run.
   replicas: 2
-  # Set the logging level for the Dashboard command
-  logLevel: Fatal
+  # dashboard.logLevel -- Set the logging level for the Dashboard command
+  logLevel: Info
   # dashboard.podAdditionalLabels -- Custom additional labels on dashboard pods.
   podAdditionalLabels: {}
   # dashboard.resources -- Requests and limits for the dashboard


### PR DESCRIPTION
**Why This PR?**

This adds the ability to set the logging level for the Dashboard deployment's command line.  Currently this is not possible to set at all.

**Changes**
Changes proposed in this pull request:

* Add `dashboard.logLevel` value & appropriate template changes to support setting the `--log-level` command line option for Dashboard

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
