### PR TITLE
[stable/polaris] add support for configUrl

### DIFF
--- a/stable/polaris/Chart.yaml
+++ b/stable/polaris/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Validation of best practices in your Kubernetes clusters
 name: polaris
-version: 5.6.1
+version: 5.6.2
 appVersion: "7.1"
 icon: https://raw.githubusercontent.com/FairwindsOps/polaris/master/pkg/dashboard/assets/favicon-32x32.png
 maintainers:

--- a/stable/polaris/Chart.yaml
+++ b/stable/polaris/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Validation of best practices in your Kubernetes clusters
 name: polaris
-version: 5.6.2
+version: 5.7.0
 appVersion: "7.1"
 icon: https://raw.githubusercontent.com/FairwindsOps/polaris/master/pkg/dashboard/assets/favicon-32x32.png
 maintainers:

--- a/stable/polaris/README.md
+++ b/stable/polaris/README.md
@@ -36,6 +36,7 @@ the 0.10.0 version of this chart will only work on kubernetes 1.14.0+
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | config | string | `nil` | The [polaris configuration](https://github.com/FairwindsOps/polaris#configuration). If not provided then the [default](https://github.com/FairwindsOps/polaris/blob/master/examples/config.yaml) config from Polaris is used. |
+| configUrl | string | `nil` | Use a config from an accessible URL source.  NOTE: `config` & `configUrl` are mutually exclusive.  Setting `configURL` will take precedence over `config`.  Only one may be used. configUrl: https://example.com/config.yaml |
 | image.repository | string | `"quay.io/fairwinds/polaris"` | Image repo |
 | image.tag | string | `""` | The Polaris Image tag to use. Defaults to the Chart's AppVersion |
 | image.pullPolicy | string | `"Always"` | Image pull policy |

--- a/stable/polaris/templates/configmap.yaml
+++ b/stable/polaris/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.configUrl }}
 {{- with .Values.config }}
 apiVersion: v1
 kind: ConfigMap
@@ -11,4 +12,5 @@ metadata:
 data:
   config.yaml: |
     {{- toYaml . | nindent 4 }}
+{{- end }}
 {{- end }}

--- a/stable/polaris/templates/dashboard.deployment.yaml
+++ b/stable/polaris/templates/dashboard.deployment.yaml
@@ -41,9 +41,14 @@ spec:
       - command:
         - polaris
         - dashboard
+        {{- if .Values.configUrl }}
+        - --config
+        - {{ .Values.configUrl | quote }}
+        {{- else }}
         {{- with .Values.config }}
         - --config
         - /opt/app/config.yaml
+        {{- end }}
         {{- end }}
         {{- with .Values.dashboard.basePath }}
         - --base-path
@@ -93,12 +98,14 @@ spec:
         securityContext:
         {{- toYaml . | nindent 12 }}
         {{- end }}                 
+        {{- if not .Values.configUrl }}
         {{- with .Values.config }}
         volumeMounts:
         - name: config
           mountPath: /opt/app/config.yaml
           subPath: config.yaml
           readOnly: true
+        {{- end }}
         {{- end }}
       {{- with .Values.dashboard.extraContainers }}
       {{- toYaml . | nindent 6 }}

--- a/stable/polaris/values.yaml
+++ b/stable/polaris/values.yaml
@@ -1,6 +1,10 @@
 # config -- The [polaris configuration](https://github.com/FairwindsOps/polaris#configuration). If not provided then the [default](https://github.com/FairwindsOps/polaris/blob/master/examples/config.yaml) config from Polaris is used.
 config: null
 
+# configUrl -- Use a config from an accessible URL source.  NOTE: `config` & `configUrl` are mutually exclusive.  Setting `configURL` will take precedence over `config`.  Only one may be used.
+# configUrl: https://example.com/config.yaml
+configUrl: null
+
 image:
   # image.repository -- Image repo
   repository: quay.io/fairwinds/polaris


### PR DESCRIPTION
**Why This PR?**
This provides the ability to supply a URL to a Polaris configuration that is hosted & maintained elsewhere (eg, Git repo) rather than hardcoding the config into the Helm values themselves.  

Setting `configUrl` will take precedence over setting `config` so that if both are set in the values only the URL will be used (`--config` flag in Polaris Dashboard deployment is set to the URL) & the `config` values will not be used at all (ConfigMap will not be created or mounted into the Polaris Dashboard deployment).

Fixes #1038 

**Changes**
Changes proposed in this pull request:

* Addition of `configUrl` value that can be used to point to a web-hosted Polaris configuration

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
