### PR TITLE
[stable/insights-agent]: Update Pluto and detect in-cluster resources  using the last-applied-configuration annotation

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.12.0
+* Update pluto, and detect in-cluster resources using the `last-applied-configuration` annotation.
+
 ## 2.11.0
 * Bumped AWS costs plugin for new Days parameter
 

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.11.0
+version: 2.12.0
 appVersion: 9.2.1
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:

--- a/stable/insights-agent/templates/pluto/cronjob.yaml
+++ b/stable/insights-agent/templates/pluto/cronjob.yaml
@@ -17,7 +17,7 @@ spec:
             args:
             - -c
             - |
-              /pluto detect-helm -ojson --target-versions {{ $.Values.pluto.targetVersions | default (printf "k8s=v%s.%s.0" .Capabilities.KubeVersion.Major (trimSuffix "+" .Capabilities.KubeVersion.Minor)) }} > /output/pluto-tmp.json
+              /pluto detect-all-in-cluster -ojson --target-versions {{ $.Values.pluto.targetVersions | default (printf "k8s=v%s.%s.0" .Capabilities.KubeVersion.Major (trimSuffix "+" .Capabilities.KubeVersion.Minor)) }} > /output/pluto-tmp.json
               cat /output/pluto-tmp.json
               mv /output/pluto-tmp.json /output/pluto.json
             env:

--- a/stable/insights-agent/templates/pluto/rbac.yaml
+++ b/stable/insights-agent/templates/pluto/rbac.yaml
@@ -21,6 +21,8 @@ subjects:
     name: {{ include "insights-agent.fullname" . }}-pluto
     namespace: {{ .Release.Namespace }}
 ---
+# This ClusterRole aims to grant Pluto access to resources that are not yet
+# part of the built-in view ClusterRole in earlier versions of Kubernetes.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -34,6 +36,140 @@ rules:
       - namespaces
       - secrets
       - configmaps
+      - componentstatuses
+      - nodes
+      - podtemplates
+      - persistentvolumes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "cert-manager.io"
+    resources:
+      - clusterissuers
+      - issuers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "flowcontrol.apiserver.k8s.io"
+    resources:
+      - flowschemas
+      - prioritylevelconfigurations
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "discovery.k8s.io"
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "node.k8s.io"
+    resources:
+      - runtimeclasses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "coordination.k8s.io"
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "scheduling.k8s.io"
+    resources:
+      - priorityclasses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "apiextensions.k8s.io"
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "admissionregistration.k8s.io"
+    resources:
+      - mutatingwebhookconfigurations
+      - validatingwebhookconfigurations
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "storage.k8s.io"
+    resources:
+      - csistoragecapacities
+      - csidrivers
+      - volumeattachments
+      - storageclasses
+      - csinodes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "rbac.authorization.k8s.io"
+    resources:
+      - clusterrolebindings
+      - clusterroles
+      - rolebindings
+      - roles
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "policy"
+    resources:
+      - podsecuritypolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "apiregistration.k8s.io"
+    resources:
+      - apiservices
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "events.k8s.io"
+    resources:
+      - events
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "networking.k8s.io"
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "certificates.k8s.io"
+    resources:
+      - certificatesigningrequests
     verbs:
       - get
       - list

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -278,7 +278,7 @@ pluto:
   targetVersions: ""
   image:
     repository: us-docker.pkg.dev/fairwinds-ops/oss/pluto
-    tag: "v5.13"
+    tag: "v5.15"
   resources:
     requests:
       cpu: 100m


### PR DESCRIPTION

**Why This PR?**
Update Pluto and detect in-cluster resources  using the last-applied-configuration annotation. This also updates the custom Pluto ClusterRole to support access to resources that may not be part of the built-in `view` ClusterRole as far back as Kube 1.21.


**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
