### PR TITLE
[stable/vpa] Add missing resources for cleanup Job

### DIFF
--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 1.5.0
+version: 1.5.1
 appVersion: 0.11.0
 maintainers:
   - name: sudermanjr

--- a/stable/vpa/templates/admission-controller-cleanup.yaml
+++ b/stable/vpa/templates/admission-controller-cleanup.yaml
@@ -74,6 +74,8 @@ spec:
             echo "Unregistering VPA admission controller webhook"
             kubectl delete -n {{ .Release.Namespace}} mutatingwebhookconfiguration.v1beta1.admissionregistration.k8s.io vpa-webhook-config || true
             kubectl delete -n {{ .Release.Namespace}} secret vpa-tls-certs || true
+        resources:
+          {{- toYaml .Values.admissionController.certGen.resources | nindent 10 }}
       {{- with .Values.admissionController.cleanupOnDelete.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
**Why This PR?**
This PR fixes `admissionController.cleanupOnDelete.resources` not being used in the Chart while being described in the values and the README.

**Changes**
Changes proposed in this pull request:

* Add **`admissionController.cleanupOnDelete.resources` to the VPA Cleanup Job

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
