### PR TITLE
[stable/goldilocks] Added capability to use custom serviceAccount name

### DIFF
--- a/stable/goldilocks/Chart.yaml
+++ b/stable/goldilocks/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 appVersion: "v4.5.1"
-version: 6.4.1
+version: 6.4.2
 description: |
   A Helm chart for running Fairwinds Goldilocks. See https://github.com/FairwindsOps/goldilocks
 name: goldilocks

--- a/stable/goldilocks/ci/service-account-name-values.yaml
+++ b/stable/goldilocks/ci/service-account-name-values.yaml
@@ -1,9 +1,7 @@
 controller:
   serviceAccount:
-    create: false
     name: controller-test
 
 dashboard:
   serviceAccount:
-    create: false
-    name: controller-test
+    name: dashboard-test

--- a/stable/goldilocks/ci/service-account-name-values.yaml
+++ b/stable/goldilocks/ci/service-account-name-values.yaml
@@ -1,9 +1,9 @@
   controller:
-    serviceAccount: 
+    serviceAccount:
       create: false
       name: controller-test
 
   dashboard:
-    serviceAccount: 
+    serviceAccount:
       create: false
-      name: controller-test    
+      name: controller-test

--- a/stable/goldilocks/ci/service-account-name-values.yaml
+++ b/stable/goldilocks/ci/service-account-name-values.yaml
@@ -1,9 +1,9 @@
-  controller:
-    serviceAccount:
-      create: false
-      name: controller-test
+controller:
+  serviceAccount:
+    create: false
+    name: controller-test
 
-  dashboard:
-    serviceAccount:
-      create: false
-      name: controller-test
+dashboard:
+  serviceAccount:
+    create: false
+    name: controller-test

--- a/stable/goldilocks/ci/service-account-name-values.yaml
+++ b/stable/goldilocks/ci/service-account-name-values.yaml
@@ -1,0 +1,9 @@
+  controller:
+    serviceAccount: 
+      create: false
+      name: controller-test
+
+  dashboard:
+    serviceAccount: 
+      create: false
+      name: controller-test    

--- a/stable/goldilocks/templates/_helpers.tpl
+++ b/stable/goldilocks/templates/_helpers.tpl
@@ -30,3 +30,25 @@ Create chart name and version as used by the chart label.
 {{- define "goldilocks.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Create the name of the service account for controller to use
+*/}}
+{{- define "controller.serviceAccountName" -}}
+{{- if .Values.controller.serviceAccount.create -}}
+    {{ default (printf "%s-controller" (include "goldilocks.fullname" .)) .Values.controller.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.controller.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account for dashboard to use
+*/}}
+{{- define "dashboard.serviceAccountName" -}}
+{{- if .Values.dashboard.serviceAccount.create -}}
+    {{ default (printf "%s-dashboard" (include "goldilocks.fullname" .)) .Values.dashboard.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.dashboard.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/stable/goldilocks/templates/controller-clusterrolebinding.yaml
+++ b/stable/goldilocks/templates/controller-clusterrolebinding.yaml
@@ -15,7 +15,7 @@ roleRef:
   name: {{ include "goldilocks.fullname" . }}-controller
 subjects:
   - kind: ServiceAccount
-    name: {{ include "goldilocks.fullname" . }}-controller
+    name: {{ template "controller.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
 
 {{- range $.Values.controller.rbac.extraClusterRoleBindings }}

--- a/stable/goldilocks/templates/controller-deployment.yaml
+++ b/stable/goldilocks/templates/controller-deployment.yaml
@@ -41,11 +41,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.controller.serviceAccount.create }}
-      serviceAccountName: {{ include "goldilocks.fullname" . }}-controller
-      {{- else }}
-      serviceAccountName: {{ .Values.controller.serviceAccount.name }}
-      {{- end }}
+      serviceAccountName: {{ template "controller.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.controller.podSecurityContext | nindent 8 }}
       containers:

--- a/stable/goldilocks/templates/controller-serviceaccount.yaml
+++ b/stable/goldilocks/templates/controller-serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "goldilocks.fullname" . }}-controller
+  name: {{ template "controller.serviceAccountName" . }}
   labels:
     app.kubernetes.io/name: {{ include "goldilocks.name" . }}
     helm.sh/chart: {{ include "goldilocks.chart" . }}

--- a/stable/goldilocks/templates/dashboard-clusterrolebinding.yaml
+++ b/stable/goldilocks/templates/dashboard-clusterrolebinding.yaml
@@ -15,6 +15,6 @@ roleRef:
   name: {{ include "goldilocks.fullname" . }}-dashboard
 subjects:
   - kind: ServiceAccount
-    name: {{ include "goldilocks.fullname" . }}-dashboard
+    name: {{ template "dashboard.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/stable/goldilocks/templates/dashboard-deployment.yaml
+++ b/stable/goldilocks/templates/dashboard-deployment.yaml
@@ -41,11 +41,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.dashboard.serviceAccount.create }}
-      serviceAccountName: {{ include "goldilocks.fullname" . }}-dashboard
-      {{- else }}
-      serviceAccountName: {{ .Values.dashboard.serviceAccount.name }}
-      {{- end }}
+      serviceAccountName: {{ template "dashboard.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.dashboard.podSecurityContext | nindent 8 }}
       containers:

--- a/stable/goldilocks/templates/dashboard-serviceaccount.yaml
+++ b/stable/goldilocks/templates/dashboard-serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "goldilocks.fullname" . }}-dashboard
+  name: {{ template "dashboard.serviceAccountName" . }}
   labels:
     app.kubernetes.io/name: {{ include "goldilocks.name" . }}
     helm.sh/chart: {{ include "goldilocks.chart" . }}


### PR DESCRIPTION
**Why This PR?**
Clusterrolebindings for goldilocks controller & dashboard is hardcoded to <goldilocks.fullname>-controller & <goldilocks.fullname>-dashboard. Due to this controller & dashboard does not work when `.Values.controller.serviceAccount.name` & `.Values.dashboard.serviceAccount.name` are set.

Fixes #1043 

**Changes**
Changes proposed in this pull request:

* Added helper methods to create service account name for controller & dashboard
* Used the above definitions in serviceAccount, clusterrolebinding & deployment

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
