### PR TITLE
[stable/goldilocks] Set enableArgoproj to false by default

### DIFF
--- a/stable/goldilocks/Chart.yaml
+++ b/stable/goldilocks/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 appVersion: "v4.6.3"
-version: 6.5.1
+version: 6.5.2
 description: |
   A Helm chart for running Fairwinds Goldilocks. See https://github.com/FairwindsOps/goldilocks
 name: goldilocks

--- a/stable/goldilocks/README.md
+++ b/stable/goldilocks/README.md
@@ -68,7 +68,7 @@ This will completely remove the VPA and then re-install it using the new method.
 | fullnameOverride | string | `""` |  |
 | controller.enabled | bool | `true` | Whether or not to install the controller deployment |
 | controller.rbac.create | bool | `true` | If set to true, rbac resources will be created for the controller |
-| controller.rbac.enableArgoproj | bool | `true` | If set to true, the clusterrole will give access to argoproj.io resources |
+| controller.rbac.enableArgoproj | bool | `false` | If set to true, the clusterrole will give access to argoproj.io resources |
 | controller.rbac.extraRules | list | `[]` | Extra rbac rules for the controller clusterrole |
 | controller.rbac.extraClusterRoleBindings | list | `[]` | A list of ClusterRoles for which ClusterRoleBindings will be created for the ServiceAccount, if enabled |
 | controller.serviceAccount.create | bool | `true` | If true, a service account will be created for the controller. If set to false, you must set `controller.serviceAccount.name` |
@@ -97,7 +97,7 @@ This will completely remove the VPA and then re-install it using the new method.
 | dashboard.logVerbosity | string | `"2"` | Dashboard log verbosity. Can be set from 1-10 with 10 being extremely verbose |
 | dashboard.excludeContainers | string | `"linkerd-proxy,istio-proxy"` | Container names to exclude from displaying in the Goldilocks dashboard |
 | dashboard.rbac.create | bool | `true` | If set to true, rbac resources will be created for the dashboard |
-| dashboard.rbac.enableArgoproj | bool | `true` | If set to true, the clusterrole will give access to argoproj.io resources |
+| dashboard.rbac.enableArgoproj | bool | `false` | If set to true, the clusterrole will give access to argoproj.io resources |
 | dashboard.serviceAccount.create | bool | `true` | If true, a service account will be created for the dashboard. If set to false, you must set `dashboard.serviceAccount.name` |
 | dashboard.serviceAccount.name | string | `nil` | The name of an existing service account to use for the controller. Combined with `dashboard.serviceAccount.create` |
 | dashboard.deployment.annotations | object | `{}` | Extra annotations for the dashboard deployment |

--- a/stable/goldilocks/values.yaml
+++ b/stable/goldilocks/values.yaml
@@ -34,7 +34,7 @@ controller:
     # controller.rbac.create -- If set to true, rbac resources will be created for the controller
     create: true
     # controller.rbac.enableArgoproj -- If set to true, the clusterrole will give access to argoproj.io resources
-    enableArgoproj: true
+    enableArgoproj: false
     # controller.rbac.extraRules -- Extra rbac rules for the controller clusterrole
     extraRules: []
     # controller.rbac.extraClusterRoleBindings -- A list of ClusterRoles for which ClusterRoleBindings will be created for the ServiceAccount, if enabled
@@ -114,7 +114,7 @@ dashboard:
     # dashboard.rbac.create -- If set to true, rbac resources will be created for the dashboard
     create: true
     # dashboard.rbac.enableArgoproj -- If set to true, the clusterrole will give access to argoproj.io resources
-    enableArgoproj: true
+    enableArgoproj: false
   serviceAccount:
     # dashboard.serviceAccount.create -- If true, a service account will be created for the dashboard. If set to false, you must set `dashboard.serviceAccount.name`
     create: true


### PR DESCRIPTION
**Why This PR?**

Argo being not used by default, disable RBAC related to it.

Fixes #1109

**Changes**
Changes proposed in this pull request:

* Set enableArgoproj to false by default
**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
