### PR TITLE
[stable/insights-agent]: Bump versions for trivy, polaris, opa, nova, and goldilocks

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,13 +1,13 @@
 # Changelog
 
-## 2.9.1
+## 2.9.2
 * Bump versions for trivy, polaris, opa, nova, and goldilocks
-
-## 2.9.0
-* Update Goldilocks to version 4.4.0
 
 ## 2.9.1
 * Add a `trivy.env` chart value to allow passing environment variables to the trivy container, as a map of `name: value`.
+
+## 2.9.0
+* Update Goldilocks to version 4.4.0
 
 ## 2.8.3
 * Update pluto to 5.11

--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 2.9.1
-* Bump trivy to use plugin 0.24 / upstream v0.34.0, and polaris to use v7.2.
+* Bump versions for trivy, polaris, opa, nova, and goldilocks
 
 ## 2.9.0
 * Update Goldilocks to version 4.4.0

--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+
+## 2.9.1
+* Bump trivy to use plugin 0.24 / upstream v0.34.0, and polaris to use v7.2.
+
 ## 2.9.0
 * Update Goldilocks to version 4.4.0
 

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.9.0
+version: 2.9.1
 appVersion: 9.2.1
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.9.1
+version: 2.9.2
 appVersion: 9.2.1
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -195,7 +195,7 @@ nova:
   logLevel: 3
   image:
     repository: quay.io/fairwinds/nova
-    tag: "3.4"
+    tag: "v3.4"
   resources:
     requests:
       cpu: 100m

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -106,7 +106,7 @@ goldilocks:
   timeout: 300
   image:
     repository: quay.io/fairwinds/goldilocks
-    tag: "v4.4.0"
+    tag: "v4.5"
   controller:
     flags:
       on-by-default: true
@@ -135,7 +135,7 @@ opa:
   timeout: 300
   image:
     repository: quay.io/fairwinds/fw-opa
-    tag: "2.1"
+    tag: "2.2"
   additionalAccess:
   # opa.defaultTargetResources -- A default list of Kubernetes targets to which OPA
   # policies will be applied.
@@ -195,7 +195,7 @@ nova:
   logLevel: 3
   image:
     repository: quay.io/fairwinds/nova
-    tag: "v3.4"
+    tag: "3.4"
   resources:
     requests:
       cpu: 100m

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -71,7 +71,7 @@ polaris:
     disabled: false
   image:
     repository: quay.io/fairwinds/polaris
-    tag: "7.1"
+    tag: "7.2"
   resources:
     requests:
       cpu: 100m
@@ -256,7 +256,7 @@ trivy:
   insecureSSL: false
   image:
     repository: quay.io/fairwinds/fw-trivy
-    tag: "0.22"
+    tag: "0.24"
   serviceAccount:
     annotations:
   resources:


### PR DESCRIPTION
**Why This PR?**
Bump to Trivy plugin 0.24 / upstream 0.34.0, and Polaris 7.2.

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
