### PR TITLE
[incubator/datadog-apm] Use TopologySpreadConstraints

### DIFF
--- a/incubator/datadog-apm/Chart.yaml
+++ b/incubator/datadog-apm/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: datadog-apm
 description: A modified chart that only installs the datadog-apm agent
 type: application
-version: 0.0.8
+version: 0.0.9
 appVersion: 7.40.0
 maintainers:
   - name: sudermanjr

--- a/incubator/datadog-apm/README.md
+++ b/incubator/datadog-apm/README.md
@@ -1,6 +1,6 @@
 # datadog-apm
 
-![Version: 0.0.8](https://img.shields.io/badge/Version-0.0.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.40.0](https://img.shields.io/badge/AppVersion-7.40.0-informational?style=flat-square)
+![Version: 0.0.9](https://img.shields.io/badge/Version-0.0.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.40.0](https://img.shields.io/badge/AppVersion-7.40.0-informational?style=flat-square)
 
 A modified chart that only installs the datadog-apm agent
 

--- a/incubator/datadog-apm/templates/cluster-agent-deployment.yaml
+++ b/incubator/datadog-apm/templates/cluster-agent-deployment.yaml
@@ -218,18 +218,19 @@ spec:
       tolerations:
 {{ toYaml .Values.clusterAgent.tolerations | indent 8 }}
       {{- end }}
-      affinity:
-        podAntiAffinity:
-            preferredDuringSchedulingIgnoredDuringExecution:
-              - weight: 100
-                podAffinityTerm:
-                  labelSelector:
-                    matchExpressions:
-                      - key: app
-                        operator: In
-                        values:
-                          - {{ template "datadog-apm.fullname" . }}-cluster-agent
-                  topologyKey: "kubernetes.io/zone"
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: "topology.kubernetes.io/zone"
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: {{ template "datadog-apm.fullname" . }}-cluster-agent
+        - maxSkew: 1
+          topologyKey: "kubernetes.io/hostname"
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: {{ template "datadog-apm.fullname" . }}-cluster-agent
       nodeSelector:
         {{ template "label.os" . }}: {{ .Values.targetSystem }}
       {{- if .Values.clusterAgent.nodeSelector }}


### PR DESCRIPTION
**Why This PR?**
Use topology spread constraints in stead of anti-affinity. Spreads apm pods across topology zones as well as hosts.

Fixes #

**Changes**
Changes proposed in this pull request:

*Use topologySpreadConstraints in place of Anti-affinity rule
*

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
