### PR TITLE
[stable/insights-agent]: Update Goldilocks, Nova, Pluto, and Polaris

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.10.1
+* Update Goldilocks, Nova, Pluto, and Polaris
+
 ## 2.10.0
 * BUmp insights-admission to chart 1.5.* (to use app 1.9)
 * Bump nova to 3.5

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.10.0
+version: 2.10.1
 appVersion: 9.2.1
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -71,7 +71,7 @@ polaris:
     disabled: false
   image:
     repository: quay.io/fairwinds/polaris
-    tag: "7.2"
+    tag: "7.3"
   resources:
     requests:
       cpu: 100m
@@ -106,7 +106,7 @@ goldilocks:
   timeout: 300
   image:
     repository: quay.io/fairwinds/goldilocks
-    tag: "v4.5"
+    tag: "v4.6"
   controller:
     flags:
       on-by-default: true
@@ -198,7 +198,7 @@ nova:
   logLevel: 3
   image:
     repository: quay.io/fairwinds/nova
-    tag: "v3.5"
+    tag: "v3.6"
   resources:
     requests:
       cpu: 100m
@@ -276,7 +276,7 @@ pluto:
   targetVersions: ""
   image:
     repository: us-docker.pkg.dev/fairwinds-ops/oss/pluto
-    tag: "v5.11"
+    tag: "v5.12"
   resources:
     requests:
       cpu: 100m


### PR DESCRIPTION
Update versions of Goldilocks, Nova, Pluto, and Polaris used by insights-agent.


**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
