### PR TITLE
Revert "[stable/insights-agent]: Update Goldilocks, Nova, Pluto, and Polaris"

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,8 +1,5 @@
 # Changelog
 
-## 2.10.1
-* Update Goldilocks, Nova, Pluto, and Polaris
-
 ## 2.10.0
 * BUmp insights-admission to chart 1.5.* (to use app 1.9)
 * Bump nova to 3.5

--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2.10.2
+* Revert v2.10.1
+
+## 2.10.1
+* Update Goldilocks, Nova, Pluto, and Polaris
+
+
 ## 2.10.0
 * BUmp insights-admission to chart 1.5.* (to use app 1.9)
 * Bump nova to 3.5

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.10.1
+version: 2.10.0
 appVersion: 9.2.1
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.10.0
+version: 2.10.2
 appVersion: 9.2.1
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -71,7 +71,7 @@ polaris:
     disabled: false
   image:
     repository: quay.io/fairwinds/polaris
-    tag: "7.3"
+    tag: "7.2"
   resources:
     requests:
       cpu: 100m
@@ -106,7 +106,7 @@ goldilocks:
   timeout: 300
   image:
     repository: quay.io/fairwinds/goldilocks
-    tag: "v4.6"
+    tag: "v4.5"
   controller:
     flags:
       on-by-default: true
@@ -198,7 +198,7 @@ nova:
   logLevel: 3
   image:
     repository: quay.io/fairwinds/nova
-    tag: "v3.6"
+    tag: "v3.5"
   resources:
     requests:
       cpu: 100m
@@ -276,7 +276,7 @@ pluto:
   targetVersions: ""
   image:
     repository: us-docker.pkg.dev/fairwinds-ops/oss/pluto
-    tag: "v5.12"
+    tag: "v5.11"
   resources:
     requests:
       cpu: 100m


### PR DESCRIPTION
Reverts FairwindsOps/charts#1069

There are issues parsing report output as new text is output to standard error.