### PR TITLE
[stable/rbac-manager] allow setting custom securityContext

### DIFF
--- a/stable/rbac-manager/Chart.yaml
+++ b/stable/rbac-manager/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rbac-manager
-version: 1.13.2
+version: 1.14.0
 appVersion: 1.4.0
 description: A Kubernetes operator that simplifies the management of Role Bindings and Service Accounts.
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/rbac-manager/icon.png

--- a/stable/rbac-manager/Chart.yaml
+++ b/stable/rbac-manager/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rbac-manager
-version: 1.13.1
+version: 1.13.2
 appVersion: 1.4.0
 description: A Kubernetes operator that simplifies the management of Role Bindings and Service Accounts.
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/rbac-manager/icon.png

--- a/stable/rbac-manager/README.md
+++ b/stable/rbac-manager/README.md
@@ -73,3 +73,5 @@ In the above workflow, an RBAC Definition installed between revision 1 and 2 sho
 | serviceMonitor.annotations | object | `{}` | Annotations to apply to the serviceMonitor and headless service |
 | serviceMonitor.namespace | string | `""` | The namespace to deploy the serviceMonitor into |
 | serviceMonitor.interval | string | `"60s"` | How often to scrape the metrics endpoint |
+| securityContext | object | `{}` | SecurityContext to apply on pod level |
+| containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true,"runAsNonRoot":true}` | SecurityContext to apply on container level |

--- a/stable/rbac-manager/templates/deployment.yaml
+++ b/stable/rbac-manager/templates/deployment.yaml
@@ -36,6 +36,7 @@ spec:
 {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
 {{- end }}
+      securityContext: {{ toYaml .Values.securityContext | nindent 8 }}
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}{{- if (.Values.image.digest) -}} @{{ .Values.image.digest }}{{- else -}}:{{ default $.Chart.AppVersion .Values.image.tag }} {{- end -}}"
@@ -59,14 +60,7 @@ spec:
             scheme: HTTP
             path: /metrics
             port: 8042
-        securityContext:
-          allowPrivilegeEscalation: false
-          privileged: false
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
-          capabilities:
-            drop:
-              - ALL
+        securityContext: {{ toYaml .Values.containerSecurityContext | nindent 10 }}
         ports:
           # metrics port
           - name: http-metrics

--- a/stable/rbac-manager/values.yaml
+++ b/stable/rbac-manager/values.yaml
@@ -61,3 +61,17 @@ serviceMonitor:
   namespace: ""
   # serviceMonitor.interval -- How often to scrape the metrics endpoint
   interval: 60s
+
+# securityContext -- SecurityContext to apply on pod level
+securityContext: {}
+
+
+# containerSecurityContext -- SecurityContext to apply on container level
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  privileged: false
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  capabilities:
+    drop:
+      - ALL


### PR DESCRIPTION

**Why This PR?**

As of now, no additional securityContext on the Pod Level can be set over the chart, this allows it and also enables us to configure the default SecurityContext on container level

**Changes**
Changes proposed in this pull request:

* add `securityContext` value to set a SecurityContext on pod level
* add `containerSecurityConatext` value with the default set in the template to enable us to customize the SecurityContext on container level

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
