### PR TITLE
[stable/fairwinds-insights] Bump version to 10.3.3

### DIFF
--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -1,11 +1,11 @@
 apiVersion: v2
-appVersion: "10.3.0"
+appVersion: "10.3.3"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 0.6.20
+version: 0.6.21
 maintainers:
 - name: rbren
-- name: makoscafee
+- name: mhoss019
 - name: ivanfetch-fw
 dependencies:
 - name: postgresql

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "10.3.3"
+appVersion: "10.3"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
 version: 0.6.21


### PR DESCRIPTION
**Why This PR?**
Bumps the version of Insights to 10.3.3



**Changes**
Changes proposed in this pull request:

* Unpins the patch version of Insights

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
