### PR TITLE
[incubator/vault-token-injector] Use latest vault-token-injector and set liveness probe

### DIFF
--- a/incubator/vault-token-injector/Chart.yaml
+++ b/incubator/vault-token-injector/Chart.yaml
@@ -5,8 +5,8 @@ description: |
 
   This will inject vault tokens and address variables into circle builds on a schedule
 type: application
-version: 2.1.1
-appVersion: "v1.5.1"
+version: 2.2.0
+appVersion: "v1.6.0"
 maintainers:
   - name: transient1
   - name: sudermanjr

--- a/incubator/vault-token-injector/README.md
+++ b/incubator/vault-token-injector/README.md
@@ -1,4 +1,4 @@
-![Version: 2.1.1](https://img.shields.io/badge/Version-2.1.1-informational?style=flat-square)
+![Version: 2.2.0](https://img.shields.io/badge/Version-2.2.0-informational?style=flat-square)
 
 # Vault Token Injector Chart
 

--- a/incubator/vault-token-injector/templates/deployment.yaml
+++ b/incubator/vault-token-injector/templates/deployment.yaml
@@ -61,6 +61,10 @@ spec:
           - name: "VAULT_TOKEN_FILE"
             value: {{ .Values.vaultTokenFile | quote }}
           {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: metrics
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
**Why This PR?**
Newer version also has a health check endpoint

**Changes**
Changes proposed in this pull request:

* Add liveness probe
* Update to 1.6.0

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.