### PR TITLE
[stable/rbac-manager] Make securityContext configurable

### DIFF
--- a/stable/rbac-manager/Chart.yaml
+++ b/stable/rbac-manager/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rbac-manager
-version: 1.14.1
+version: 1.15.0
 appVersion: 1.4.0
 description: A Kubernetes operator that simplifies the management of Role Bindings and Service Accounts.
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/rbac-manager/icon.png

--- a/stable/rbac-manager/README.md
+++ b/stable/rbac-manager/README.md
@@ -68,6 +68,8 @@ In the above workflow, an RBAC Definition installed between revision 1 and 2 sho
 | affinity | object | `{}` | Deployment affinity |
 | podAnnotations | object | `{}` | Annotations to apply to the pods |
 | podLabels | object | `{}` | Labels to apply to the pod |
+| podSecurityContext | object | `{}` | securityContext to apply to the whole pod |
+| securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true,"runAsNonRoot":true}` | securityContext to apply to the rbac-manager container |
 | deploymentLabels | object | `{}` | Labels to apply to the Deployment resource |
 | serviceMonitor.enabled | bool | `false` | If true, a ServiceMonitor will be created for Prometheus |
 | serviceMonitor.additionalLabels | list | `[]` | Additional labels to ServiceMonitor |

--- a/stable/rbac-manager/templates/deployment.yaml
+++ b/stable/rbac-manager/templates/deployment.yaml
@@ -30,6 +30,8 @@ spec:
     {{- end }}
     spec:
       serviceAccountName: {{ template "rbac-manager.fullname" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{- if .Values.image.imagePullSecrets }}
       imagePullSecrets:
         {{- range .Values.image.imagePullSecrets }}
@@ -63,13 +65,7 @@ spec:
             path: /metrics
             port: 8042
         securityContext:
-          allowPrivilegeEscalation: false
-          privileged: false
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
-          capabilities:
-            drop:
-              - ALL
+          {{- toYaml .Values.securityContext | nindent 10 }}
         ports:
           # metrics port
           - name: http-metrics

--- a/stable/rbac-manager/values.yaml
+++ b/stable/rbac-manager/values.yaml
@@ -50,6 +50,18 @@ podAnnotations: {}
 # podLabels -- Labels to apply to the pod
 podLabels: {}
 
+# podSecurityContext -- securityContext to apply to the whole pod
+podSecurityContext: {}
+# securityContext -- securityContext to apply to the rbac-manager container
+securityContext:
+  allowPrivilegeEscalation: false
+  privileged: false
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  capabilities:
+    drop:
+      - ALL
+
 # deploymentLabels -- Labels to apply to the Deployment resource
 deploymentLabels: {}
 


### PR DESCRIPTION
**Why This PR?**
Using the [Pod Security Standard "restricted" level](https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted) requires certain securityContext settings to be set. While the container of rbac-manager actually already fulfills most of the requirements (uid has to be explicitly set if the container image uses a named user) the mandatory seccompProfile is missing and since the securityContext for neither pod nor container is configurable this cannot be amended trivially. This PR makes securityContext for both the pod and container fully configurable via values.yaml.

Fixes #1006

**Changes**
Changes proposed in this pull request:

* Move container securityContext values to values.yaml as defaults for securityContext
* Add podSecurityContext in values.yaml which is rendered to securityContext on pod level

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
