### PR TITLE
[stable/insights-agent]: FWI-3155: Add Trivy `unsetAWSRegionEnvVars` to help Trivy scan ECR in a different region

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.8.4
+## 2.9.1
 * Add `trivy.unsetAWSRegionEnvVars` chart value, to facilitate Trivy authenticating to ECR in a different region. More background can be found at https://github.com/aquasecurity/trivy/issues/1026
 
 ## 2.8.3

--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.8.4
+* Add `trivy.unsetAWSRegionEnvVars` chart value, to facilitate Trivy authenticating to ECR in a different region. More background can be found at https://github.com/aquasecurity/trivy/issues/1026
+
 ## 2.8.3
 * Update pluto to 5.11
 

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.8.3
+version: 2.8.4
 appVersion: 9.2.1
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.8.4
+version: 2.9.1
 appVersion: 9.2.1
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:

--- a/stable/insights-agent/README.md
+++ b/stable/insights-agent/README.md
@@ -104,6 +104,7 @@ Parameter | Description | Default
 `trivy.maxScansPerRun` | Maximum number of images to scan on a single run | 20
 `trivy.namespaceBlacklist` | Specifies which namespaces to not scan, takes an array of namespaces for example: `--set trivy.namespaceBlacklist="{kube-system,default}"` | nil
 `trivy.serviceAccount.annotations` | Annotations to add to the Trivy service account, e.g. `eks.amazonaws.com/role-arn: arn:aws:iam::ACCOUNT_ID:role/IAM_ROLE_NAME` for accessing private images | nil
+`trivy.unsetAWSRegionEnvVars` | Unset AWS_DEFAULT_REGION and AWS_REGION environment variables, as a work around to help trivy authenticate to ECR when the repository is in a different region than the calling cluster node. Ref: https://github.com/aquasecurity/trivy/issues/1026  | `false`
 `opa.role` | Specifies which ClusterRole to grant the OPA agent access to | view
 `opa.additionalAccess` | Specifies additional access to grant the OPA agent. This should contain an array of objects with each having an array of apiGroups, an array of resources, and an array of verbs. Just like a RoleBinding. | null
 `insights-agent` chart twice you will want to set this flag to `false` on *one* of the installs, doesn't matter which. | true

--- a/stable/insights-agent/templates/trivy/cronjob.yaml
+++ b/stable/insights-agent/templates/trivy/cronjob.yaml
@@ -65,6 +65,12 @@ spec:
             - name: NAMESPACE_BLACKLIST
               value: {{ join "," .Values.trivy.namespaceBlacklist | lower }}
             {{ end }}
+            {{ if .Values.trivy.unsetAWSRegionEnvVars }}
+            - name: AWS_DEFAULT_REGION
+              value: ""
+            - name: AWS_REGION
+              value: ""
+            {{ end }}
             {{ include "security-context" . | indent 12 | trim }}
           {{ include "uploaderContainer" . | indent 10 | trim }}
 {{- end -}}

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -254,6 +254,11 @@ trivy:
   maxScansPerRun: 20
   timeout: 2400
   insecureSSL: false
+  # trivy.unsetAWSRegionEnvVars -- Unset AWS_DEFAULT_REGION and AWS_REGION
+  # environment variables, as a work around to help trivy authenticate to ECR
+  # when the repository is in a different region than the calling cluster node.
+  # Ref: https://github.com/aquasecurity/trivy/issues/1026
+  unsetAWSRegionEnvVars: false
   image:
     repository: quay.io/fairwinds/fw-trivy
     tag: "0.22"


### PR DESCRIPTION
**Why This PR?**
[FWI-3155](https://fairwinds.myjetbrains.com/youtrack/issue/FWI-3155) - help Trivy authenticate to ECR when ECR is in a different region, by unsetting `AWS_DEFAULT_REGION` and `AWS_REGION` environment variables which in turn [keep the EKS pod identity WebHook from injecting those same variables](https://github.com/aquasecurity/trivy/issues/1026) based on the cluster's location.

A new `Trivy.unsetAWSRegionEnvVars` boolean chart value causes the above environment variables to be unset in the Trivy CronJob. I verified this unsets these environment variables when set statically in a "pretend Trivy" CronJob image, as a test.

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
