### PR TITLE
[incubator/datadog-apm] use latest datadog agent image

### DIFF
--- a/incubator/datadog-apm/Chart.yaml
+++ b/incubator/datadog-apm/Chart.yaml
@@ -6,5 +6,5 @@ type: application
 version: 0.0.8
 appVersion: 7.40.0
 maintainers:
-  - name: sammc3
+  - name: sudermanjr
   - name: Azahorscak

--- a/incubator/datadog-apm/Chart.yaml
+++ b/incubator/datadog-apm/Chart.yaml
@@ -3,8 +3,8 @@ apiVersion: v2
 name: datadog-apm
 description: A modified chart that only installs the datadog-apm agent
 type: application
-version: 0.0.7
-appVersion: 7.32.4
+version: 0.0.8
+appVersion: 7.40.0
 maintainers:
   - name: sammc3
   - name: Azahorscak

--- a/incubator/datadog-apm/README.md
+++ b/incubator/datadog-apm/README.md
@@ -1,6 +1,6 @@
 # datadog-apm
 
-![Version: 0.0.7](https://img.shields.io/badge/Version-0.0.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.32.4](https://img.shields.io/badge/AppVersion-7.32.4-informational?style=flat-square)
+![Version: 0.0.8](https://img.shields.io/badge/Version-0.0.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.40.0](https://img.shields.io/badge/AppVersion-7.40.0-informational?style=flat-square)
 
 A modified chart that only installs the datadog-apm agent
 
@@ -8,7 +8,7 @@ A modified chart that only installs the datadog-apm agent
 
 | Name | Email | Url |
 | ---- | ------ | --- |
-| sammc3 |  |  |
+| sudermanjr |  |  |
 | Azahorscak |  |  |
 
 ## Values


### PR DESCRIPTION
**Why This PR?**
Bumps appVersion to use latest datadog agent image

Fixes #

**Changes**
Changes proposed in this pull request:

*Bumps appVersion to use latest datadog agent image
*Updates Codeowners in documentation.

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
