### PR TITLE
[stable/insights-admission]: Bump the insights-admission `app` to v1.9

### DIFF
--- a/stable/insights-admission/CHANGELOG.md
+++ b/stable/insights-admission/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.5.0
+* Bump insights-admission to version 1.9
+
 ## 1.4.3
 * Add a MutatingWebhookConfiguration resource, enabled via the `webhookConfig.mutating.enable` chart value.
 

--- a/stable/insights-admission/Chart.yaml
+++ b/stable/insights-admission/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: insights-admission
 description: A Validating Webhook Admission Controller that utilizes Fairwinds Insights.
 type: application
-version: 1.4.3
-appVersion: "1.8"
+version: 1.5.0
+appVersion: "1.9"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-admission/icon.png
 maintainers:
 - name: rbren


### PR DESCRIPTION
**Why This PR?**
Bump the insights-admission app version to 1.9.

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
