### PR TITLE
[stable/fairwinds-insights] Add timeout to health probes

### DIFF
--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 0.7.6
+* Increase timeout on health probes
 
 ## 0.7.4
 * Update application version to 10.7. [See the release notes for more details](https://insights.docs.fairwinds.com/release-notes)

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "10.7"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 0.7.4
+version: 0.7.6
 maintainers:
 - name: rbren
 - name: mhoss019

--- a/stable/fairwinds-insights/templates/deployment-api.yaml
+++ b/stable/fairwinds-insights/templates/deployment-api.yaml
@@ -43,10 +43,12 @@ spec:
             httpGet:
               path: /health
               port: http
+              timeoutSeconds: 5
           readinessProbe:
             httpGet:
               path: /health
               port: http
+              timeoutSeconds: 5
           volumeMounts:
           - name: tmp
             mountPath: /tmp


### PR DESCRIPTION
**Why This PR?**
We're seeing occasional timeouts on the health probes. Increasing the timeout from 1s to 5s should help

**Changes**
Changes proposed in this pull request:
* liveness and readiness probe timeout increased from 1s to 5s
*

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
