### PR TITLE
[stable/insights-admission] Add default topologySpreadConstraints to controller

### DIFF
--- a/stable/insights-admission/CHANGELOG.md
+++ b/stable/insights-admission/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 1.5.2
+* Add default topologySpreadConstraints
+
 ## 1.5.1
 * Update testing versions
 

--- a/stable/insights-admission/Chart.yaml
+++ b/stable/insights-admission/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: insights-admission
 description: A Validating Webhook Admission Controller that utilizes Fairwinds Insights.
 type: application
-version: 1.5.1
+version: 1.5.2
 appVersion: "1.9"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-admission/icon.png
 maintainers:

--- a/stable/insights-admission/README.md
+++ b/stable/insights-admission/README.md
@@ -92,6 +92,7 @@ rules:
 | ignoreRequestUsernames | string | `"system:addon-manager"` | Specify a comma-separated list of usernames whos admission-requests will be ignored. This is useful for automation that regularly updates in-cluster resources. |
 | nodeSelector | object | `{}` | nodSelector to add to the controller. |
 | tolerations | list | `[]` | Toleratations to add to the controller. |
+| topologySpreadConstraints | list | `[{"labelSelector":{"matchLabels":{"component":"controller"}},"maxSkew":1,"topologyKey":"topology.kubernetes.io/zone","whenUnsatisfiable":"ScheduleAnyway"},{"labelSelector":{"matchLabels":{"component":"controller"}},"maxSkew":1,"topologyKey":"kubernetes.io/hostname","whenUnsatisfiable":"ScheduleAnyway"}]` | TopologySpreadConstraints to add to the controller. |
 | affinity | object | `{}` | Pod affinity/anti-affinity rules |
 | caBundle | string | `""` | If you are providing your own certificate then this is the Certificate Authority for that certificate |
 | secretName | string | `""` | If you are providing your own certificate then this is the name of the secret holding the certificate. |

--- a/stable/insights-admission/templates/deployment.yaml
+++ b/stable/insights-admission/templates/deployment.yaml
@@ -93,7 +93,7 @@ spec:
                 key: host
           - name: FAIRWINDS_IGNORE_USERNAMES
             value: {{ .Values.ignoreRequestUsernames }}
-            {{ include "proxy-env-spec" . | indent 10 | trim }}
+          {{ include "proxy-env-spec" . | indent 10 | trim }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/stable/insights-admission/templates/deployment.yaml
+++ b/stable/insights-admission/templates/deployment.yaml
@@ -104,9 +104,9 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.dashboard.topologySpreadConstraints }}
+      {{- if .Values.topologySpreadConstraints }}
       topologySpreadConstraints:
-        {{ toYaml .Values.dashboard.topologySpreadConstraints | indent 8 }}
+        {{ toYaml .Values.topologySpreadConstraints | indent 8 }}
       {{- end }}
       {{- with .Values.tolerations }}
       tolerations:

--- a/stable/insights-admission/templates/deployment.yaml
+++ b/stable/insights-admission/templates/deployment.yaml
@@ -106,7 +106,7 @@ spec:
       {{- end }}
       {{- if .Values.topologySpreadConstraints }}
       topologySpreadConstraints:
-        {{ toYaml .Values.topologySpreadConstraints | indent 8 }}
+        {{ toYaml .Values.topologySpreadConstraints | nindent 8 }}
       {{- end }}
       {{- with .Values.tolerations }}
       tolerations:

--- a/stable/insights-admission/templates/deployment.yaml
+++ b/stable/insights-admission/templates/deployment.yaml
@@ -104,6 +104,10 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.dashboard.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{ toYaml .Values.dashboard.topologySpreadConstraints | indent 8 }}
+      {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/stable/insights-admission/templates/deployment.yaml
+++ b/stable/insights-admission/templates/deployment.yaml
@@ -93,7 +93,7 @@ spec:
                 key: host
           - name: FAIRWINDS_IGNORE_USERNAMES
             value: {{ .Values.ignoreRequestUsernames }}
-          {{ include "proxy-env-spec" . | indent 10 | trim }}
+            {{ include "proxy-env-spec" . | indent 10 | trim }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/stable/insights-admission/templates/test-deployment.yaml
+++ b/stable/insights-admission/templates/test-deployment.yaml
@@ -53,6 +53,19 @@ spec:
                 return
             server = HTTPServer(('', 8080), FileHandler)
             server.serve_forever()
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              component: test
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              component: test
 ---
 apiVersion: v1
 kind: Service

--- a/stable/insights-admission/values.yaml
+++ b/stable/insights-admission/values.yaml
@@ -206,6 +206,20 @@ nodeSelector: {}
 # tolerations -- Toleratations to add to the controller.
 tolerations: []
 
+# topologySpreadConstraints -- TopologySpreadConstraints to add to the controller.
+topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: topology.kubernetes.io/zone
+    whenUnsatisfiable: ScheduleAnyway
+    labelSelector:
+      matchLabels:
+        component: controller
+  - maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: ScheduleAnyway
+    labelSelector:
+      matchLabels:
+        component: controller
 # affinity -- Pod affinity/anti-affinity rules
 affinity: {}
 


### PR DESCRIPTION
**Why This PR?**
Sets reasonable, soft, topologySpreadConstraints and allows for overwriting. 

Fixes #

**Changes**
Changes proposed in this pull request:

*Sets reasonable, soft, topologySpreadConstraints and allows for overwriting. 
*

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
