### PR TITLE
[stable/goldilocks] Update metrics-server dependency

### DIFF
--- a/stable/goldilocks/Chart.yaml
+++ b/stable/goldilocks/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 appVersion: "v4.5.1"
-version: 6.3.3
+version: 6.4.0
 description: |
   A Helm chart for running Fairwinds Goldilocks. See https://github.com/FairwindsOps/goldilocks
 name: goldilocks

--- a/stable/goldilocks/Chart.yaml
+++ b/stable/goldilocks/Chart.yaml
@@ -19,6 +19,6 @@ dependencies:
   repository: https://charts.fairwinds.com/stable
   condition: vpa.enabled
 - name: metrics-server
-  version: 5.11.4
+  version: 6.2.4
   repository: https://charts.bitnami.com/bitnami
   condition: metrics-server.enabled


### PR DESCRIPTION
**Why This PR?**
Old one doesn't seem to exist in bitnami anymore

**Changes**
Changes proposed in this pull request:

* Update metrics-server to 6.2.4

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.