### PR TITLE
[stable/insights-agent] bump nova version and add new params

### DIFF
--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: "9.10.0"
+appVersion: "9.11.0"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 0.6.8
+version: 0.6.9
 maintainers:
 - name: rbren
 - name: makoscafee

--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-## 2.6.10
+## 2.6.11
 * Update `nova` version to `v3.4` 
 * Add new flags to `nova find` command 
 

--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 ## 2.6.11
 * Update `nova` version to `v3.4` 
-* Add new flags to `nova find` command 
+* Use `nova find --helm --containers` to run `nova` - This way, both outdated/deprecated charts and containers will be reported to the output file
 
 ## 2.6.10
 Update insights-admission dependency - reattempt of 2.6.9

--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 2.6.10
+Update `nova` version to `v3.4` and add new flags to `find` command 
+
 ## 2.6.9
 Update insights-admission dependency (Now uses admission plugin 1.6)
 

--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 ## 2.6.10
-Update `nova` version to `v3.4` and add new flags to `find` command 
+* Update `nova` version to `v3.4` 
+* Add new flags to `nova find` command 
+
+## 2.6.10
+Update insights-admission dependency - reattempt of 2.6.9
 
 ## 2.6.9
 Update insights-admission dependency (Now uses admission plugin 1.6)

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.6.9
+version: 2.6.10
 appVersion: 9.2.1
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.6.10
+version: 2.6.11
 appVersion: 9.2.1
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:

--- a/stable/insights-agent/templates/nova/cronjob.yaml
+++ b/stable/insights-agent/templates/nova/cronjob.yaml
@@ -27,8 +27,8 @@ spec:
             command:
               - /nova
               - find
-              - -- helm
-              - -- containers
+              - --helm
+              - --containers
               - --config={{ .Config.configLocation }}
               - -v{{ .Config.logLevel }}
             env:

--- a/stable/insights-agent/templates/nova/cronjob.yaml
+++ b/stable/insights-agent/templates/nova/cronjob.yaml
@@ -27,6 +27,8 @@ spec:
             command:
               - /nova
               - find
+              - -- helm
+              - -- containers
               - --config={{ .Config.configLocation }}
               - -v{{ .Config.logLevel }}
             env:

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -195,7 +195,7 @@ nova:
   logLevel: 3
   image:
     repository: quay.io/fairwinds/nova
-    tag: "v3.3"
+    tag: "v3.4"
   resources:
     requests:
       cpu: 100m


### PR DESCRIPTION
**Why This PR?**
Bump nova version that has support for `--helm` and `--containers` flags for `find` command
Requires [Nova 3.4 release](https://github.com/FairwindsOps/nova/pull/154)

Fixes #

**Changes**
Changes proposed in this pull request:

* Bump version
* Add new flags to the find command

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
