### PR TITLE
[stable/polaris]: nodeselector should be set to linux by default

### DIFF
--- a/stable/polaris/Chart.yaml
+++ b/stable/polaris/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Validation of best practices in your Kubernetes clusters
 name: polaris
-version: 5.7.0
+version: 5.7.1
 appVersion: "7.1"
 icon: https://raw.githubusercontent.com/FairwindsOps/polaris/master/pkg/dashboard/assets/favicon-32x32.png
 maintainers:

--- a/stable/polaris/templates/dashboard.deployment.yaml
+++ b/stable/polaris/templates/dashboard.deployment.yaml
@@ -112,9 +112,13 @@ spec:
       {{- end }}
       serviceAccountName: {{ template "polaris.serviceAccountName" . }}
       nodeSelector:
+      {{- if .Values.dashboard.nodeSelector }}
       {{- with .Values.dashboard.nodeSelector }}
 {{ toYaml . | indent 8 }}
-        {{- end }}
+      {{- end }}
+      {{- else }}
+        kubernetes.io/os: linux
+      {{- end }}
       tolerations:
       {{- with .Values.dashboard.tolerations }}
 {{ toYaml . | indent 6 }}

--- a/stable/polaris/templates/webhook.deployment.yaml
+++ b/stable/polaris/templates/webhook.deployment.yaml
@@ -99,9 +99,13 @@ spec:
       priorityClassName: {{ .Values.webhook.priorityClassName | quote }}
       {{- end }}
       nodeSelector:
-      {{- with .Values.webhook.nodeSelector }}
+      {{- if .Values.dashboard.nodeSelector }}
+      {{- with .Values.dashboard.nodeSelector }}
 {{ toYaml . | indent 8 }}
-        {{- end }}
+      {{- end }}
+      {{- else }}
+        kubernetes.io/os: linux
+      {{- end }}
       tolerations:
       {{- with .Values.webhook.tolerations }}
 {{ toYaml . | indent 6 }}


### PR DESCRIPTION
**Why This PR?**

Following [getting started guide](https://polaris.docs.fairwinds.com/dashboard/#installation) for polaris aka

```bash
helm repo add fairwinds-stable https://charts.fairwinds.com/stable
helm upgrade --install polaris fairwinds-stable/polaris --namespace polaris --create-namespace
```

Got an issue, because in our cluster there is an windows node for experiments and it is usually empty Kubernetes tries to deploy things to it, as a result whenever chart has no node selector configured and there is no Windows images deployments failing

Fixes - https://github.com/FairwindsOps/polaris/issues/892

**Changes**

* added fallback value `kubernetes.io/os: linux` to both dashboard and webhook deployment
* changes are reverse compatible, e.g. if user provides node selector via values it will be used instead so no braking changes here

**Checklist:**

* [+] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [+] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [-] Any new values are backwards compatible and/or have sensible default.
* [-] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.

**Notes for checklist:**

- ~~this change does not reserve new release so not touching `Chart.yaml`~~
- no new values have been added only modification of defaults so no changes to here as well

**Other notes:**

Originally comes from [here](https://github.com/FairwindsOps/polaris/issues/892) by suggestion of @sudermanjr 