### PR TITLE
[stable/fairwinds-insights] fix service-account for automated-pr-job

### DIFF
--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.12.1
+* fix service-account ref. for automated-pr-jobs deployment
+
 ## 0.12.0
 * Add `automatedPullRequestJob` support to `stable/fairwinds-insights`.
 

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "11.7"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 0.12.0
+version: 0.12.1
 maintainers:
   - name: rbren
   - name: mhoss019

--- a/stable/fairwinds-insights/templates/deployment-automated-pr-job.yaml
+++ b/stable/fairwinds-insights/templates/deployment-automated-pr-job.yaml
@@ -30,7 +30,7 @@ spec:
       imagePullSecrets:
         - name: {{ . }}
       {{- end }}
-      serviceAccountName: {{ include "fairwinds-insights.fullname" . }}-insights
+      serviceAccountName: {{ include "fairwinds-insights.fullname" . }}-automated-pr-job
       containers:
         - name: fairwinds-insights
           image: "{{ .Values.apiImage.repository }}:{{ include "fairwinds-insights.apiImageTag" . }}"


### PR DESCRIPTION
**Why This PR?**
Update service-account reference to the right one on automated-pr-job deployment

Fixes internal [FWI-3726](https://fairwinds.myjetbrains.com/youtrack/issue/FWI-3726/Fix-service-account-for-automated-pr-job)

**Changes**
Changes proposed in this pull request:

* Update service-account reference to the right one on automated-pr-job deployment

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
