### PR TITLE
[stable/polaris] Update Polaris RBAC to support Polaris PR #832

### DIFF
--- a/stable/polaris/CHANGELOG.md
+++ b/stable/polaris/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this Helm chart will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this chart adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 5.4.3
+### Added
+RBAC permission to get and list ClusterRoles, ClusterRoleBindings, Roles, and RoleBindings. These permissions are required by new RBAC related checks:
+* https://github.com/FairwindsOps/polaris/pull/820
+* https://github.com/FairwindsOps/polaris/pull/823
+
 ## 4.2.1
 
 ### Added

--- a/stable/polaris/Chart.yaml
+++ b/stable/polaris/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Validation of best practices in your Kubernetes clusters
 name: polaris
-version: 5.4.2
+version: 5.4.3
 appVersion: "7.0"
 icon: https://raw.githubusercontent.com/FairwindsOps/polaris/master/pkg/dashboard/assets/favicon-32x32.png
 maintainers:

--- a/stable/polaris/templates/rbac.yaml
+++ b/stable/polaris/templates/rbac.yaml
@@ -38,6 +38,16 @@ rules:
     verbs:
       - 'get'
       - 'list'
+  - apiGroups:
+      - 'rbac.authorization.k8s.io'
+    resources:
+      - 'clusterroles'
+      - 'clusterrolebindings'
+      - 'roles'
+      - 'rolebindings'
+    verbs:
+      - 'get'
+      - 'list'
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION

**Why This PR?**
Update Polaris RBAC to support [Polaris PR #832](https://github.com/FairwindsOps/polaris/pull/832) which includes RBAC-related checks for (Cluster)Roles and their bindings.

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
