### PR TITLE
[stable/goldilocks]: Add `controller.rbac.extraClusterRoleBindings`

### DIFF
--- a/stable/goldilocks/Chart.yaml
+++ b/stable/goldilocks/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 appVersion: "v4.5.1"
-version: 6.3.2
+version: 6.3.3
 description: |
   A Helm chart for running Fairwinds Goldilocks. See https://github.com/FairwindsOps/goldilocks
 name: goldilocks

--- a/stable/goldilocks/README.md
+++ b/stable/goldilocks/README.md
@@ -70,6 +70,7 @@ This will completely remove the VPA and then re-install it using the new method.
 | controller.rbac.create | bool | `true` | If set to true, rbac resources will be created for the controller |
 | controller.rbac.enableArgoproj | bool | `true` | If set to true, the clusterrole will give access to argoproj.io resources |
 | controller.rbac.extraRules | list | `[]` | Extra rbac rules for the controller clusterrole |
+| controller.rbac.extraClusterRoleBindings | list | `[]` | A list of ClusterRoles for which ClusterRoleBindings will be created for the ServiceAccount, if enabled |
 | controller.serviceAccount.create | bool | `true` | If true, a service account will be created for the controller. If set to false, you must set `controller.serviceAccount.name` |
 | controller.serviceAccount.name | string | `nil` | The name of an existing service account to use for the controller. Combined with `controller.serviceAccount.create` |
 | controller.flags | object | `{}` | A map of additional flags to pass to the controller |

--- a/stable/goldilocks/ci/test-values.yaml
+++ b/stable/goldilocks/ci/test-values.yaml
@@ -27,12 +27,12 @@ controller:
           - "get"
           - "list"
           - "watch"
+    extraClusterRoleBindings:
+      - view
 
 dashboard:
   basePath: goldilocks
   ingress:
-    extraClusterRoleBindings:
-      - view
     enabled: true
     hosts:
       - host: goldilocks.example.local

--- a/stable/goldilocks/ci/test-values.yaml
+++ b/stable/goldilocks/ci/test-values.yaml
@@ -31,6 +31,8 @@ controller:
 dashboard:
   basePath: goldilocks
   ingress:
+    extraClusterRoleBindings:
+      - view
     enabled: true
     hosts:
       - host: goldilocks.example.local

--- a/stable/goldilocks/templates/controller-clusterrolebinding.yaml
+++ b/stable/goldilocks/templates/controller-clusterrolebinding.yaml
@@ -18,7 +18,7 @@ subjects:
     name: {{ include "goldilocks.fullname" . }}-controller
     namespace: {{ .Release.Namespace }}
 
-    {{- range $.Values.controller.rbac.extraClusterRoleBindings }}
+{{- range $.Values.controller.rbac.extraClusterRoleBindings }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/stable/goldilocks/templates/controller-clusterrolebinding.yaml
+++ b/stable/goldilocks/templates/controller-clusterrolebinding.yaml
@@ -17,4 +17,27 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "goldilocks.fullname" . }}-controller
     namespace: {{ .Release.Namespace }}
+
+    {{- range $.Values.controller.rbac.extraClusterRoleBindings }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "goldilocks.fullname" $ }}-controller-{{ . }}
+  labels:
+    app.kubernetes.io/name: {{ include "goldilocks.name" $ }}
+    helm.sh/chart: {{ include "goldilocks.chart" $ }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+    app.kubernetes.io/component: controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "goldilocks.fullname" $ }}-controller
+    namespace: {{ $.Release.Namespace }}
 {{- end }}
+{{- end }}
+

--- a/stable/goldilocks/values.yaml
+++ b/stable/goldilocks/values.yaml
@@ -37,6 +37,8 @@ controller:
     enableArgoproj: true
     # controller.rbac.extraRules -- Extra rbac rules for the controller clusterrole
     extraRules: []
+    # controller.rbac.extraClusterRoleBindings -- A list of ClusterRoles for which ClusterRoleBindings will be created for the ServiceAccount, if enabled
+    extraClusterRoleBindings: []
   serviceAccount:
     # controller.serviceAccount.create -- If true, a service account will be created for the controller. If set to false, you must set `controller.serviceAccount.name`
     create: true


### PR DESCRIPTION
**Why This PR?**
Add the ability to specify additional ClusterRoleBindings for the Goldilocks cluster role. This helps grant access to resources, E.G. via the built-in `view` ClusterRole.


**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
