### PR TITLE
[stable/fairwinds-insights] disable weekly digest emails

### DIFF
--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.7.5
+* Disable weekly digest emails
+
 ## 0.7.4
 * Update application version to 10.7. [See the release notes for more details](https://insights.docs.fairwinds.com/release-notes)
 

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "10.7"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 0.7.4
+version: 0.7.5
 maintainers:
 - name: rbren
 - name: mhoss019

--- a/stable/fairwinds-insights/README.md
+++ b/stable/fairwinds-insights/README.md
@@ -96,7 +96,7 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | aggregateCronjob.schedules | list | `[{"cron":"5 0/2 * * *","interval":"120m","name":"bi-hourly"}]` | CRON schedules for the Workload Metrics aggregation job. |
 | aggregateCronjob.securityContext.runAsUser | int | `10324` | The user ID to run the Workload Metrics aggregation job under. |
 | emailCronjob.resources | object | `{"limits":{"cpu":"500m","memory":"1024Mi"},"requests":{"cpu":"80m","memory":"128Mi"}}` | Resources for the Action Items email job. |
-| emailCronjob.schedules | list | `[{"cron":"0 16 * * 1","interval":"168h","name":"weekly-email"}]` | CRON schedules for the Action Items email job. |
+| emailCronjob.schedules | list | `[]` | CRON schedules for the Action Items email job. |
 | emailCronjob.securityContext.runAsUser | int | `10324` | The user ID to run the email job under. |
 | databaseCleanupCronjob.enabled | bool | `true` | Enable database cleanup true by default |
 | databaseCleanupCronjob.resources | object | `{"limits":{"cpu":"500m","memory":"1024Mi"},"requests":{"cpu":"80m","memory":"128Mi"}}` | Resources for the database cleanup job. |

--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -323,10 +323,7 @@ emailCronjob:
       cpu: 80m
       memory: 128Mi
   # -- CRON schedules for the Action Items email job.
-  schedules:
-    - name: weekly-email
-      interval: 168h
-      cron: "0 16 * * 1"
+  schedules: []
   securityContext:
     # -- The user ID to run the email job under.
     runAsUser: 10324


### PR DESCRIPTION
**Why This PR?**

**Changes**
Changes proposed in this pull request:
* Disable weekly digest emails for insights

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
