### PR TITLE
Add deployment and hpa for automated pull request processor

### DIFF
--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.11.0
+* Add `automatedPullRequest` support to `stable/fairwinds-insights`.
+
 ## 0.10.1
 * Updated self hosted agent version to 2.10
 

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "11.6"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 0.10.1
+version: 0.11.0
 maintainers:
   - name: rbren
   - name: mhoss019

--- a/stable/fairwinds-insights/README.md
+++ b/stable/fairwinds-insights/README.md
@@ -205,6 +205,27 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | reportjob.resources.requests.memory | string | `"128Mi"` |  |
 | reportjob.nodeSelector | object | `{}` |  |
 | reportjob.tolerations | list | `[]` |  |
+| automatedPullRequest.enabled | bool | `true` |  |
+| automatedPullRequest.hpa.enabled | bool | `true` |  |
+| automatedPullRequest.hpa.min | int | `1` |  |
+| automatedPullRequest.hpa.max | int | `3` |  |
+| automatedPullRequest.hpa.metrics[0].type | string | `"Resource"` |  |
+| automatedPullRequest.hpa.metrics[0].resource.name | string | `"cpu"` |  |
+| automatedPullRequest.hpa.metrics[0].resource.target.type | string | `"Utilization"` |  |
+| automatedPullRequest.hpa.metrics[0].resource.target.averageUtilization | int | `75` |  |
+| automatedPullRequest.hpa.metrics[1].type | string | `"Resource"` |  |
+| automatedPullRequest.hpa.metrics[1].resource.name | string | `"memory"` |  |
+| automatedPullRequest.hpa.metrics[1].resource.target.type | string | `"Utilization"` |  |
+| automatedPullRequest.hpa.metrics[1].resource.target.averageUtilization | int | `75` |  |
+| automatedPullRequest.resources.limits.cpu | string | `"500m"` |  |
+| automatedPullRequest.resources.limits.memory | string | `"1024Mi"` |  |
+| automatedPullRequest.resources.requests.cpu | string | `"250m"` |  |
+| automatedPullRequest.resources.requests.memory | string | `"512Mi"` |  |
+| automatedPullRequest.nodeSelector | object | `{}` |  |
+| automatedPullRequest.tolerations | list | `[]` |  |
+| automatedPullRequest.cloneDir.sizeLimit | string | `"2Gi"` |  |
+| automatedPullRequest.git.email | string | `"bot@fairwinds.com"` |  |
+| automatedPullRequest.git.username | string | `"Fairwinds Insights"` |  |
 | repoScanJob.enabled | bool | `false` |  |
 | repoScanJob.insightsCIVersion | string | `"4.2"` |  |
 | repoScanJob.hpa.enabled | bool | `true` |  |

--- a/stable/fairwinds-insights/templates/_env.yaml
+++ b/stable/fairwinds-insights/templates/_env.yaml
@@ -174,4 +174,10 @@ env:
   value: {{ .Release.Namespace }}
 - name: INSIGHTS_CI_IMAGE_VERSION
   value: {{ .Values.repoScanJob.insightsCIVersion | quote }}
+
+# automated-pull-request-processor specific
+- name: GIT_EMAIL
+  value: {{ .Values.automatedPullRequest.git.email | quote }}
+- name: GIT_USERNAME
+  value: {{ .Values.automatedPullRequest.git.username | quote }}
 {{ end }}

--- a/stable/fairwinds-insights/templates/deployment-automated-pr.yaml
+++ b/stable/fairwinds-insights/templates/deployment-automated-pr.yaml
@@ -1,0 +1,72 @@
+{{- if .Values.automatedPullRequest.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "fairwinds-insights.fullname" . }}-automated-pr
+  labels:
+    {{- include "fairwinds-insights.labels" . | nindent 4 }}
+    app.kubernetes.io/component: automated-pr
+    {{- if .Values.deployments.additionalLabels }}
+    {{ toYaml .Values.deployments.additionalLabels | nindent 4 }}
+    {{- end }}
+  annotations:
+    polaris.fairwinds.com/livenessProbeMissing-exempt: "true"
+    polaris.fairwinds.com/readinessProbeMissing-exempt: "true"
+spec:
+  selector:
+    matchLabels:
+      {{- include "fairwinds-insights.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: automated-pr
+  template:
+    metadata:
+      labels:
+        {{- include "fairwinds-insights.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: automated-pr
+        {{- if .Values.deployments.additionalPodLabels }}
+        {{ toYaml .Values.deployments.additionalPodLabels | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.image.pullSecret }}
+      imagePullSecrets:
+        - name: {{ . }}
+      {{- end }}
+      serviceAccountName: {{ include "fairwinds-insights.fullname" . }}-insights
+      containers:
+        - name: fairwinds-insights
+          image: "{{ .Values.apiImage.repository }}:{{ include "fairwinds-insights.apiImageTag" . }}"
+          imagePullPolicy: Always
+          command: ["automated_pull_requests_processor"]
+          {{- include "env" . | indent 10 }}
+          volumeMounts:
+            - name: secrets
+              mountPath: /var/run/secrets/github
+            - name: clone-dir
+              mountPath: /tmp/clone_dir
+          resources:
+            {{- toYaml .Values.automatedPullRequest.resources | nindent 12 }}
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            privileged: false
+            runAsNonRoot: true
+            runAsUser: 10324
+            capabilities:
+              drop:
+                - ALL
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: secrets
+          secret:
+            secretName: github-secrets
+            optional: true
+        - name: clone-dir
+          emptyDir:
+            sizeLimit: {{ .Values.automatedPullRequest.cloneDir.sizeLimit }}
+    {{- with .Values.automatedPullRequest.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+{{- end }}

--- a/stable/fairwinds-insights/templates/hpa-automated-pr.yaml
+++ b/stable/fairwinds-insights/templates/hpa-automated-pr.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.automatedPullRequest.hpa.enabled }}
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "fairwinds-insights.fullname" . }}-automated-pr-hpa
+  labels:
+    {{- include "fairwinds-insights.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: automated-pr
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "fairwinds-insights.fullname" . }}-automated-pr
+  minReplicas: {{ .Values.automatedPullRequest.hpa.min }}
+  maxReplicas: {{ .Values.automatedPullRequest.hpa.max }}
+  metrics:
+  {{- toYaml .Values.automatedPullRequest.hpa.metrics | nindent 4 }}
+{{- end }}

--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -626,6 +626,40 @@ reportjob:
   nodeSelector: {}
   tolerations: []
 
+automatedPullRequest:
+  enabled: true
+  hpa:
+    enabled: true
+    min: 1
+    max: 3
+    metrics:
+      - type: Resource
+        resource:
+          name: cpu
+          target:
+            type: Utilization
+            averageUtilization: 75
+      - type: Resource
+        resource:
+          name: memory
+          target:
+            type: Utilization
+            averageUtilization: 75
+  resources:
+    limits:
+      cpu: 500m
+      memory: 1024Mi
+    requests:
+      cpu: 250m
+      memory: 512Mi
+  nodeSelector: {}
+  tolerations: []
+  cloneDir:
+    sizeLimit: 2Gi
+  git:
+    email: bot@fairwinds.com
+    username: Fairwinds Insights
+
 repoScanJob:
   enabled: false
   insightsCIVersion: "4.2"


### PR DESCRIPTION
**Why This PR?**
Add deployment and hpa for automated pull request processor

Fixes internal FWI-3686

**Changes**
Changes proposed in this pull request:

* add deployment` and `hpa` for automated pull request processor which currently clone, run polaris and create fix PR on Github for the selected action items 

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
