### PR TITLE
[stable/polaris] Allow user to override container.securityContext

### DIFF
--- a/stable/polaris/CHANGELOG.md
+++ b/stable/polaris/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this Helm chart will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this chart adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 5.3.0
+
+### Added
+Refactor container securityContext into `values.yaml` for added flexibility (i.e seccomp profiles).
+
 ## 4.2.1
 
 ### Added

--- a/stable/polaris/Chart.yaml
+++ b/stable/polaris/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Validation of best practices in your Kubernetes clusters
 name: polaris
-version: 5.4.2
+version: 5.3.0
 appVersion: "7.0"
 icon: https://raw.githubusercontent.com/FairwindsOps/polaris/master/pkg/dashboard/assets/favicon-32x32.png
 maintainers:

--- a/stable/polaris/Chart.yaml
+++ b/stable/polaris/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Validation of best practices in your Kubernetes clusters
 name: polaris
-version: 5.3.0
+version: 5.5.0
 appVersion: "7.0"
 icon: https://raw.githubusercontent.com/FairwindsOps/polaris/master/pkg/dashboard/assets/favicon-32x32.png
 maintainers:

--- a/stable/polaris/README.md
+++ b/stable/polaris/README.md
@@ -66,6 +66,7 @@ the 0.10.0 version of this chart will only work on kubernetes 1.14.0+
 | dashboard.disallowExemptions | bool | `false` | Disallow any exemption |
 | dashboard.disallowConfigExemptions | bool | `false` | Disallow exemptions that are configured in the config file |
 | dashboard.disallowAnnotationExemptions | bool | `false` | Disallow exemptions that are configured via annotations |
+| dashboard.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true,"runAsNonRoot":true}` | securityContext to apply to the dashboard container |
 | webhook.enable | bool | `false` | Whether to run the webhook |
 | webhook.validate | bool | `true` | Enables the Validating Webhook, to reject resources with issues |
 | webhook.mutate | bool | `false` | Enables the Mutating Webhook, to modify resources with issues |

--- a/stable/polaris/templates/dashboard.deployment.yaml
+++ b/stable/polaris/templates/dashboard.deployment.yaml
@@ -89,14 +89,10 @@ spec:
           periodSeconds: 20
         resources:
           {{- toYaml .Values.dashboard.resources | nindent 10 }}
+        {{- with .Values.dashboard.containerSecurityContext }}
         securityContext:
-          allowPrivilegeEscalation: false
-          privileged: false
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
-          capabilities:
-            drop:
-              - ALL
+        {{- toYaml . | nindent 12 }}
+        {{- end }}                 
         {{- with .Values.config }}
         volumeMounts:
         - name: config

--- a/stable/polaris/values.yaml
+++ b/stable/polaris/values.yaml
@@ -77,6 +77,7 @@ dashboard:
   disallowConfigExemptions: false
   # dashboard.disallowAnnotationExemptions -- Disallow exemptions that are configured via annotations
   disallowAnnotationExemptions: false
+  # dashboard.containerSecurityContext -- securityContext to apply to the dashboard container
   containerSecurityContext:
     allowPrivilegeEscalation: false
     privileged: false

--- a/stable/polaris/values.yaml
+++ b/stable/polaris/values.yaml
@@ -77,6 +77,14 @@ dashboard:
   disallowConfigExemptions: false
   # dashboard.disallowAnnotationExemptions -- Disallow exemptions that are configured via annotations
   disallowAnnotationExemptions: false
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    privileged: false
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    capabilities:
+      drop:
+        - ALL
 
 webhook:
   # webhook.enable -- Whether to run the webhook


### PR DESCRIPTION
**Why This PR?**

Hey guys, for your consideration, I've refactored the polaris chart, so that the container `securityContext` can be amended / altered in `values.yaml`.

Why?

I need to add a seccomp profile to my deployment, and the way the container `securityContext` is currently hard-coded, this is not possible. If the entire `container.securityContext` is moved into `values.yaml`, then users like me could alter / append to it, but if unaltered, the existing `securityContext` will still apply.

**Changes**
Changes proposed in this pull request:

* Move Polaris dashboard deployment container securityContext into `values.yaml`

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
