### PR TITLE
[stable/fairwinds-insights] adds CRON_JOB_IMAGE_REPOSITORY to deployment env. vars

### DIFF
--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog
 
+## 0.12.2
+* Adds `CRON_JOB_IMAGE_REPOSITORY` to `stable/fairwinds-insights` deployments environment variables
+
 ## 0.12.1
-* fix service-account ref. for automated-pr-jobs deployment
+* Fix service-account ref. for automated-pr-jobs deployment
 
 ## 0.12.0
 * Add `automatedPullRequestJob` support to `stable/fairwinds-insights`.

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "11.7"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 0.12.1
+version: 0.12.2
 maintainers:
   - name: rbren
   - name: mhoss019

--- a/stable/fairwinds-insights/templates/_env.yaml
+++ b/stable/fairwinds-insights/templates/_env.yaml
@@ -176,6 +176,8 @@ env:
   value: {{ .Values.repoScanJob.insightsCIVersion | quote }}
 
 # tag used for the fixer container 
+- name: CRON_JOB_IMAGE_REPOSITORY
+  value: {{ .Values.cronjobImage.repository | quote }}
 - name: CRON_JOB_IMAGE_TAG
   value: {{ include "fairwinds-insights.cronjobImageTag" . | quote }}
 {{ end }}


### PR DESCRIPTION
**Why This PR?**
Adds `CRON_JOB_IMAGE_REPOSITORY` to deployment env. vars

Fixes #

**Changes**
Changes proposed in this pull request:

* adds CRON_JOB_IMAGE_REPOSITORY to deployment env. vars

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
