### PR TITLE
[stable/rbac-manager] Fix crd automount service account token field

### DIFF
--- a/stable/rbac-manager/Chart.yaml
+++ b/stable/rbac-manager/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rbac-manager
-version: 1.15.2
+version: 1.15.3
 appVersion: 1.4.2
 description: A Kubernetes operator that simplifies the management of Role Bindings and Service Accounts.
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/rbac-manager/icon.png

--- a/stable/rbac-manager/templates/customresourcedefinition.yaml
+++ b/stable/rbac-manager/templates/customresourcedefinition.yaml
@@ -89,6 +89,8 @@ spec:
                     items:
                       type: object
                       properties:
+                        automountServiceAccountToken:
+                          type: boolean
                         imagePullSecrets:
                           type: array
                           items:


### PR DESCRIPTION
**Why This PR?**
This PR adds the `automountServiceAccountToken` field to CRD.

Fixes #1103 and https://github.com/FairwindsOps/rbac-manager/issues/370

**Changes**
* Add missing `automountServiceAccountToken` field to CRD

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
