### PR TITLE
[incubator/basic-demo] Update some yaml for later versions of kube

### DIFF
--- a/.helmdocsignore
+++ b/.helmdocsignore
@@ -1,5 +1,4 @@
 incubator/autospotting
-incubator/basic-demo
 incubator/capsize
 incubator/custom-iptables
 incubator/fluentd

--- a/incubator/basic-demo/Chart.yaml
+++ b/incubator/basic-demo/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Basic Kubernetes Demo Chart
 name: basic-demo
-version: 0.5.2
+version: 0.6.0
 maintainers:
   - name: sudermanjr

--- a/incubator/basic-demo/README.md
+++ b/incubator/basic-demo/README.md
@@ -10,32 +10,43 @@ Due to the [future deprecation](https://kubernetes.io/blog/2019/07/18/api-deprec
 
 ## Values
 
-| Parameter | Description | Default | Required |
-| --------- | ----------- | ------- | -------- |
-| `affinity` | Pod Affinity  | `{}` | no |
-| `demo.metadata` | Flavor text on demo app page  | `ehazlett/docker-demo - Chart by ReactiveOps` | |
-| `demo.refreshInterval` | How often the demo frontend should refresh (ms)  | `500` | yes |
-| `demo.title` | Title on the demo app page | `Kuberneteseckoner Demo` | no |
-| `hpa.max` | Maximum replicas  | `20` | yes |
-| `hpa.min` | Minimum replicas  | `3` | yes |
-| `hpa.cpuTarget` | CPU scaling target if not using custom metrics | `60` | no |
-| `hpa.customMetric.enabled` | Enable scaling on custom metrics | `false` | no |
-| `hpa.customMetric.metric` | Custom metric to scale on | `cpu` | yes |
-| `hpa.customMetric.target` | HPA custom metric target  | `30m` | yes |
-| `image.pullPolicy` | Pull Policy  | `Always` | yes |
-| `image.repository` | Image Repository  | `quay.io/fairwinds/docker-demo` | yes |
-| `image.tag` | Image Tag  | `latest` | yes |
-| `ingress.annotations` | Annotations on Ingress  | `{}` | no |
-| `ingress.enabled` | Whether or not to enable the ingress  | `False` | no |
-| `ingress.hosts` | Hostnames of ingress  | `chart-example.local` | no |
-| `ingress.paths` | Ingress Paths  | `[]` | no |
-| `ingress.tls` | Ingress TLS Block  | `[]` | no |
-| `nodeSelector` |  | `{}` | no |
-| `resources.limits.cpu` |  | `100m` | yes |
-| `resources.limits.memory` |  | `128Mi` | yes |
-| `resources.requests.cpu` |  | `100m` | yes |
-| `resources.requests.memory` |  | `128Mi` | yes |
-| `service.port` |  | `80` | no |
-| `service.type` |  | `ClusterIP` | yes |
-| `tolerations` |  | `[]` | no |
-| `linkerd.serviceProfile` | Install a linkerd2 serviceprofile with the app | `false` | no |
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| demo.refreshInterval | int | `500` |  |
+| demo.title | string | `"Kubernetes Demo"` |  |
+| demo.metadata | string | `""` |  |
+| hpa.enabled | bool | `true` |  |
+| hpa.min | int | `3` |  |
+| hpa.max | int | `20` |  |
+| hpa.cpuTarget | int | `60` |  |
+| hpa.customMetric.enabled | bool | `false` |  |
+| hpa.customMetric.metric | string | `"somecustommetricname"` |  |
+| hpa.customMetric.target | int | `30` |  |
+| vpa.enabled | bool | `false` |  |
+| vpa.updateMode | string | `"Off"` |  |
+| pdb.enabled | bool | `true` |  |
+| pdb.maxUnavailable | int | `1` |  |
+| image.repository | string | `"quay.io/fairwinds/docker-demo"` |  |
+| image.tag | string | `"latest"` |  |
+| image.pullPolicy | string | `"Always"` |  |
+| nameOverride | string | `""` |  |
+| fullnameOverride | string | `""` |  |
+| service.type | string | `"ClusterIP"` |  |
+| service.port | int | `80` |  |
+| ingress.enabled | bool | `false` |  |
+| ingress.ingressClassName | string | `""` |  |
+| ingress.annotations | object | `{}` |  |
+| ingress.paths | list | `[]` |  |
+| ingress.hosts[0] | string | `"chart-example.local"` |  |
+| ingress.tls | list | `[]` |  |
+| resources.limits.cpu | string | `"70m"` |  |
+| resources.limits.memory | string | `"131072k"` |  |
+| resources.requests.cpu | string | `"10m"` |  |
+| resources.requests.memory | string | `"131072k"` |  |
+| nodeSelector | object | `{}` |  |
+| tolerations | list | `[]` |  |
+| affinity | object | `{}` |  |
+| linkerd.serviceProfile | bool | `false` |  |
+| linkerd.enableRetry | bool | `true` |  |

--- a/incubator/basic-demo/README.md.gotmpl
+++ b/incubator/basic-demo/README.md.gotmpl
@@ -1,0 +1,13 @@
+# Basic Kubernetes Demo
+
+Runs a frontend that shows which pods it is connecting to.  Good for scaling demos.
+
+Credit for the app goes to [ehazlett](https://github.com/ehazlett/docker-demo)
+
+## A Note on Chart Version 0.3.0+
+
+Due to the [future deprecation](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/) of various `extensions/v1beta1` API's, the 0.3.0 version of this chart will only work on kubernetes 1.14.0+
+
+## Values
+
+{{ template "chart.valuesSection" . }}

--- a/incubator/basic-demo/templates/hpa.yaml
+++ b/incubator/basic-demo/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.hpa.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "basic-demo.fullname" . }}

--- a/incubator/basic-demo/templates/pdb.yaml
+++ b/incubator/basic-demo/templates/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.pdb.enabled }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "basic-demo.fullname" . }}


### PR DESCRIPTION
**Why This PR?**
There were some old apiVersions for pdb and HPA in the chart


**Changes**
Changes proposed in this pull request:

* update pdb to policy v1
* update hpa to autoscaling v2

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.