### PR TITLE
change timescale defaults

### DIFF
--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 0.10.0
+* Change default timescale options to better support the default installation
+
 ## 0.9.11
 * Update testing versions
 

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "11.5"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 0.9.11
+version: 0.10.0
 maintainers:
   - name: rbren
   - name: mhoss019

--- a/stable/fairwinds-insights/README.md
+++ b/stable/fairwinds-insights/README.md
@@ -138,7 +138,7 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | postgresql.primary.resources | object | `{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":"75m","memory":"256Mi"}}` | Resources section for Postgres |
 | encryption.aes.cypherKey | string | `nil` |  |
 | timescale.fullnameOverride | string | `"timescale"` |  |
-| timescale.replicaCount | int | `2` |  |
+| timescale.replicaCount | int | `1` |  |
 | timescale.clusterName | string | `"timescale"` |  |
 | timescale.ephemeral | bool | `true` | Use the ephemeral Timescale chart by default |
 | timescale.pdb.enabled | bool | `true` | Use pdb enabled by default |

--- a/stable/fairwinds-insights/README.md
+++ b/stable/fairwinds-insights/README.md
@@ -153,7 +153,6 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | timescale.service.primary | object | `{"port":5433}` | Port of the Timescale Database |
 | timescale.loadBalancer.enabled | bool | `false` |  |
 | timescale.timescaledbTune | object | `{"enabled":false}` | Database tuning for timescale |
-| timescale.persistentVolumes | object | `{"data":{"enabled":false},"wal":{"enabled":false}}` | Timescale persistent volume options |
 | timescale.patroni | object | `{"log":{"level":"DEBUG"},"postgresql":{"create_replica_methods":[],"pgbackrest":{}}}` | Timescale patroni options |
 | timescale.resources | object | `{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":"75m","memory":"256Mi"}}` | Resources section for Timescale |
 | email.strategy | string | `"memory"` | How to send emails, valid values include memory, ses, and smtp |

--- a/stable/fairwinds-insights/README.md
+++ b/stable/fairwinds-insights/README.md
@@ -152,6 +152,9 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | timescale.secrets.credentialsSecretName | string | `"fwinsights-timescale"` |  |
 | timescale.service.primary | object | `{"port":5433}` | Port of the Timescale Database |
 | timescale.loadBalancer.enabled | bool | `false` |  |
+| timescale.timescaledbTune | object | `{"enabled":false}` | Database tuning for timescale |
+| timescale.persistentVolumes | object | `{"data":{"enabled":false},"wal":{"enabled":false}}` | Timescale persistent volume options |
+| timescale.patroni | object | `{"log":{"level":"DEBUG"},"postgresql":{"create_replica_methods":[],"pgbackrest":{}}}` | Timescale patroni options |
 | timescale.resources | object | `{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":"75m","memory":"256Mi"}}` | Resources section for Timescale |
 | email.strategy | string | `"memory"` | How to send emails, valid values include memory, ses, and smtp |
 | email.sender | string | `nil` | Email address that emails will come from |

--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -503,12 +503,6 @@ timescale:
   # -- Database tuning for timescale
   timescaledbTune:
     enabled: false
-  # -- Timescale persistent volume options
-  persistentVolumes:
-    data:
-      enabled: false
-    wal:
-      enabled: false
   # -- Timescale patroni options
   patroni:
     log:

--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -472,7 +472,7 @@ encryption:
 
 timescale:
   fullnameOverride: timescale
-  replicaCount: 2
+  replicaCount: 1
   clusterName: timescale
   # -- Use the ephemeral Timescale chart by default
   ephemeral: true
@@ -500,6 +500,22 @@ timescale:
       port: 5433
   loadBalancer:
     enabled: false
+  # -- Database tuning for timescale
+  timescaledbTune:
+    enabled: false
+  # -- Timescale persistent volume options
+  persistentVolumes:
+    data:
+      enabled: false
+    wal:
+      enabled: false
+  # -- Timescale patroni options
+  patroni:
+    log:
+      level: DEBUG
+    postgresql:
+      create_replica_methods: []
+      pgbackrest: {}
   # -- Resources section for Timescale
   resources:
     limits:


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_
Current default timescale options don't properly resolve leader-election on vanilla installs. These options fix the issue.

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
