### PR TITLE
[stable/goldilocks] Update vpa dependency

### DIFF
--- a/stable/goldilocks/Chart.yaml
+++ b/stable/goldilocks/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 appVersion: "v4.5.1"
-version: 6.4.0
+version: 6.4.1
 description: |
   A Helm chart for running Fairwinds Goldilocks. See https://github.com/FairwindsOps/goldilocks
 name: goldilocks
@@ -15,7 +15,7 @@ keywords:
   - kubernetes
 dependencies:
 - name: vpa
-  version: 1.3.0
+  version: 1.6.0
   repository: https://charts.fairwinds.com/stable
   condition: vpa.enabled
 - name: metrics-server


### PR DESCRIPTION
**Why This PR?**
 VPA subchart hasn't been updated for a while

Fixes #

**Changes**
Changes proposed in this pull request:

* Update vpa to 1.6.0

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
