### PR TITLE
[stable/insights-agent] Add ClusterRole, ClusterRoleBinding, Role, and RoleBinding to Polaris RBAC

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## 2.6.8
+Add Polaris RBAC permission to get and list ClusterRoles, ClusterRoleBindings, Roles, and RoleBindings. These permissions are required by new RBAC related Polaris checks:
+* https://github.com/FairwindsOps/polaris/pull/820
+* https://github.com/FairwindsOps/polaris/pull/823
+
 ## 2.6.7
 * Fix for how report-specific securityContexts are handled
 

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.6.7
+version: 2.6.8
 appVersion: 9.2.1
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:

--- a/stable/insights-agent/templates/polaris/rbac.yaml
+++ b/stable/insights-agent/templates/polaris/rbac.yaml
@@ -20,6 +20,16 @@ rules:
     verbs:
       - 'get'
       - 'list'
+  - apiGroups:
+      - 'rbac.authorization.k8s.io'
+    resources:
+      - 'clusterroles'
+      - 'clusterrolebindings'
+      - 'roles'
+      - 'rolebindings'
+    verbs:
+      - 'get'
+      - 'list'
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
**Why This PR?**
Update Polaris RBAC to support [Polaris PR #832](https://github.com/FairwindsOps/polaris/pull/832) which includes RBAC-related checks for (Cluster)Roles and their bindings.

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
