### PR TITLE
Fix #1059 - Add additionalExemptions

### DIFF
--- a/stable/polaris/README.md
+++ b/stable/polaris/README.md
@@ -36,6 +36,7 @@ the 0.10.0 version of this chart will only work on kubernetes 1.14.0+
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | config | string | `nil` | The [polaris configuration](https://github.com/FairwindsOps/polaris#configuration). If not provided then the [default](https://github.com/FairwindsOps/polaris/blob/master/examples/config.yaml) config from Polaris is used. |
+| additionExemptions | string | `nil` | List of additional exemptions to append to the exemptions given in `config` |
 | configUrl | string | `nil` | Use a config from an accessible URL source.  NOTE: `config` & `configUrl` are mutually exclusive.  Setting `configURL` will take precedence over `config`.  Only one may be used. configUrl: https://example.com/config.yaml |
 | image.repository | string | `"quay.io/fairwinds/polaris"` | Image repo |
 | image.tag | string | `""` | The Polaris Image tag to use. Defaults to the Chart's AppVersion |

--- a/stable/polaris/ci/merge-values.yaml
+++ b/stable/polaris/ci/merge-values.yaml
@@ -1,0 +1,66 @@
+# Based upon https://github.com/FairwindsOps/polaris/blob/master/examples/config.yaml
+nameOverride: polaris
+
+config:
+  checks:
+    # reliability
+    deploymentMissingReplicas: warning
+    priorityClassNotSet: ignore
+    tagNotSpecified: danger
+    pullPolicyNotAlways: warning
+    readinessProbeMissing: warning
+    livenessProbeMissing: warning
+    metadataAndNameMismatched: ignore
+    pdbDisruptionsIsZero: warning
+    missingPodDisruptionBudget: ignore
+    topologySpreadConstraint: warning
+
+    # efficiency
+    cpuRequestsMissing: warning
+    cpuLimitsMissing: warning
+    memoryRequestsMissing: warning
+    memoryLimitsMissing: warning
+    # security
+    automountServiceAccountToken: ignore
+    hostIPCSet: danger
+    hostPIDSet: danger
+    linuxHardening: warning
+    missingNetworkPolicy: ignore
+    notReadOnlyRootFilesystem: warning
+    privilegeEscalationAllowed: danger
+    runAsRootAllowed: danger
+    runAsPrivileged: danger
+    dangerousCapabilities: danger
+    insecureCapabilities: warning
+    hostNetworkSet: danger
+    hostPortSet: warning
+    tlsSettingsMissing: warning
+    # These are initially warning and will later be promoted to danger.
+    sensitiveContainerEnvVar: warning
+    sensitiveConfigmapContent: warning
+    clusterrolePodExecAttach: warning
+    rolePodExecAttach: warning
+    clusterrolebindingPodExecAttach: warning
+    rolebindingClusterRolePodExecAttach: warning
+    rolebindingRolePodExecAttach: warning
+    clusterrolebindingClusterAdmin: warning
+    rolebindingClusterAdminClusterRole: warning
+    rolebindingClusterAdminRole: warning
+
+  mutations:
+    - pullPolicyNotAlways
+
+  exemptions:
+    - namespace: kube-system
+      controllerNames:
+        - coredns
+      rules:
+        - automountServiceAccountToken
+        - missingNetworkPolicy
+
+additionalExemptions:
+  - namespace: foo
+    containerName:
+      - bar
+    rules:
+      - privilegeEscalationAllowed

--- a/stable/polaris/templates/configmap.yaml
+++ b/stable/polaris/templates/configmap.yaml
@@ -1,16 +1,20 @@
 {{- if not .Values.configUrl }}
-{{- with .Values.config }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "polaris.fullname" $ }}
-  {{- if $.Values.templateOnly }}
-  namespace: {{ $.Release.Namespace }}
+  name: {{ include "polaris.fullname" . }}
+  {{- if .Values.templateOnly }}
+  namespace: {{ .Release.Namespace }}
   {{- end }}
   labels:
-    {{- include "polaris.labels" $ | nindent 4 }}
+    {{- include "polaris.labels" . | nindent 4 }}
 data:
   config.yaml: |
-    {{- toYaml . | nindent 4 }}
-{{- end }}
+    {{- range $key, $value := .Values.config }}
+    {{ $key }}:
+    {{- toYaml $value | nindent 6 }}
+    {{- if and (eq $key "exemptions") ($.Values.additionalExemptions) }}
+    {{- toYaml $.Values.additionalExemptions | nindent 6 }}
+    {{- end }}
+    {{- end }}
 {{- end }}

--- a/stable/polaris/values.yaml
+++ b/stable/polaris/values.yaml
@@ -1,5 +1,6 @@
 # config -- The [polaris configuration](https://github.com/FairwindsOps/polaris#configuration). If not provided then the [default](https://github.com/FairwindsOps/polaris/blob/master/examples/config.yaml) config from Polaris is used.
 config: null
+additionExemptions: null
 
 # configUrl -- Use a config from an accessible URL source.  NOTE: `config` & `configUrl` are mutually exclusive.  Setting `configURL` will take precedence over `config`.  Only one may be used.
 # configUrl: https://example.com/config.yaml

--- a/stable/polaris/values.yaml
+++ b/stable/polaris/values.yaml
@@ -1,5 +1,7 @@
 # config -- The [polaris configuration](https://github.com/FairwindsOps/polaris#configuration). If not provided then the [default](https://github.com/FairwindsOps/polaris/blob/master/examples/config.yaml) config from Polaris is used.
 config: null
+
+# additionExemptions -- List of additional exemptions to append to the exemptions given in `config`
 additionExemptions: null
 
 # configUrl -- Use a config from an accessible URL source.  NOTE: `config` & `configUrl` are mutually exclusive.  Setting `configURL` will take precedence over `config`.  Only one may be used.


### PR DESCRIPTION
**Why This PR?**
Support default exemptions and additional exemptions
Fixes #1059 

**Changes**
Changes proposed in this pull request:

* The merge-values.yaml is just for testing the chart
* Helm merge function is not used as it does not merge lists. The implementation therefore uses a range loop over the `config` element.

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [ ] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
