### PR TITLE
[stable/polaris] Anti affinity

### DIFF
--- a/stable/polaris/Chart.yaml
+++ b/stable/polaris/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Validation of best practices in your Kubernetes clusters
 name: polaris
-version: 5.6.1
+version: 5.6.2
 appVersion: "7.1"
 icon: https://raw.githubusercontent.com/FairwindsOps/polaris/master/pkg/dashboard/assets/favicon-32x32.png
 maintainers:

--- a/stable/polaris/templates/dashboard.deployment.yaml
+++ b/stable/polaris/templates/dashboard.deployment.yaml
@@ -92,7 +92,7 @@ spec:
         {{- with .Values.dashboard.containerSecurityContext }}
         securityContext:
         {{- toYaml . | nindent 12 }}
-        {{- end }}                 
+        {{- end }}
         {{- with .Values.config }}
         volumeMounts:
         - name: config
@@ -112,8 +112,26 @@ spec:
       {{- with .Values.dashboard.tolerations }}
 {{ toYaml . | indent 6 }}
       {{- end }}
-{{- if .Values.dashboard.affinity }}
       affinity:
+{{- if .Values.dashboard.affinity }}
 {{ toYaml .Values.dashboard.affinity | indent 8 }}
+{{- else }}
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 50
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                {{- range $key, $value := ( include "polaris.selectors" . | fromYaml ) }}
+                - key: {{ $key }}
+                  operator: In
+                  values:
+                  - {{ $value }}
+                {{- end }}
+                - key: component
+                  operator: In
+                  values:
+                  - dashboard
+              topologyKey: kubernetes.io/hostname
 {{- end }}
 {{- end -}}

--- a/stable/polaris/templates/webhook.deployment.yaml
+++ b/stable/polaris/templates/webhook.deployment.yaml
@@ -106,9 +106,27 @@ spec:
       {{- with .Values.webhook.tolerations }}
 {{ toYaml . | indent 6 }}
       {{- end }}
-{{- if .Values.webhook.affinity }}
       affinity:
+{{- if .Values.webhook.affinity }}
 {{ toYaml .Values.webhook.affinity | indent 8 }}
+{{- else }}
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 50
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                {{- range $key, $value := ( include "polaris.selectors" . | fromYaml ) }}
+                - key: {{ $key }}
+                  operator: In
+                  values:
+                  - {{ $value }}
+                {{- end }}
+                - key: component
+                  operator: In
+                  values:
+                  - webhook
+              topologyKey: kubernetes.io/hostname
 {{- end }}
       volumes:
         {{- with .Values.config }}


### PR DESCRIPTION
**Why This PR?**
Fixes #997 

**Changes**
Changes proposed in this pull request:
* Add reasonable podAntiAffinity default for Polaris

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
