### PR TITLE
[stable/fairwinds-insights] enable automatedPullRequestJob by default and update CIVersion to 5.0…

### DIFF
--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.12.4
+* Enable `automatedPullRequestJob` by default and update `repoScanJob.insightsCIVersion` to `5.0` which contains manifests `filename` fix 
+
 ## 0.12.3
 * Update application version to 11.8. [See the release notes for more details](https://insights.docs.fairwinds.com/release-notes)
 

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "11.8"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 0.12.3
+version: 0.12.4
 maintainers:
   - name: rbren
   - name: mhoss019

--- a/stable/fairwinds-insights/README.md
+++ b/stable/fairwinds-insights/README.md
@@ -207,7 +207,7 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | reportjob.resources.requests.memory | string | `"128Mi"` |  |
 | reportjob.nodeSelector | object | `{}` |  |
 | reportjob.tolerations | list | `[]` |  |
-| automatedPullRequestJob.enabled | string | `"enable"` |  |
+| automatedPullRequestJob.enabled | bool | `true` |  |
 | automatedPullRequestJob.hpa.enabled | bool | `true` |  |
 | automatedPullRequestJob.hpa.min | int | `2` |  |
 | automatedPullRequestJob.hpa.max | int | `4` |  |

--- a/stable/fairwinds-insights/README.md
+++ b/stable/fairwinds-insights/README.md
@@ -207,7 +207,7 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | reportjob.resources.requests.memory | string | `"128Mi"` |  |
 | reportjob.nodeSelector | object | `{}` |  |
 | reportjob.tolerations | list | `[]` |  |
-| automatedPullRequestJob.enabled | bool | `false` |  |
+| automatedPullRequestJob.enabled | string | `"enable"` |  |
 | automatedPullRequestJob.hpa.enabled | bool | `true` |  |
 | automatedPullRequestJob.hpa.min | int | `2` |  |
 | automatedPullRequestJob.hpa.max | int | `4` |  |
@@ -226,7 +226,7 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | automatedPullRequestJob.nodeSelector | object | `{}` |  |
 | automatedPullRequestJob.tolerations | list | `[]` |  |
 | repoScanJob.enabled | bool | `false` |  |
-| repoScanJob.insightsCIVersion | string | `"4.2"` |  |
+| repoScanJob.insightsCIVersion | string | `"5.0"` |  |
 | repoScanJob.hpa.enabled | bool | `true` |  |
 | repoScanJob.hpa.min | int | `2` |  |
 | repoScanJob.hpa.max | int | `6` |  |

--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -637,7 +637,7 @@ reportjob:
   tolerations: []
 
 automatedPullRequestJob:
-  enabled: false
+  enabled: enable
   hpa:
     enabled: true
     min: 2
@@ -667,7 +667,7 @@ automatedPullRequestJob:
 
 repoScanJob:
   enabled: false
-  insightsCIVersion: "4.2"
+  insightsCIVersion: "5.0"
   hpa:
     enabled: true
     min: 2

--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -637,7 +637,7 @@ reportjob:
   tolerations: []
 
 automatedPullRequestJob:
-  enabled: enable
+  enabled: true
   hpa:
     enabled: true
     min: 2


### PR DESCRIPTION
Fixes internal FWI-3724

**Why This PR?**
Enable `automatedPullRequestJob` by default and update `repoScanJob.insightsCIVersion` to `5.0` which contains manifests `filename` fix 

Fixes #

**Changes**
Changes proposed in this pull request:
* default configuration changes

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
