### PR TITLE
[stable/insights-agent] Fix CronJob version override for awscosts and falco

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.10.6
+* Fix CronJob version override for aws-costs and falco
+
 ## 2.10.5
 * Allow overriding cronjob apiVersion and update goldilocks repository
 

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.10.5
+version: 2.10.6
 appVersion: 9.2.1
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:

--- a/stable/insights-agent/templates/awscosts/cronjob.yaml
+++ b/stable/insights-agent/templates/awscosts/cronjob.yaml
@@ -1,14 +1,7 @@
 {{- if .Values.awscosts.enabled -}}
 {{- $_ := set . "Label" "awscosts" }}
 {{- $_ := set . "Config" .Values.awscosts }}
-{{- if not (.Capabilities.APIVersions.Has "batch/v1/CronJob") }}
-apiVersion: batch/v1beta1
-{{- else }}
-apiVersion: batch/v1
-{{- end }}
-kind: CronJob
-metadata:
-  {{- include "metadata" . }}
+{{- include "cronjob" . }}
 spec:
   {{ include "cronjob-spec" . | nindent 2 | trim }}
   jobTemplate:

--- a/stable/insights-agent/templates/falco/cronjob.yaml
+++ b/stable/insights-agent/templates/falco/cronjob.yaml
@@ -1,14 +1,7 @@
 {{- if .Values.falco.enabled -}}
 {{- $_ := set . "Label" "falco" }}
 {{- $_ := set . "Config" .Values.falco }}
-{{- if not (.Capabilities.APIVersions.Has "batch/v1/CronJob") }}
-apiVersion: batch/v1beta1
-{{- else }}
-apiVersion: batch/v1
-{{- end }}
-kind: CronJob
-metadata:
-  {{- include "metadata" . }}
+{{- include "cronjob" . }}
 spec:
   {{ include "cronjob-spec" . | nindent 2 | trim }}
   jobTemplate:


### PR DESCRIPTION
**Why This PR?**
AWS costs and falco weren't using the CJ template


**Changes**
Changes proposed in this pull request: 
* Use CJ template for aws costs and falco

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.

