### PR TITLE
[incubator/vault-token-injector] Allow disabling liveness probe and update to v1.8.1

### DIFF
--- a/incubator/vault-token-injector/Chart.yaml
+++ b/incubator/vault-token-injector/Chart.yaml
@@ -5,7 +5,7 @@ description: |
 
   This will inject vault tokens and address variables into circle builds on a schedule
 type: application
-version: 2.2.0
+version: 2.3.0
 appVersion: "v1.6.0"
 maintainers:
   - name: transient1

--- a/incubator/vault-token-injector/Chart.yaml
+++ b/incubator/vault-token-injector/Chart.yaml
@@ -6,7 +6,7 @@ description: |
   This will inject vault tokens and address variables into circle builds on a schedule
 type: application
 version: 2.3.0
-appVersion: "v1.6.0"
+appVersion: "v1.8.1"
 maintainers:
   - name: transient1
   - name: sudermanjr

--- a/incubator/vault-token-injector/README.md
+++ b/incubator/vault-token-injector/README.md
@@ -31,7 +31,7 @@ Chart version 2.0.0 introduced a metrics endpoint by default.
 | metrics.serviceMonitor.labels | object | `{}` |  |
 | logLevel | int | `1` | The klog log level (1-10). WARNING: Log level 10 will print secrets to logs |
 | probes.liveness.enabled | bool | `false` |  |
-| image.repository | string | `"us-docker.pkg.dev/fairwinds-ops/oss/vault-token-injector"` | The image repository to pullt he vault-token-injector image from |
+| image.repository | string | `"us-docker.pkg.dev/fairwinds-ops/oss/vault-token-injector"` | The image repository to pull the vault-token-injector image from |
 | image.pullPolicy | string | `"Always"` | This is recommended to be set as Always |
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | imagePullSecrets | list | `[]` | A list of imagePullSecrets to use |

--- a/incubator/vault-token-injector/README.md
+++ b/incubator/vault-token-injector/README.md
@@ -1,4 +1,4 @@
-![Version: 2.2.0](https://img.shields.io/badge/Version-2.2.0-informational?style=flat-square)
+![Version: 2.3.0](https://img.shields.io/badge/Version-2.3.0-informational?style=flat-square)
 
 # Vault Token Injector Chart
 
@@ -30,7 +30,8 @@ Chart version 2.0.0 introduced a metrics endpoint by default.
 | metrics.serviceMonitor.scrapeTimeout | string | `"30s"` |  |
 | metrics.serviceMonitor.labels | object | `{}` |  |
 | logLevel | int | `1` | The klog log level (1-10). WARNING: Log level 10 will print secrets to logs |
-| image.repository | string | `"quay.io/fairwinds/vault-token-injector"` | The image repository to pullt he vault-token-injector image from |
+| probes.liveness.enabled | bool | `false` |  |
+| image.repository | string | `"us-docker.pkg.dev/fairwinds-ops/oss/vault-token-injector"` | The image repository to pullt he vault-token-injector image from |
 | image.pullPolicy | string | `"Always"` | This is recommended to be set as Always |
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | imagePullSecrets | list | `[]` | A list of imagePullSecrets to use |

--- a/incubator/vault-token-injector/templates/deployment.yaml
+++ b/incubator/vault-token-injector/templates/deployment.yaml
@@ -61,10 +61,12 @@ spec:
           - name: "VAULT_TOKEN_FILE"
             value: {{ .Values.vaultTokenFile | quote }}
           {{- end }}
+          {{- if .Values.probes.liveness.enabled }}
           livenessProbe:
             httpGet:
               path: /health
               port: metrics
+          {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/incubator/vault-token-injector/values.yaml
+++ b/incubator/vault-token-injector/values.yaml
@@ -38,6 +38,10 @@ metrics:
 # -- The klog log level (1-10). WARNING: Log level 10 will print secrets to logs
 logLevel: 1
 
+probes:
+  liveness:
+    enabled: false
+
 image:
   # -- The image repository to pullt he vault-token-injector image from
   repository: quay.io/fairwinds/vault-token-injector

--- a/incubator/vault-token-injector/values.yaml
+++ b/incubator/vault-token-injector/values.yaml
@@ -43,7 +43,7 @@ probes:
     enabled: false
 
 image:
-  # -- The image repository to pullt he vault-token-injector image from
+  # -- The image repository to pull the vault-token-injector image from
   repository: us-docker.pkg.dev/fairwinds-ops/oss/vault-token-injector
   # -- This is recommended to be set as Always
   pullPolicy: Always

--- a/incubator/vault-token-injector/values.yaml
+++ b/incubator/vault-token-injector/values.yaml
@@ -44,7 +44,7 @@ probes:
 
 image:
   # -- The image repository to pullt he vault-token-injector image from
-  repository: quay.io/fairwinds/vault-token-injector
+  repository: us-docker.pkg.dev/fairwinds-ops/oss/vault-token-injector
   # -- This is recommended to be set as Always
   pullPolicy: Always
   # -- Overrides the image tag whose default is the chart appVersion.


### PR DESCRIPTION
**Why This PR?**
Sometimes you don't want the pod to crash if it has errors

**Changes**
Changes proposed in this pull request:

* Add a value to the chart for enabling/disabling the liveness probe

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.