### PR TITLE
[stable/insights-agent] Update Pluto image host from GCR to Quay

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 2.6.11
+Update pluto image host from GCR to Quay
+
 ## 2.6.10
 Update insights-admission dependency - reattempt of 2.6.9
 

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.6.10
+version: 2.6.11
 appVersion: 9.2.1
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -270,7 +270,7 @@ pluto:
   timeout: 300
   targetVersions: ""
   image:
-    repository: us-docker.pkg.dev/fairwinds-ops/oss/pluto
+    repository: quay.io/fairwinds/pluto
     tag: "v5.10"
   resources:
     requests:


### PR DESCRIPTION
**Why This PR?**
All container images for insights-agent point to Quay except for Pluto, which is pointing to Google Cloud Repository. Updated link to point to Quay.

**Changes**
Changes proposed in this pull request:

* Change image link for pluto from image hosted on GCR to Quay (https://quay.io/repository/fairwinds/pluto)

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.