### PR TITLE
[stable/polaris] Add default topology spread constraints

### DIFF
--- a/stable/polaris/Chart.yaml
+++ b/stable/polaris/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Validation of best practices in your Kubernetes clusters
 name: polaris
-version: 5.7.2
+version: 5.7.3
 appVersion: "7.1"
 icon: https://raw.githubusercontent.com/FairwindsOps/polaris/master/pkg/dashboard/assets/favicon-32x32.png
 maintainers:

--- a/stable/polaris/Chart.yaml
+++ b/stable/polaris/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Validation of best practices in your Kubernetes clusters
 name: polaris
-version: 5.7.0
+version: 5.7.1
 appVersion: "7.1"
 icon: https://raw.githubusercontent.com/FairwindsOps/polaris/master/pkg/dashboard/assets/favicon-32x32.png
 maintainers:

--- a/stable/polaris/Chart.yaml
+++ b/stable/polaris/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Validation of best practices in your Kubernetes clusters
 name: polaris
-version: 5.7.1
+version: 5.7.2
 appVersion: "7.1"
 icon: https://raw.githubusercontent.com/FairwindsOps/polaris/master/pkg/dashboard/assets/favicon-32x32.png
 maintainers:

--- a/stable/polaris/README.md
+++ b/stable/polaris/README.md
@@ -35,66 +35,66 @@ the 0.10.0 version of this chart will only work on kubernetes 1.14.0+
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| audit.cleanup | bool | `false` | Whether to delete the namespace once the audit is finished. |
-| audit.enable | bool | `false` | Runs a one-time audit. This is used internally at Fairwinds, and may not be useful for others. |
-| audit.outputURL | string | `""` | A URL which will receive a POST request with audit results. |
 | config | string | `nil` | The [polaris configuration](https://github.com/FairwindsOps/polaris#configuration). If not provided then the [default](https://github.com/FairwindsOps/polaris/blob/master/examples/config.yaml) config from Polaris is used. |
 | configUrl | string | `nil` | Use a config from an accessible URL source.  NOTE: `config` & `configUrl` are mutually exclusive.  Setting `configURL` will take precedence over `config`.  Only one may be used. configUrl: https://example.com/config.yaml |
-| dashboard.affinity | object | `{}` | Dashboard pods affinity |
-| dashboard.basePath | string | `nil` | Path on which the dashboard is served. Defaults to `/` |
-| dashboard.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true,"runAsNonRoot":true}` | securityContext to apply to the dashboard container |
-| dashboard.disallowAnnotationExemptions | bool | `false` | Disallow exemptions that are configured via annotations |
-| dashboard.disallowConfigExemptions | bool | `false` | Disallow exemptions that are configured in the config file |
-| dashboard.disallowExemptions | bool | `false` | Disallow any exemption |
-| dashboard.enable | bool | `true` | Whether to run the dashboard. |
-| dashboard.extraContainers | list | `[]` | allows injecting additional containers. |
-| dashboard.ingress.annotations | object | `{}` | Web ingress annotations |
-| dashboard.ingress.enabled | bool | `false` | Whether to enable ingress to the dashboard |
-| dashboard.ingress.hosts | list | `[]` | Web ingress hostnames |
-| dashboard.ingress.ingressClassName | string | `nil` | From Kubernetes 1.18+ this field is supported in case your ingress controller supports it. When set, you do not need to add the ingress class as annotation. |
-| dashboard.ingress.tls | list | `[]` | Ingress TLS configuration |
-| dashboard.listeningAddress | string | `nil` | Dashboard listerning address. |
-| dashboard.logLevel | string | `"Info"` | Set the logging level for the Dashboard command |
-| dashboard.nodeSelector | object | `{}` | Dashboard pod nodeSelector |
-| dashboard.podAdditionalLabels | object | `{}` | Custom additional labels on dashboard pods. |
-| dashboard.port | int | `8080` | Port that the dashboard will run from. |
-| dashboard.priorityClassName | string | `nil` | Priority Class name to be used in deployment if provided. |
-| dashboard.replicas | int | `2` | Number of replicas to run. |
-| dashboard.resources | object | `{"limits":{"cpu":"150m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | Requests and limits for the dashboard |
-| dashboard.service.annotations | object | `{}` | Service annotations |
-| dashboard.service.loadBalancerSourceRanges | list | `[]` | List of allowed CIDR values |
-| dashboard.service.targetPort | string | `nil` | Service targetport, defaults to dashboard.port |
-| dashboard.service.type | string | `"ClusterIP"` | Service Type |
-| dashboard.tolerations | list | `[]` | Dashboard pod tolerations |
-| dashboard.topologySpreadConstraints | list | `[{"labelSelector":{"matchLabels":{"component":"dashboard"}},"maxSkew":1,"topologyKey":"topology.kubernetes.io/zone","whenUnsatisfiable":"ScheduleAnyway"},{"labelSelector":{"matchLabels":{"component":"dashboard"}},"maxSkew":1,"topologyKey":"kubernetes.io/hostname","whenUnsatisfiable":"ScheduleAnyway"}]` | Dashboard pods topologySpreadConstraints |
-| image.pullPolicy | string | `"Always"` | Image pull policy |
-| image.pullSecrets | list | `[]` | Image pull secrets |
 | image.repository | string | `"quay.io/fairwinds/polaris"` | Image repo |
 | image.tag | string | `""` | The Polaris Image tag to use. Defaults to the Chart's AppVersion |
+| image.pullPolicy | string | `"Always"` | Image pull policy |
+| image.pullSecrets | list | `[]` | Image pull secrets |
 | rbac.enabled | bool | `true` | Whether RBAC resources (ClusterRole, ClusterRolebinding) should be created |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `nil` | The name of the service account to use. |
 | templateOnly | bool | `false` | Outputs Namespace names, used with `helm template` |
-| webhook.affinity | object | `{}` | Webhook pods affinity |
-| webhook.caBundle | string | `nil` | CA Bundle to use for Validating Webhook instead of cert-manager |
-| webhook.defaultRules | list | `[{"apiGroups":["apps"],"apiVersions":["v1","v1beta1","v1beta2"],"operations":["CREATE","UPDATE"],"resources":["daemonsets","deployments","statefulsets"],"scope":"Namespaced"},{"apiGroups":["batch"],"apiVersions":["v1","v1beta1"],"operations":["CREATE","UPDATE"],"resources":["jobs","cronjobs"],"scope":"Namespaced"},{"apiGroups":[""],"apiVersions":["v1"],"operations":["CREATE","UPDATE"],"resources":["pods","replicationcontrollers"],"scope":"Namespaced"}]` | An array of rules for common types for the ValidatingWebhookConfiguration |
-| webhook.disallowAnnotationExemptions | bool | `false` | Disallow exemptions that are configured via annotations |
-| webhook.disallowConfigExemptions | bool | `false` | Disallow exemptions that are configured in the config file |
-| webhook.disallowExemptions | bool | `false` | Disallow any exemption |
+| dashboard.basePath | string | `nil` | Path on which the dashboard is served. Defaults to `/` |
+| dashboard.enable | bool | `true` | Whether to run the dashboard. |
+| dashboard.port | int | `8080` | Port that the dashboard will run from. |
+| dashboard.listeningAddress | string | `nil` | Dashboard listerning address. |
+| dashboard.replicas | int | `2` | Number of replicas to run. |
+| dashboard.logLevel | string | `"Info"` | Set the logging level for the Dashboard command |
+| dashboard.podAdditionalLabels | object | `{}` | Custom additional labels on dashboard pods. |
+| dashboard.resources | object | `{"limits":{"cpu":"150m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | Requests and limits for the dashboard |
+| dashboard.extraContainers | list | `[]` | allows injecting additional containers. |
+| dashboard.service.type | string | `"ClusterIP"` | Service Type |
+| dashboard.service.annotations | object | `{}` | Service annotations |
+| dashboard.service.targetPort | string | `nil` | Service targetport, defaults to dashboard.port |
+| dashboard.service.loadBalancerSourceRanges | list | `[]` | List of allowed CIDR values |
+| dashboard.nodeSelector | object | `{}` | Dashboard pod nodeSelector |
+| dashboard.tolerations | list | `[]` | Dashboard pod tolerations |
+| dashboard.affinity | object | `{}` | Dashboard pods affinity |
+| dashboard.topologySpreadConstraints | list | `[{"labelSelector":{"matchLabels":{"component":"dashboard"}},"maxSkew":1,"topologyKey":"topology.kubernetes.io/zone","whenUnsatisfiable":"ScheduleAnyway"},{"labelSelector":{"matchLabels":{"component":"dashboard"}},"maxSkew":1,"topologyKey":"kubernetes.io/hostname","whenUnsatisfiable":"ScheduleAnyway"}]` | Dashboard pods topologySpreadConstraints |
+| dashboard.ingress.enabled | bool | `false` | Whether to enable ingress to the dashboard |
+| dashboard.ingress.ingressClassName | string | `nil` | From Kubernetes 1.18+ this field is supported in case your ingress controller supports it. When set, you do not need to add the ingress class as annotation. |
+| dashboard.ingress.hosts | list | `[]` | Web ingress hostnames |
+| dashboard.ingress.annotations | object | `{}` | Web ingress annotations |
+| dashboard.ingress.tls | list | `[]` | Ingress TLS configuration |
+| dashboard.priorityClassName | string | `nil` | Priority Class name to be used in deployment if provided. |
+| dashboard.disallowExemptions | bool | `false` | Disallow any exemption |
+| dashboard.disallowConfigExemptions | bool | `false` | Disallow exemptions that are configured in the config file |
+| dashboard.disallowAnnotationExemptions | bool | `false` | Disallow exemptions that are configured via annotations |
+| dashboard.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true,"runAsNonRoot":true}` | securityContext to apply to the dashboard container |
 | webhook.enable | bool | `false` | Whether to run the webhook |
+| webhook.validate | bool | `true` | Enables the Validating Webhook, to reject resources with issues |
+| webhook.mutate | bool | `false` | Enables the Mutating Webhook, to modify resources with issues |
+| webhook.replicas | int | `2` | Number of replicas |
+| webhook.nodeSelector | object | `{}` | Webhook pod nodeSelector |
+| webhook.tolerations | list | `[]` | Webhook pod tolerations |
+| webhook.affinity | object | `{}` | Webhook pods affinity |
+| webhook.topologySpreadConstraints | list | `[{"labelSelector":{"matchLabels":{"component":"webhook"}},"maxSkew":1,"topologyKey":"topology.kubernetes.io/zone","whenUnsatisfiable":"ScheduleAnyway"},{"labelSelector":{"matchLabels":{"component":"webhook"}},"maxSkew":1,"topologyKey":"kubernetes.io/hostname","whenUnsatisfiable":"ScheduleAnyway"}]` | Webhook pods topologySpreadConstraints |
+| webhook.caBundle | string | `nil` | CA Bundle to use for Validating Webhook instead of cert-manager |
+| webhook.secretName | string | `nil` | Name of the secret containing a TLS certificate to use if cert-manager is not used. |
 | webhook.failurePolicy | string | `"Fail"` | failurePolicy for the ValidatingWebhookConfiguration |
 | webhook.matchPolicy | string | `"Exact"` | matchPolicy for the ValidatingWebhookConfiguration |
-| webhook.mutate | bool | `false` | Enables the Mutating Webhook, to modify resources with issues |
-| webhook.mutatingRules | list | `[]` | An array of additional rules for the MutatingWebhookConfiguration. Each requires a set of apiGroups, apiVersions, operations, resources, and a scope. |
 | webhook.namespaceSelector | object | `{"matchExpressions":[{"key":"control-plane","operator":"DoesNotExist"}]}` | namespaceSelector for the ValidatingWebhookConfiguration |
-| webhook.nodeSelector | object | `{}` | Webhook pod nodeSelector |
 | webhook.objectSelector | object | `{}` | objectSelector for the ValidatingWebhookConfiguration |
-| webhook.podAdditionalLabels | object | `{}` | Custom additional labels on webhook pods. |
-| webhook.priorityClassName | string | `nil` | Priority Class name to be used in deployment if provided. |
-| webhook.replicas | int | `2` | Number of replicas |
-| webhook.resources | object | `{"limits":{"cpu":"100m","memory":"128Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | Requests and limits for the webhook. |
 | webhook.rules | list | `[]` | An array of additional rules for the ValidatingWebhookConfiguration. Each requires a set of apiGroups, apiVersions, operations, resources, and a scope. |
-| webhook.secretName | string | `nil` | Name of the secret containing a TLS certificate to use if cert-manager is not used. |
-| webhook.tolerations | list | `[]` | Webhook pod tolerations |
-| webhook.topologySpreadConstraints | list | `[{"labelSelector":{"matchLabels":{"component":"webhook"}},"maxSkew":1,"topologyKey":"topology.kubernetes.io/zone","whenUnsatisfiable":"ScheduleAnyway"},{"labelSelector":{"matchLabels":{"component":"webhook"}},"maxSkew":1,"topologyKey":"kubernetes.io/hostname","whenUnsatisfiable":"ScheduleAnyway"}]` | Webhook pods topologySpreadConstraints |
-| webhook.validate | bool | `true` | Enables the Validating Webhook, to reject resources with issues |
+| webhook.mutatingRules | list | `[]` | An array of additional rules for the MutatingWebhookConfiguration. Each requires a set of apiGroups, apiVersions, operations, resources, and a scope. |
+| webhook.defaultRules | list | `[{"apiGroups":["apps"],"apiVersions":["v1","v1beta1","v1beta2"],"operations":["CREATE","UPDATE"],"resources":["daemonsets","deployments","statefulsets"],"scope":"Namespaced"},{"apiGroups":["batch"],"apiVersions":["v1","v1beta1"],"operations":["CREATE","UPDATE"],"resources":["jobs","cronjobs"],"scope":"Namespaced"},{"apiGroups":[""],"apiVersions":["v1"],"operations":["CREATE","UPDATE"],"resources":["pods","replicationcontrollers"],"scope":"Namespaced"}]` | An array of rules for common types for the ValidatingWebhookConfiguration |
+| webhook.podAdditionalLabels | object | `{}` | Custom additional labels on webhook pods. |
+| webhook.resources | object | `{"limits":{"cpu":"100m","memory":"128Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | Requests and limits for the webhook. |
+| webhook.priorityClassName | string | `nil` | Priority Class name to be used in deployment if provided. |
+| webhook.disallowExemptions | bool | `false` | Disallow any exemption |
+| webhook.disallowConfigExemptions | bool | `false` | Disallow exemptions that are configured in the config file |
+| webhook.disallowAnnotationExemptions | bool | `false` | Disallow exemptions that are configured via annotations |
+| audit.enable | bool | `false` | Runs a one-time audit. This is used internally at Fairwinds, and may not be useful for others. |
+| audit.cleanup | bool | `false` | Whether to delete the namespace once the audit is finished. |
+| audit.outputURL | string | `""` | A URL which will receive a POST request with audit results. |

--- a/stable/polaris/README.md
+++ b/stable/polaris/README.md
@@ -62,10 +62,9 @@ the 0.10.0 version of this chart will only work on kubernetes 1.14.0+
 | dashboard.replicas | int | `2` | Number of replicas to run. |
 | dashboard.resources | object | `{"limits":{"cpu":"150m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | Requests and limits for the dashboard |
 | dashboard.service.annotations | object | `{}` | Service annotations |
+| dashboard.service.loadBalancerSourceRanges | list | `[]` | List of allowed CIDR values |
 | dashboard.service.targetPort | string | `nil` | Service targetport, defaults to dashboard.port |
 | dashboard.service.type | string | `"ClusterIP"` | Service Type |
-| dashboard.service.loadBalancerSourceRanges | list | `[]` | List of allowed CIDR values |
-| dashboard.nodeSelector | object | `{}` | Dashboard pod nodeSelector |
 | dashboard.tolerations | list | `[]` | Dashboard pod tolerations |
 | dashboard.topologySpreadConstraints | list | `[{"labelSelector":{"matchLabels":{"component":"dashboard"}},"maxSkew":1,"topologyKey":"topology.kubernetes.io/zone","whenUnsatisfiable":"ScheduleAnyway"},{"labelSelector":{"matchLabels":{"component":"dashboard"}},"maxSkew":1,"topologyKey":"kubernetes.io/hostname","whenUnsatisfiable":"ScheduleAnyway"}]` | Dashboard pods topologySpreadConstraints |
 | image.pullPolicy | string | `"Always"` | Image pull policy |

--- a/stable/polaris/README.md
+++ b/stable/polaris/README.md
@@ -35,63 +35,65 @@ the 0.10.0 version of this chart will only work on kubernetes 1.14.0+
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| audit.cleanup | bool | `false` | Whether to delete the namespace once the audit is finished. |
+| audit.enable | bool | `false` | Runs a one-time audit. This is used internally at Fairwinds, and may not be useful for others. |
+| audit.outputURL | string | `""` | A URL which will receive a POST request with audit results. |
 | config | string | `nil` | The [polaris configuration](https://github.com/FairwindsOps/polaris#configuration). If not provided then the [default](https://github.com/FairwindsOps/polaris/blob/master/examples/config.yaml) config from Polaris is used. |
 | configUrl | string | `nil` | Use a config from an accessible URL source.  NOTE: `config` & `configUrl` are mutually exclusive.  Setting `configURL` will take precedence over `config`.  Only one may be used. configUrl: https://example.com/config.yaml |
-| image.repository | string | `"quay.io/fairwinds/polaris"` | Image repo |
-| image.tag | string | `""` | The Polaris Image tag to use. Defaults to the Chart's AppVersion |
+| dashboard.affinity | object | `{}` | Dashboard pods affinity |
+| dashboard.basePath | string | `nil` | Path on which the dashboard is served. Defaults to `/` |
+| dashboard.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true,"runAsNonRoot":true}` | securityContext to apply to the dashboard container |
+| dashboard.disallowAnnotationExemptions | bool | `false` | Disallow exemptions that are configured via annotations |
+| dashboard.disallowConfigExemptions | bool | `false` | Disallow exemptions that are configured in the config file |
+| dashboard.disallowExemptions | bool | `false` | Disallow any exemption |
+| dashboard.enable | bool | `true` | Whether to run the dashboard. |
+| dashboard.extraContainers | list | `[]` | allows injecting additional containers. |
+| dashboard.ingress.annotations | object | `{}` | Web ingress annotations |
+| dashboard.ingress.enabled | bool | `false` | Whether to enable ingress to the dashboard |
+| dashboard.ingress.hosts | list | `[]` | Web ingress hostnames |
+| dashboard.ingress.ingressClassName | string | `nil` | From Kubernetes 1.18+ this field is supported in case your ingress controller supports it. When set, you do not need to add the ingress class as annotation. |
+| dashboard.ingress.tls | list | `[]` | Ingress TLS configuration |
+| dashboard.listeningAddress | string | `nil` | Dashboard listerning address. |
+| dashboard.logLevel | string | `"Info"` | Set the logging level for the Dashboard command |
+| dashboard.nodeSelector | object | `{}` | Dashboard pod nodeSelector |
+| dashboard.podAdditionalLabels | object | `{}` | Custom additional labels on dashboard pods. |
+| dashboard.port | int | `8080` | Port that the dashboard will run from. |
+| dashboard.priorityClassName | string | `nil` | Priority Class name to be used in deployment if provided. |
+| dashboard.replicas | int | `2` | Number of replicas to run. |
+| dashboard.resources | object | `{"limits":{"cpu":"150m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | Requests and limits for the dashboard |
+| dashboard.service.annotations | object | `{}` | Service annotations |
+| dashboard.service.targetPort | string | `nil` | Service targetport, defaults to dashboard.port |
+| dashboard.service.type | string | `"ClusterIP"` | Service Type |
+| dashboard.tolerations | list | `[]` | Dashboard pod tolerations |
+| dashboard.topologySpreadConstraints | list | `[{"labelSelector":{"matchLabels":{"component":"dashboard"}},"maxSkew":1,"topologyKey":"topology.kubernetes.io/zone","whenUnsatisfiable":"ScheduleAnyway"},{"labelSelector":{"matchLabels":{"component":"dashboard"}},"maxSkew":1,"topologyKey":"kubernetes.io/hostname","whenUnsatisfiable":"ScheduleAnyway"}]` | Dashboard pods topologySpreadConstraints |
 | image.pullPolicy | string | `"Always"` | Image pull policy |
 | image.pullSecrets | list | `[]` | Image pull secrets |
+| image.repository | string | `"quay.io/fairwinds/polaris"` | Image repo |
+| image.tag | string | `""` | The Polaris Image tag to use. Defaults to the Chart's AppVersion |
 | rbac.enabled | bool | `true` | Whether RBAC resources (ClusterRole, ClusterRolebinding) should be created |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `nil` | The name of the service account to use. |
 | templateOnly | bool | `false` | Outputs Namespace names, used with `helm template` |
-| dashboard.basePath | string | `nil` | Path on which the dashboard is served. Defaults to `/` |
-| dashboard.enable | bool | `true` | Whether to run the dashboard. |
-| dashboard.port | int | `8080` | Port that the dashboard will run from. |
-| dashboard.listeningAddress | string | `nil` | Dashboard listerning address. |
-| dashboard.replicas | int | `2` | Number of replicas to run. |
-| dashboard.logLevel | string | `"Info"` | Set the logging level for the Dashboard command |
-| dashboard.podAdditionalLabels | object | `{}` | Custom additional labels on dashboard pods. |
-| dashboard.resources | object | `{"limits":{"cpu":"150m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | Requests and limits for the dashboard |
-| dashboard.extraContainers | list | `[]` | allows injecting additional containers. |
-| dashboard.service.type | string | `"ClusterIP"` | Service Type |
-| dashboard.service.annotations | object | `{}` | Service annotations |
-| dashboard.service.targetPort | string | `nil` | Service targetport, defaults to dashboard.port |
-| dashboard.nodeSelector | object | `{}` | Dashboard pod nodeSelector |
-| dashboard.tolerations | list | `[]` | Dashboard pod tolerations |
-| dashboard.affinity | object | `{}` | Dashboard pods affinity |
-| dashboard.ingress.enabled | bool | `false` | Whether to enable ingress to the dashboard |
-| dashboard.ingress.ingressClassName | string | `nil` | From Kubernetes 1.18+ this field is supported in case your ingress controller supports it. When set, you do not need to add the ingress class as annotation. |
-| dashboard.ingress.hosts | list | `[]` | Web ingress hostnames |
-| dashboard.ingress.annotations | object | `{}` | Web ingress annotations |
-| dashboard.ingress.tls | list | `[]` | Ingress TLS configuration |
-| dashboard.priorityClassName | string | `nil` | Priority Class name to be used in deployment if provided. |
-| dashboard.disallowExemptions | bool | `false` | Disallow any exemption |
-| dashboard.disallowConfigExemptions | bool | `false` | Disallow exemptions that are configured in the config file |
-| dashboard.disallowAnnotationExemptions | bool | `false` | Disallow exemptions that are configured via annotations |
-| dashboard.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true,"runAsNonRoot":true}` | securityContext to apply to the dashboard container |
-| webhook.enable | bool | `false` | Whether to run the webhook |
-| webhook.validate | bool | `true` | Enables the Validating Webhook, to reject resources with issues |
-| webhook.mutate | bool | `false` | Enables the Mutating Webhook, to modify resources with issues |
-| webhook.replicas | int | `2` | Number of replicas |
-| webhook.nodeSelector | object | `{}` | Webhook pod nodeSelector |
-| webhook.tolerations | list | `[]` | Webhook pod tolerations |
 | webhook.affinity | object | `{}` | Webhook pods affinity |
 | webhook.caBundle | string | `nil` | CA Bundle to use for Validating Webhook instead of cert-manager |
-| webhook.secretName | string | `nil` | Name of the secret containing a TLS certificate to use if cert-manager is not used. |
+| webhook.defaultRules | list | `[{"apiGroups":["apps"],"apiVersions":["v1","v1beta1","v1beta2"],"operations":["CREATE","UPDATE"],"resources":["daemonsets","deployments","statefulsets"],"scope":"Namespaced"},{"apiGroups":["batch"],"apiVersions":["v1","v1beta1"],"operations":["CREATE","UPDATE"],"resources":["jobs","cronjobs"],"scope":"Namespaced"},{"apiGroups":[""],"apiVersions":["v1"],"operations":["CREATE","UPDATE"],"resources":["pods","replicationcontrollers"],"scope":"Namespaced"}]` | An array of rules for common types for the ValidatingWebhookConfiguration |
+| webhook.disallowAnnotationExemptions | bool | `false` | Disallow exemptions that are configured via annotations |
+| webhook.disallowConfigExemptions | bool | `false` | Disallow exemptions that are configured in the config file |
+| webhook.disallowExemptions | bool | `false` | Disallow any exemption |
+| webhook.enable | bool | `false` | Whether to run the webhook |
 | webhook.failurePolicy | string | `"Fail"` | failurePolicy for the ValidatingWebhookConfiguration |
 | webhook.matchPolicy | string | `"Exact"` | matchPolicy for the ValidatingWebhookConfiguration |
-| webhook.namespaceSelector | object | `{"matchExpressions":[{"key":"control-plane","operator":"DoesNotExist"}]}` | namespaceSelector for the ValidatingWebhookConfiguration |
-| webhook.objectSelector | object | `{}` | objectSelector for the ValidatingWebhookConfiguration |
-| webhook.rules | list | `[]` | An array of additional rules for the ValidatingWebhookConfiguration. Each requires a set of apiGroups, apiVersions, operations, resources, and a scope. |
+| webhook.mutate | bool | `false` | Enables the Mutating Webhook, to modify resources with issues |
 | webhook.mutatingRules | list | `[]` | An array of additional rules for the MutatingWebhookConfiguration. Each requires a set of apiGroups, apiVersions, operations, resources, and a scope. |
-| webhook.defaultRules | list | `[{"apiGroups":["apps"],"apiVersions":["v1","v1beta1","v1beta2"],"operations":["CREATE","UPDATE"],"resources":["daemonsets","deployments","statefulsets"],"scope":"Namespaced"},{"apiGroups":["batch"],"apiVersions":["v1","v1beta1"],"operations":["CREATE","UPDATE"],"resources":["jobs","cronjobs"],"scope":"Namespaced"},{"apiGroups":[""],"apiVersions":["v1"],"operations":["CREATE","UPDATE"],"resources":["pods","replicationcontrollers"],"scope":"Namespaced"}]` | An array of rules for common types for the ValidatingWebhookConfiguration |
+| webhook.namespaceSelector | object | `{"matchExpressions":[{"key":"control-plane","operator":"DoesNotExist"}]}` | namespaceSelector for the ValidatingWebhookConfiguration |
+| webhook.nodeSelector | object | `{}` | Webhook pod nodeSelector |
+| webhook.objectSelector | object | `{}` | objectSelector for the ValidatingWebhookConfiguration |
 | webhook.podAdditionalLabels | object | `{}` | Custom additional labels on webhook pods. |
-| webhook.resources | object | `{"limits":{"cpu":"100m","memory":"128Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | Requests and limits for the webhook. |
 | webhook.priorityClassName | string | `nil` | Priority Class name to be used in deployment if provided. |
-| webhook.disallowExemptions | bool | `false` | Disallow any exemption |
-| webhook.disallowConfigExemptions | bool | `false` | Disallow exemptions that are configured in the config file |
-| webhook.disallowAnnotationExemptions | bool | `false` | Disallow exemptions that are configured via annotations |
-| audit.enable | bool | `false` | Runs a one-time audit. This is used internally at Fairwinds, and may not be useful for others. |
-| audit.cleanup | bool | `false` | Whether to delete the namespace once the audit is finished. |
-| audit.outputURL | string | `""` | A URL which will receive a POST request with audit results. |
+| webhook.replicas | int | `2` | Number of replicas |
+| webhook.resources | object | `{"limits":{"cpu":"100m","memory":"128Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | Requests and limits for the webhook. |
+| webhook.rules | list | `[]` | An array of additional rules for the ValidatingWebhookConfiguration. Each requires a set of apiGroups, apiVersions, operations, resources, and a scope. |
+| webhook.secretName | string | `nil` | Name of the secret containing a TLS certificate to use if cert-manager is not used. |
+| webhook.tolerations | list | `[]` | Webhook pod tolerations |
+| webhook.topologySpreadConstraints | list | `[{"labelSelector":{"matchLabels":{"component":"webhook"}},"maxSkew":1,"topologyKey":"topology.kubernetes.io/zone","whenUnsatisfiable":"ScheduleAnyway"},{"labelSelector":{"matchLabels":{"component":"webhook"}},"maxSkew":1,"topologyKey":"kubernetes.io/hostname","whenUnsatisfiable":"ScheduleAnyway"}]` | Webhook pods topologySpreadConstraints |
+| webhook.validate | bool | `true` | Enables the Validating Webhook, to reject resources with issues |

--- a/stable/polaris/templates/dashboard.deployment.yaml
+++ b/stable/polaris/templates/dashboard.deployment.yaml
@@ -119,6 +119,10 @@ spec:
       {{- with .Values.dashboard.tolerations }}
 {{ toYaml . | indent 6 }}
       {{- end }}
+{{- if .Values.dashboard.topologySpreadConstraints }}
+      topologySpreadConstraints:
+{{ toYaml .Values.dashboard.topologySpreadConstraints | indent 6 }}
+      {{- end }}
 {{- if .Values.dashboard.affinity }}
       affinity:
 {{ toYaml .Values.dashboard.affinity | indent 8 }}

--- a/stable/polaris/templates/dashboard.deployment.yaml
+++ b/stable/polaris/templates/dashboard.deployment.yaml
@@ -121,7 +121,7 @@ spec:
       {{- end }}
 {{- if .Values.dashboard.topologySpreadConstraints }}
       topologySpreadConstraints:
-{{ toYaml .Values.dashboard.topologySpreadConstraints | indent 8 }}
+{{ toYaml .Values.dashboard.topologySpreadConstraints | indent 6 }}
       {{- end }}
 {{- if .Values.dashboard.affinity }}
       affinity:

--- a/stable/polaris/templates/dashboard.deployment.yaml
+++ b/stable/polaris/templates/dashboard.deployment.yaml
@@ -121,7 +121,7 @@ spec:
       {{- end }}
 {{- if .Values.dashboard.topologySpreadConstraints }}
       topologySpreadConstraints:
-{{ toYaml .Values.dashboard.topologySpreadConstraints | indent 6 }}
+{{ toYaml .Values.dashboard.topologySpreadConstraints | indent 8 }}
       {{- end }}
 {{- if .Values.dashboard.affinity }}
       affinity:

--- a/stable/polaris/templates/webhook.deployment.yaml
+++ b/stable/polaris/templates/webhook.deployment.yaml
@@ -110,6 +110,10 @@ spec:
       affinity:
 {{ toYaml .Values.webhook.affinity | indent 8 }}
 {{- end }}
+{{- if .Values.webhook.topologySpreadConstraints }}
+      topologySpreadConstraints:
+{{ toYaml .Values.webhook.topologySpreadConstraints | indent 6 }}
+      {{- end }}
       volumes:
         {{- with .Values.config }}
         - name: config

--- a/stable/polaris/templates/webhook.deployment.yaml
+++ b/stable/polaris/templates/webhook.deployment.yaml
@@ -112,7 +112,7 @@ spec:
 {{- end }}
 {{- if .Values.webhook.topologySpreadConstraints }}
       topologySpreadConstraints:
-{{ toYaml .Values.webhook.topologySpreadConstraints | indent 8 }}
+{{ toYaml .Values.webhook.topologySpreadConstraints | indent 6 }}
       {{- end }}
       volumes:
         {{- with .Values.config }}

--- a/stable/polaris/templates/webhook.deployment.yaml
+++ b/stable/polaris/templates/webhook.deployment.yaml
@@ -112,7 +112,7 @@ spec:
 {{- end }}
 {{- if .Values.webhook.topologySpreadConstraints }}
       topologySpreadConstraints:
-{{ toYaml .Values.webhook.topologySpreadConstraints | indent 6 }}
+{{ toYaml .Values.webhook.topologySpreadConstraints | indent 8 }}
       {{- end }}
       volumes:
         {{- with .Values.config }}

--- a/stable/polaris/values.yaml
+++ b/stable/polaris/values.yaml
@@ -137,18 +137,18 @@ webhook:
   affinity: {}
   # webhook.topologySpreadConstraints -- Webhook pods topologySpreadConstraints
   topologySpreadConstraints:
-    - maxSkew: 1
-      topologyKey: topology.kubernetes.io/zone
-      whenUnsatisfiable: ScheduleAnyway
-      labelSelector:
-        matchLabels:
-          component: webhook
-    - maxSkew: 1
-      topologyKey: kubernetes.io/hostname
-      whenUnsatisfiable: ScheduleAnyway
-      labelSelector:
-        matchLabels:
-          component: webhook
+  - maxSkew: 1
+    topologyKey: topology.kubernetes.io/zone
+    whenUnsatisfiable: ScheduleAnyway
+    labelSelector:
+      matchLabels:
+        component: webhook
+  - maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: ScheduleAnyway
+    labelSelector:
+      matchLabels:
+        component: webhook
   # webhook.caBundle -- CA Bundle to use for Validating Webhook instead of cert-manager
   caBundle: null
   # webhook.secretName -- Name of the secret containing a TLS certificate to use if cert-manager is not used.

--- a/stable/polaris/values.yaml
+++ b/stable/polaris/values.yaml
@@ -135,7 +135,7 @@ webhook:
   tolerations: []
   # webhook.affinity -- Webhook pods affinity
   affinity: {}
-  # dashboard.topologySpreadConstraints -- Dashboard pods topologySpreadConstraints
+  # webhook.topologySpreadConstraints -- Webhook pods topologySpreadConstraints
   topologySpreadConstraints:
     - maxSkew: 1
       topologyKey: topology.kubernetes.io/zone

--- a/stable/polaris/values.yaml
+++ b/stable/polaris/values.yaml
@@ -77,6 +77,20 @@ dashboard:
   tolerations: []
   # dashboard.affinity -- Dashboard pods affinity
   affinity: {}
+  # dashboard.topologySpreadConstraints -- Dashboard pods topologySpreadConstraints
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          component: dashboard
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          component: dashboard
   ingress:
     # dashboard.ingress.enabled -- Whether to enable ingress to the dashboard
     enabled: false
@@ -121,6 +135,20 @@ webhook:
   tolerations: []
   # webhook.affinity -- Webhook pods affinity
   affinity: {}
+  # dashboard.topologySpreadConstraints -- Dashboard pods topologySpreadConstraints
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          component: webhook
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          component: webhook
   # webhook.caBundle -- CA Bundle to use for Validating Webhook instead of cert-manager
   caBundle: null
   # webhook.secretName -- Name of the secret containing a TLS certificate to use if cert-manager is not used.


### PR DESCRIPTION
**Why This PR?**
Should prefer scheduling pods in the same deployment on both different nodes and different availability zones to ensure reliability by default and not impact existing environments or block scheduling.

Fixes #
https://github.com/FairwindsOps/charts/issues/997

**Changes**
Changes proposed in this pull request:

* Adds configurable default topologySpreadConstraints to the values.yaml for both polaris dashboard and webhook deployments.
*

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
