### PR TITLE
[stable/insights-agent] bump fw-opa version

### DIFF
--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: "10.1.0"
+appVersion: "10.2.0"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 0.6.18
+version: 0.6.19
 maintainers:
 - name: rbren
 - name: makoscafee

--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+
+## 2.6.12
+* Update `quay.io/fairwinds/fw-opa` version to `v2.2`
+
 ## 2.8.1
 * Add error messages when required values are not set for awscosts
 

--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.6.12
+## 2.8.2
 * Update `quay.io/fairwinds/fw-opa` version to `v2.2`
 
 ## 2.8.1

--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,4 @@
 # Changelog
-
 ## 2.8.2
 * Update `quay.io/fairwinds/fw-opa` version to `v2.2`
 

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.8.1
+version: 2.8.2
 appVersion: 9.2.1
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -135,7 +135,7 @@ opa:
   timeout: 300
   image:
     repository: quay.io/fairwinds/fw-opa
-    tag: "2.1"
+    tag: "2.2"
   additionalAccess:
   # opa.defaultTargetResources -- A default list of Kubernetes targets to which OPA
   # policies will be applied.


### PR DESCRIPTION
**Why This PR?**
Fairwinds Agent should bring-in `fw-opa` new functionality that exposes `admissionRequest` in OPA engine

Fixes #

**Changes**
Changes proposed in this pull request:

* Bump `fw-opa` plugin version to 2.2

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
