### PR TITLE
[stable/insights] FWI-3207 - add rbac secret mgnt

### DIFF
--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog
 
-## 0.7.6
+## 0.7.7
 * Add secrets RBAC capabilities (get/create/delete) to repo-scan-job service-account
+
+## 0.7.6
+* Update application version to 10.8. [See the release notes for more details](https://insights.docs.fairwinds.com/release-notes)
 
 ## 0.7.5
 * Disable weekly digest emails

--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.7.6
+* Add secrets RBAC capabilities (get/create/delete) to repo-scan-job service-account
+
 ## 0.7.5
 * Disable weekly digest emails
 

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "10.8"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 0.7.6
+version: 0.7.7
 maintainers:
 - name: rbren
 - name: mhoss019

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "10.7"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 0.7.5
+version: 0.7.6
 maintainers:
 - name: rbren
 - name: mhoss019

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "10.7"
+appVersion: "10.8"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
 version: 0.7.6

--- a/stable/fairwinds-insights/templates/rbac-repo-scan-job.yaml
+++ b/stable/fairwinds-insights/templates/rbac-repo-scan-job.yaml
@@ -25,6 +25,9 @@ rules:
 - apiGroups: [""]
   resources: ["events"]
   verbs: ["list", "get"]
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["create", "delete", "get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/stable/fairwinds-insights/templates/rbac-repo-scan-job.yaml
+++ b/stable/fairwinds-insights/templates/rbac-repo-scan-job.yaml
@@ -27,7 +27,7 @@ rules:
   verbs: ["list", "get"]
 - apiGroups: [""]
   resources: ["secrets"]
-  verbs: ["create", "delete", "get"]
+  verbs: ["create", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
**Why This PR?**
Add secret management (get, create, delete) for repo-scan-job service-account

Fixes internal FWI-3207

**Changes**
Changes proposed in this pull request:

* add get/create/delete secrets to repo-scan-job service-account

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
