### PR TITLE
[stable/insights-agent] Install jq during kubectl download

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog
 
+## 2.10.1
+* Add `jq` to download-kubectl.sh
+
 ## 2.10.0
-* BUmp insights-admission to chart 1.5.* (to use app 1.9)
+* Bump insights-admission to chart 1.5.* (to use app 1.9)
 * Bump nova to 3.5
 
 ## 2.9.4

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.10.0
+version: 2.10.1
 appVersion: 9.2.1
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:

--- a/stable/insights-agent/download-kubectl.sh
+++ b/stable/insights-agent/download-kubectl.sh
@@ -5,6 +5,8 @@ set -eo pipefail
 kubectl_os=$(uname -s | awk '{print tolower($0)}' || echo linux)
 kubectl_arch=$(uname -m | awk '{print tolower($0)}' |sed -e 's/aarch/arm/' -e 's/x86_/amd/' || echo amd64)
 
+sudo apt-get install -y jq
+
 mkdir /tmp/bin
 export PATH=$PATH:/tmp/bin
 export SERVICEACCOUNT=/var/run/secrets/kubernetes.io/serviceaccount

--- a/stable/insights-agent/download-kubectl.sh
+++ b/stable/insights-agent/download-kubectl.sh
@@ -5,7 +5,7 @@ set -eo pipefail
 kubectl_os=$(uname -s | awk '{print tolower($0)}' || echo linux)
 kubectl_arch=$(uname -m | awk '{print tolower($0)}' |sed -e 's/aarch/arm/' -e 's/x86_/amd/' || echo amd64)
 
-sudo apt-get install -y jq
+apt-get install -y jq
 
 mkdir /tmp/bin
 export PATH=$PATH:/tmp/bin


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

`jq` appears to be missing in the bitnami/kubectl image

**Changes**
Changes proposed in this pull request:

`sudo apt-get install -y jq`

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [ ] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
