### PR TITLE
[stable/insights-admission]: Add ability to use a custom SSL certificate when communicating with the Insights API

### DIFF
--- a/stable/insights-admission/CHANGELOG.md
+++ b/stable/insights-admission/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 1.6.0
+* Add the ability to use a custom SSL certificate to validate communication with a self-hosted Insights API.
+
 ## 1.5.2
 * Add default topologySpreadConstraints
 

--- a/stable/insights-admission/Chart.yaml
+++ b/stable/insights-admission/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: insights-admission
 description: A Validating Webhook Admission Controller that utilizes Fairwinds Insights.
 type: application
-version: 1.5.2
+version: 1.6.0
 appVersion: "1.9"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-admission/icon.png
 maintainers:

--- a/stable/insights-admission/README.md
+++ b/stable/insights-admission/README.md
@@ -41,8 +41,8 @@ rules:
 | global.proxy.https | string | `nil` | Annotations used to access the proxy servers(https). |
 | global.proxy.ftp | string | `nil` | Annotations used to access the proxy servers(ftp). |
 | global.proxy.no_proxy | string | `nil` | Annotations to provides a way to exclude traffic destined to certain hosts from using the proxy. |
-| global.sslCertFile.secretName | string | `nil` | The name of an existing Secret containing an SSL certificate file to be used when communicating with a self-hosted Insights API. |
-| global.sslCertFile.secretKey | string | `nil` | The key, within global.sslCertFile.secretName, containing an SSL certificate file to be used when communicating with a self-hosted Insights API. |
+| global.sslCertFileSecretName | string | `nil` | The name of an existing Secret containing an SSL certificate file to be used when communicating with a self-hosted Insights API. |
+| global.sslCertFileSecretKey | string | `nil` | The key, within global.sslCertFileSecretName, containing an SSL certificate file to be used when communicating with a self-hosted Insights API. |
 | insights.organization | string | `""` | The name of your Organization from Fairwinds Insights |
 | insights.cluster | string | `""` | The name of your cluster from Fairwinds Insights |
 | insights.host | string | `"https://insights.fairwinds.com"` | Override the hostname for Fairwinds Insights |

--- a/stable/insights-admission/README.md
+++ b/stable/insights-admission/README.md
@@ -41,6 +41,8 @@ rules:
 | global.proxy.https | string | `nil` | Annotations used to access the proxy servers(https). |
 | global.proxy.ftp | string | `nil` | Annotations used to access the proxy servers(ftp). |
 | global.proxy.no_proxy | string | `nil` | Annotations to provides a way to exclude traffic destined to certain hosts from using the proxy. |
+| global.sslCertFile.secretName | string | `nil` | The name of an existing Secret containing an SSL certificate file to be used when communicating with a self-hosted Insights API. |
+| global.sslCertFile.secretKey | string | `nil` | The key, within global.sslCertFile.secretName, containing an SSL certificate file to be used when communicating with a self-hosted Insights API. |
 | insights.organization | string | `""` | The name of your Organization from Fairwinds Insights |
 | insights.cluster | string | `""` | The name of your cluster from Fairwinds Insights |
 | insights.host | string | `"https://insights.fairwinds.com"` | Override the hostname for Fairwinds Insights |

--- a/stable/insights-admission/templates/_specs.yaml
+++ b/stable/insights-admission/templates/_specs.yaml
@@ -25,3 +25,29 @@
   value: {{ .Values.global.proxy.no_proxy }}
 {{- end }}
 {{- end }}
+
+{{ define "ssl-cert-file-volume-spec" }}
+{{- if and .Values.global.sslCertFile.secretName .Values.global.sslCertFile.secretKey }}
+- name: sslcertfile
+  secret:
+    secretName: {{ .Values.global.sslCertFile.secretName }}
+    items:
+    - key: {{ .Values.global.sslCertFile.secretKey }}
+      path: ca.crt
+{{- end }}
+{{- end }}
+
+{{ define "ssl-cert-file-volumemount-spec" }}
+{{- if and .Values.global.sslCertFile.secretName .Values.global.sslCertFile.secretKey }}
+- name: sslcertfile
+  mountPath: /ssl-cert-file
+{{- end }}
+{{- end }}
+
+{{ define "ssl-cert-file-env-spec" }}
+{{- if and .Values.global.sslCertFile.secretName .Values.global.sslCertFile.secretKey }}
+- name: SSL_CERT_FILE
+  value: /ssl-cert-file/ca.crt
+  {{- end }}
+  {{- end }}
+

--- a/stable/insights-admission/templates/_specs.yaml
+++ b/stable/insights-admission/templates/_specs.yaml
@@ -48,6 +48,6 @@
 {{- if and .Values.global.sslCertFile.secretName .Values.global.sslCertFile.secretKey }}
 - name: SSL_CERT_FILE
   value: /ssl-cert-file/ca.crt
-  {{- end }}
-  {{- end }}
+{{- end }}
+{{- end }}
 

--- a/stable/insights-admission/templates/_specs.yaml
+++ b/stable/insights-admission/templates/_specs.yaml
@@ -27,25 +27,25 @@
 {{- end }}
 
 {{ define "ssl-cert-file-volume-spec" }}
-{{- if and ((.Values.global.sslCertFile.secretName)) ((.Values.global.sslCertFile.secretKey)) }}
+{{- if and .Values.global.sslCertFileSecretName .Values.global.sslCertFileSecretKey }}
 - name: sslcertfile
   secret:
-    secretName: {{ .Values.global.sslCertFile.secretName }}
+    secretName: {{ .Values.global.sslCertFileSecretName }}
     items:
-    - key: {{ .Values.global.sslCertFile.secretKey }}
+    - key: {{ .Values.global.sslCertFileSecretKey }}
       path: ca.crt
 {{- end }}
 {{- end }}
 
 {{ define "ssl-cert-file-volumemount-spec" }}
-{{- if and ((.Values.global.sslCertFile.secretName)) ((.Values.global.sslCertFile.secretKey)) }}
+{{- if and .Values.global.sslCertFileSecretName .Values.global.sslCertFileSecretKey }}
 - name: sslcertfile
   mountPath: /ssl-cert-file
 {{- end }}
 {{- end }}
 
 {{ define "ssl-cert-file-env-spec" }}
-{{- if and ((.Values.global.sslCertFile.secretName)) ((.Values.global.sslCertFile.secretKey)) }}
+{{- if and .Values.global.sslCertFileSecretName .Values.global.sslCertFileSecretKey }}
 - name: SSL_CERT_FILE
   value: /ssl-cert-file/ca.crt
 {{- end }}

--- a/stable/insights-admission/templates/_specs.yaml
+++ b/stable/insights-admission/templates/_specs.yaml
@@ -27,7 +27,7 @@
 {{- end }}
 
 {{ define "ssl-cert-file-volume-spec" }}
-{{- if and .Values.global.sslCertFile.secretName .Values.global.sslCertFile.secretKey }}
+{{- if and ((.Values.global.sslCertFile.secretName)) ((.Values.global.sslCertFile.secretKey)) }}
 - name: sslcertfile
   secret:
     secretName: {{ .Values.global.sslCertFile.secretName }}
@@ -38,14 +38,14 @@
 {{- end }}
 
 {{ define "ssl-cert-file-volumemount-spec" }}
-{{- if and .Values.global.sslCertFile.secretName .Values.global.sslCertFile.secretKey }}
+{{- if and ((.Values.global.sslCertFile.secretName)) ((.Values.global.sslCertFile.secretKey)) }}
 - name: sslcertfile
   mountPath: /ssl-cert-file
 {{- end }}
 {{- end }}
 
 {{ define "ssl-cert-file-env-spec" }}
-{{- if and .Values.global.sslCertFile.secretName .Values.global.sslCertFile.secretKey }}
+{{- if and ((.Values.global.sslCertFile.secretName)) ((.Values.global.sslCertFile.secretKey)) }}
 - name: SSL_CERT_FILE
   value: /ssl-cert-file/ca.crt
 {{- end }}

--- a/stable/insights-admission/templates/deployment.yaml
+++ b/stable/insights-admission/templates/deployment.yaml
@@ -61,6 +61,7 @@ spec:
           - name: secret
             mountPath: /opt/cert/
             readOnly: true
+{{ include "ssl-cert-file-volumemount-spec" . | indent 10 }}
           env:
           # This is always specified as pluto is enabled in Insights settings.
           - name: PLUTO_TARGET_VERSIONS
@@ -94,6 +95,7 @@ spec:
           - name: FAIRWINDS_IGNORE_USERNAMES
             value: {{ .Values.ignoreRequestUsernames }}
           {{ include "proxy-env-spec" . | indent 10 | trim }}
+          {{ include "ssl-cert-file-env-spec" . | indent 10 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}
@@ -119,4 +121,5 @@ spec:
           secretName: {{ . }}
           {{- else }}
           secretName: {{ include "insights-admission.fullname" . }}
+{{ include "ssl-cert-file-volume-spec" . | indent 6 }}
           {{- end }}

--- a/stable/insights-admission/values.yaml
+++ b/stable/insights-admission/values.yaml
@@ -8,11 +8,11 @@ global:
     ftp:
     # global.proxy.no_proxy -- Annotations to provides a way to exclude traffic destined to certain hosts from using the proxy.
     no_proxy:
-  sslCertFile: {}
+  sslCertFile:
     # global.sslCertFile.secretName -- The name of an existing Secret containing an SSL certificate file to be used when communicating with a self-hosted Insights API.
-    # secretName:
+    secretName:
     # global.sslCertFile.secretKey -- The key, within global.sslCertFile.secretName, containing an SSL certificate file to be used when communicating with a self-hosted Insights API.
-    # secretKey:
+    secretKey:
 
 insights:
   # insights.organization -- The name of your Organization from Fairwinds Insights

--- a/stable/insights-admission/values.yaml
+++ b/stable/insights-admission/values.yaml
@@ -8,6 +8,11 @@ global:
     ftp:
     # global.proxy.no_proxy -- Annotations to provides a way to exclude traffic destined to certain hosts from using the proxy.
     no_proxy:
+  sslCertFile:
+    # global.sslCertFile.secretName -- The name of an existing Secret containing an SSL certificate file to be used when communicating with a self-hosted Insights API.
+    secretName:
+    # global.sslCertFile.secretKey -- The key, within global.sslCertFile.secretName, containing an SSL certificate file to be used when communicating with a self-hosted Insights API.
+    secretKey:
 
 insights:
   # insights.organization -- The name of your Organization from Fairwinds Insights

--- a/stable/insights-admission/values.yaml
+++ b/stable/insights-admission/values.yaml
@@ -8,11 +8,10 @@ global:
     ftp:
     # global.proxy.no_proxy -- Annotations to provides a way to exclude traffic destined to certain hosts from using the proxy.
     no_proxy:
-  sslCertFile:
-    # global.sslCertFile.secretName -- The name of an existing Secret containing an SSL certificate file to be used when communicating with a self-hosted Insights API.
-    secretName:
-    # global.sslCertFile.secretKey -- The key, within global.sslCertFile.secretName, containing an SSL certificate file to be used when communicating with a self-hosted Insights API.
-    secretKey:
+  # global.sslCertFileSecretName -- The name of an existing Secret containing an SSL certificate file to be used when communicating with a self-hosted Insights API.
+  sslCertFileSecretName:
+  # global.sslCertFileSecretKey -- The key, within global.sslCertFileSecretName, containing an SSL certificate file to be used when communicating with a self-hosted Insights API.
+  sslCertFileSecretKey:
 
 insights:
   # insights.organization -- The name of your Organization from Fairwinds Insights

--- a/stable/insights-admission/values.yaml
+++ b/stable/insights-admission/values.yaml
@@ -8,11 +8,11 @@ global:
     ftp:
     # global.proxy.no_proxy -- Annotations to provides a way to exclude traffic destined to certain hosts from using the proxy.
     no_proxy:
-  sslCertFile:
+  sslCertFile: {}
     # global.sslCertFile.secretName -- The name of an existing Secret containing an SSL certificate file to be used when communicating with a self-hosted Insights API.
-    secretName:
+    #secretName:
     # global.sslCertFile.secretKey -- The key, within global.sslCertFile.secretName, containing an SSL certificate file to be used when communicating with a self-hosted Insights API.
-    secretKey:
+    #secretKey:
 
 insights:
   # insights.organization -- The name of your Organization from Fairwinds Insights

--- a/stable/insights-admission/values.yaml
+++ b/stable/insights-admission/values.yaml
@@ -10,9 +10,9 @@ global:
     no_proxy:
   sslCertFile: {}
     # global.sslCertFile.secretName -- The name of an existing Secret containing an SSL certificate file to be used when communicating with a self-hosted Insights API.
-    #secretName:
+    # secretName:
     # global.sslCertFile.secretKey -- The key, within global.sslCertFile.secretName, containing an SSL certificate file to be used when communicating with a self-hosted Insights API.
-    #secretKey:
+    # secretKey:
 
 insights:
   # insights.organization -- The name of your Organization from Fairwinds Insights


### PR DESCRIPTION
**Why This PR?**
Add the ability to use a custom SSL certificate when communicating with the Insights API. THIs is useful for self-hosted Insights that use a self-signed certificate or certificate authority on the API Kubernetes Ingress.

These new chart values are also used by an [identical feature for the insights-agent chart](https://github.com/FairwindsOps/charts/pull/1121).

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
