### PR TITLE
[stable/insights-admission] bump admission request chart to use the latest 1.8 tag

### DIFF
--- a/stable/insights-admission/Chart.yaml
+++ b/stable/insights-admission/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: insights-admission
 description: A Validating Webhook Admission Controller that utilizes Fairwinds Insights.
 type: application
-version: 1.4.1
+version: 1.4.2
 appVersion: "1.8"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-admission/icon.png
 maintainers:


### PR DESCRIPTION
**Why This PR?**
bump admission request chart to use the latest 1.8 tag (836a9c47ad76)

Fixes #

**Changes**
Changes proposed in this pull request:

* bump admission request to use the latest 1.8 tag (836a9c47ad76)

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
