### PR TITLE
[stable/vpa] Update vpa to 0.11.0

### DIFF
--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 1.4.0
-appVersion: 0.10.0
+version: 1.5.0
+appVersion: 0.11.0
 maintainers:
   - name: sudermanjr


### PR DESCRIPTION
**Why This PR?**

Update the VPA to the 0.11.0 version. The 0.12.0 has be released since but adds breaking changes so it should be releases in another PR.

The only relevant diff from the `v0.11.0` is 

> Potentially breaking change:
> Added validation - CPU values will be accepted only with resolution of 1 mCPU, memory with resolution of 1 b (https://github.com/kubernetes/autoscaler/pull/4798).

I don't think it a _true_ breaking change, so I did not bump the major version of the Chart, but this can be discussed!

I have run locally the official [VerticalPodAutoscaler repo](https://github.com/kubernetes/autoscaler) script for any "manifest" differences but only the image version changes. The test are still passing

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
