### PR TITLE
[stable/insights-agent] [FWI-3538] Allow overriding the cronjob apiVersion and update goldilocks repository

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 2.10.5
-* Allow overriding cronjob apiVersion
+* Allow overriding cronjob apiVersion and update goldilocks repository
 
 ## 2.10.4
 * Update polaris, pluto, nova, goldilocks

--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.10.5
+* Allow overriding cronjob apiVersion
+
 ## 2.10.4
 * Update polaris, pluto, nova, goldilocks
 

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.10.4
+version: 2.10.5
 appVersion: 9.2.1
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:

--- a/stable/insights-agent/templates/_specs.yaml
+++ b/stable/insights-agent/templates/_specs.yaml
@@ -12,10 +12,14 @@
 {{- end }}
 
 {{ define "cronjob" }}
+{{- if .Values.cronjobs.apiVersion }}
+apiVersion: {{ .Values.cronjobs.apiVersion }}
+{{- else }}
 {{- if not (.Capabilities.APIVersions.Has "batch/v1/CronJob") }}
 apiVersion: batch/v1beta1
 {{- else }}
 apiVersion: batch/v1
+{{- end }}
 {{- end }}
 kind: CronJob
 metadata:

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -107,7 +107,7 @@ goldilocks:
   schedule: "rand * * * *"
   timeout: 300
   image:
-    repository: quay.io/fairwinds/goldilocks
+    repository: us-docker.pkg.dev/fairwinds-ops/oss/goldilocks
     tag: "v4.6"
   controller:
     flags:

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -35,6 +35,8 @@ uploader:
   env:
 
 cronjobs:
+  # -- If set, will override the cronjob apiVersion for all cronjobs
+  apiVersion: ""
   disableServiceMesh: true
   backoffLimit: 1
   failedJobsHistoryLimit: 2


### PR DESCRIPTION
**Why This PR?**
For templating manifests, apiVersion detection does not work. This allows overriding the cronjob apiVersion

**Changes**
Changes proposed in this pull request:

* Add a `.Values.cronjobs.apiVersion` that overrides all cronjob apiVersions

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.