### PR TITLE
[stable/insights-agent]: CronJobExecutor uses a new insights-utils image, Kube download supports arm64 architecture

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-## 2.6.12
+## 2.7.0
 * Support arm64 architecture (CronJob executor and insights-plugins)
 
 ## 2.6.11

--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 ## 2.6.12
-* Update CronJob Executor to support arm64 architecture
+* Support arm64 architecture (CronJob executor and insights-plugins)
 
 ## 2.6.11
 * Update `nova` version to `v3.4` 

--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 2.6.12
+* Update CronJob Executor to support arm64 architecture
+
 ## 2.6.11
 * Update `nova` version to `v3.4` 
 * Use `nova find --helm --containers` to run `nova` - This way, both outdated/deprecated charts and containers will be reported to the output file

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.6.12
+version: 2.7.0
 appVersion: 9.2.1
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.6.11
+version: 2.6.12
 appVersion: 9.2.1
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:

--- a/stable/insights-agent/download-kubectl.sh
+++ b/stable/insights-agent/download-kubectl.sh
@@ -1,6 +1,9 @@
 #! /bin/sh
 
 set -eo pipefail
+# Get the OS and architecture, defaulting to linux/amd64
+kubectl_os=$(uname -s | awk '{print tolower($0)}' || echo linux)
+kubectl_arch=$(uname -m | awk '{print tolower($0)}' |sed -e 's/aarch/arm/' -e 's/x86_/amd/' || echo amd64)
 
 mkdir /tmp/bin
 export PATH=$PATH:/tmp/bin
@@ -14,9 +17,6 @@ cd /tmp/bin
 
 old_kubectl_version='v1.19.6'
 default_kubectl_version=$(curl -fsSL https://dl.k8s.io/release/stable.txt)
-echo "Downloading jq . . ."
-curl -fsSLo jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && chmod +x jq
-
 version_pattern='v[0-9]+\.[0-9]+.[0-9]+)'
 kubectl_version=""
 
@@ -44,10 +44,10 @@ if [ "${kubectl_version}" == "" ] ; then
   kubectl_version="${default_kubectl_version}"
 fi
 
-echo Downloading kubectl version ${kubectl_version}
-curl -fsSLo kubectl "https://dl.k8s.io/release/${kubectl_version}/bin/linux/amd64/kubectl" && chmod +x kubectl
+echo Downloading kubectl version ${kubectl_version} for ${kubectl_os}/${kubectl_arch}
+curl -fsSLo kubectl "https://dl.k8s.io/release/${kubectl_version}/bin/${kubectl_os}/${kubectl_arch}/kubectl" && chmod +x kubectl
 echo Downloading kubectl checksum
-curl -fsSLO https://dl.k8s.io/${kubectl_version}/bin/linux/amd64/kubectl.sha256 >kubectl.sha256 >/tmp/bin/kubectl.sha256
+curl -fsSLO https://dl.k8s.io/${kubectl_version}/bin/${kubectl_os}/${kubectl_arch}/kubectl.sha256 >kubectl.sha256 >/tmp/bin/kubectl.sha256
 # THe busybox version of sha256sum wants two spaces between the checksum and filename.
 sed -i -e 's/$/  kubectl/'  /tmp/bin/kubectl.sha256
 echo Verifying kubectl checksum

--- a/stable/insights-agent/requirements.yaml
+++ b/stable/insights-agent/requirements.yaml
@@ -9,7 +9,7 @@ dependencies:
   condition: prometheus-metrics.installPrometheusServer
 - name: insights-admission
   repository: https://charts.fairwinds.com/stable
-  version: '1.2.*'
+  version: '1.3.*'
   condition: admission.enabled
 - name: falco
   repository: https://falcosecurity.github.io/charts

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -46,8 +46,8 @@ cronjobs:
 
 cronjobExecutor:
   image:
-    repository: curlimages/curl
-    tag: "7.84.0"
+    repository: quay.io/fairwinds/insights-utils
+    tag: "0.0.1"
   resources:
     requests:
       cpu: 100m

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -22,7 +22,7 @@ rbac:
 uploader:
   image:
     repository: quay.io/fairwinds/insights-uploader
-    tag: "0.3"
+    tag: "0.4"
   imagePullSecret: ""
   sendFailures: true
   resources:
@@ -47,7 +47,7 @@ cronjobs:
 cronjobExecutor:
   image:
     repository: quay.io/fairwinds/insights-utils
-    tag: "0.0.1"
+    tag: "0.0"
   resources:
     requests:
       cpu: 100m
@@ -56,7 +56,7 @@ cronjobExecutor:
 installReporter:
   image:
     repository: quay.io/fairwinds/insights-uploader
-    tag: "0.3"
+    tag: "0.4"
   resources:
     requests:
       cpu: 100m
@@ -71,7 +71,7 @@ polaris:
     disabled: false
   image:
     repository: quay.io/fairwinds/polaris
-    tag: "7.0"
+    tag: "7.1"
   resources:
     requests:
       cpu: 100m
@@ -135,7 +135,7 @@ opa:
   timeout: 300
   image:
     repository: quay.io/fairwinds/fw-opa
-    tag: "2.0"
+    tag: "2.1"
   additionalAccess:
   # opa.defaultTargetResources -- A default list of Kubernetes targets to which OPA
   # policies will be applied.
@@ -182,7 +182,7 @@ workloads:
   timeout: 300
   image:
     repository: quay.io/fairwinds/workloads
-    tag: "2.2"
+    tag: "2.3"
   resources:
     requests:
       cpu: 100m
@@ -215,7 +215,7 @@ rbac-reporter:
   timeout: 300
   image:
     repository: quay.io/fairwinds/rbac-reporter
-    tag: "1.2"
+    tag: "1.3"
   resources:
     requests:
       cpu: 100m
@@ -229,11 +229,11 @@ kube-bench:
   timeout: 600
   image:
     repository: quay.io/fairwinds/fw-kube-bench
-    tag: 0.3
+    tag: 0.4
   aggregator:
     image:
       repository: quay.io/fairwinds/fw-kube-bench-aggregator
-      tag: 0.2
+      tag: 0.3
     resources:
       requests:
         cpu: 100m
@@ -256,7 +256,7 @@ trivy:
   insecureSSL: false
   image:
     repository: quay.io/fairwinds/fw-trivy
-    tag: "0.21"
+    tag: "0.22"
   serviceAccount:
     annotations:
   resources:
@@ -285,7 +285,7 @@ prometheus-metrics:
   address: "http://prometheus-server"
   image:
     repository: quay.io/fairwinds/prometheus-collector
-    tag: "1.0"
+    tag: "1.1"
   resources:
     requests:
       cpu: 100m
@@ -383,7 +383,7 @@ awscosts:
   timeout: 300
   image:
     repository: quay.io/fairwinds/aws-costs
-    tag: "1.0"
+    tag: "1.1"
   serviceAccount:
     annotations:
   resources:
@@ -402,7 +402,7 @@ right-sizer:
   # This image is for the controller, the agent only runs the Insights uploader.
   image:
     repository: quay.io/fairwinds/right-sizer
-    tag: 0.3
+    tag: 0.4
     pullPolicy: Always
   # rightsizer.imagePullSecrets -- imagePullSecrets containing private registry credentials.
   imagePullSecrets: []
@@ -495,7 +495,7 @@ falco:
     port: 3031
   image:
     repository: quay.io/fairwinds/falco-agent
-    tag: "0.1"
+    tag: "0.2"
     pullPolicy: Always
   podSecurityContext:
     fsGroup: 101


### PR DESCRIPTION
NOTE this PR requires [PR 947](https://github.com/FairwindsOps/charts/pull/947) for the insights-admission chart.

**Why This PR?**
* Switch CronJobExecutor from the curl to a new insights-utils docker image, which provides curl + jq on amd64 or arm64 architectures
* Update the download-kubectl script to support arm64
* Update insights-plugin versions to those that are built for arm64

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
