### PR TITLE
[stable/fairwinds-insights] change downstream timescale chart

### DIFF
--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.7.2
+* Change downstream timescale chart to the official one
+
 ## 0.7.1
 * Update application version to 10.5. [See the release notes for more details](https://insights.docs.fairwinds.com/release-notes)
 

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "10.5"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 0.7.1
+version: 0.7.2
 maintainers:
 - name: rbren
 - name: mhoss019
@@ -17,7 +17,7 @@ dependencies:
   repository: https://helm.min.io/
   condition: minio.install
 - name: timescaledb-single
-  version: 0.21.*
-  repository: https://charts.fairwinds.com/incubator
+  version: 0.21.0
+  repository: https://charts.timescale.com
   condition: timescale.ephemeral
   alias: timescale


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Trying to get rid of our fork of the timescale chart. 

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
