### PR TITLE
[stable/insights-agent]: Bump nova to v3.5 and insights-admission `app` to v1.9

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.10.0
+* BUmp insights-admission to chart 1.5.* (to use app 1.9)
+
 ## 2.9.4
 * Bumped workload version for saving Ingresses information
 

--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.10.0
 * BUmp insights-admission to chart 1.5.* (to use app 1.9)
+* Bump nova to 3.5
 
 ## 2.9.4
 * Bumped workload version for saving Ingresses information

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.9.4
+version: 2.10.0
 appVersion: 9.2.1
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:

--- a/stable/insights-agent/requirements.yaml
+++ b/stable/insights-agent/requirements.yaml
@@ -9,7 +9,7 @@ dependencies:
   condition: prometheus-metrics.installPrometheusServer
 - name: insights-admission
   repository: https://charts.fairwinds.com/stable
-  version: '1.4.*'
+  version: '1.5.*'
   condition: admission.enabled
 - name: falco
   repository: https://falcosecurity.github.io/charts

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -198,7 +198,7 @@ nova:
   logLevel: 3
   image:
     repository: quay.io/fairwinds/nova
-    tag: "v3.4"
+    tag: "v3.5"
   resources:
     requests:
       cpu: 100m


### PR DESCRIPTION
* Update the insights-admission chart requirement to 1.5, to use the insights-admission plugin 1.9.
* Bump nova to v3.5 RE: CVEs

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
