### PR TITLE
[stable/insights-agent]: FWI-3806: Add ability to use a custom SSL certificate when communicating with the Insights API

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.12.0
+* Add the ability to use a custom SSL certificate to validate communication with a self-hosted Insights API.
+
 ## 2.11.1
 * Changed the backend for the fleet installer test
 

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.11.1
+version: 2.12.0
 appVersion: 9.2.1
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:

--- a/stable/insights-agent/README.md
+++ b/stable/insights-agent/README.md
@@ -65,8 +65,8 @@ Parameter | Description | Default
 `global.proxy.https` | Annotations used to access the proxy servers(https) | ""
 `global.proxy.ftp` | Annotations used to access the proxy servers(ftp) | ""
 `global.proxy.no_proxy` | Annotations to provides a way to exclude traffic destined to certain hosts from using the proxy | ""
-`global.sslCertFile.secretName` | The name of an existing Secret containing an SSL certificate file to be used when communicating with a self-hosted Insights API. | ""
-`global.sslCertFile.secretKey` | The key, within global.sslCertFile.secretName, containing an SSL certificate file to be used when communicating with a self-hosted Insights API. | ""
+`global.sslCertFileSecretName` | The name of an existing Secret containing an SSL certificate file to be used when communicating with a self-hosted Insights API. | ""
+`global.sslCertFileSecretKey` | The key, within global.sslCertFileSecretName, containing an SSL certificate file to be used when communicating with a self-hosted Insights API. | ""
 `insights.apiToken` | Only needed if `fleetInstall=true` | ""
 `uploader.image.repository`  | The repository to pull the uploader script from | quay.io/fairwinds/insights-uploader
 `uploader.imagePullSecret` | A pull secret for a private uploader image

--- a/stable/insights-agent/README.md
+++ b/stable/insights-agent/README.md
@@ -65,6 +65,8 @@ Parameter | Description | Default
 `global.proxy.https` | Annotations used to access the proxy servers(https) | ""
 `global.proxy.ftp` | Annotations used to access the proxy servers(ftp) | ""
 `global.proxy.no_proxy` | Annotations to provides a way to exclude traffic destined to certain hosts from using the proxy | ""
+`global.sslCertFile.secretName` | The name of an existing Secret containing an SSL certificate file to be used when communicating with a self-hosted Insights API. | ""
+`global.sslCertFile.secretKey` | The key, within global.sslCertFile.secretName, containing an SSL certificate file to be used when communicating with a self-hosted Insights API. | ""
 `insights.apiToken` | Only needed if `fleetInstall=true` | ""
 `uploader.image.repository`  | The repository to pull the uploader script from | quay.io/fairwinds/insights-uploader
 `uploader.imagePullSecret` | A pull secret for a private uploader image

--- a/stable/insights-agent/requirements.yaml
+++ b/stable/insights-agent/requirements.yaml
@@ -9,7 +9,7 @@ dependencies:
   condition: prometheus-metrics.installPrometheusServer
 - name: insights-admission
   repository: https://charts.fairwinds.com/stable
-  version: '1.5.*'
+  version: '1.6.*'
   condition: admission.enabled
 - name: falco
   repository: https://falcosecurity.github.io/charts

--- a/stable/insights-agent/templates/_specs.yaml
+++ b/stable/insights-agent/templates/_specs.yaml
@@ -62,7 +62,7 @@ tolerations:
 securityContext:
   {{- toYaml . | nindent 2 }}
 {{- end }}
-{{- if or (not .Config.SkipVolumes) (and .Values.global.sslCertFile.secretName .Values.global.sslCertFile.secretKey) }}
+{{- if or (not .Config.SkipVolumes) (and .Values.global.sslCertFileSecretName .Values.global.sslCertFileSecretKey) }}
 volumes:
 {{- end }}
 {{- if not .Config.SkipVolumes }}
@@ -82,7 +82,7 @@ imagePullSecrets:
 {{- end }}
 resources:
   {{- toYaml .Config.resources | nindent 2 }}
-{{- if and .Values.global.sslCertFile.secretName .Values.global.sslCertFile.secretKey }}
+{{- if and .Values.global.sslCertFileSecretName .Values.global.sslCertFileSecretKey }}
 env:
 {{ include "ssl-cert-file-env-spec" . | trim }}
 {{- end }}
@@ -209,25 +209,25 @@ securityContext:
 {{- end }}
 {{- end }}
 {{ define "ssl-cert-file-volume-spec" }}
-{{- if and .Values.global.sslCertFile.secretName .Values.global.sslCertFile.secretKey }}
+{{- if and .Values.global.sslCertFileSecretName .Values.global.sslCertFileSecretKey }}
 - name: sslcertfile
   secret:
-    secretName: {{ .Values.global.sslCertFile.secretName }}
+    secretName: {{ .Values.global.sslCertFileSecretName }}
     items:
-    - key: {{ .Values.global.sslCertFile.secretKey }}
+    - key: {{ .Values.global.sslCertFileSecretKey }}
       path: ca.crt
 {{- end }}
 {{- end }}
 
 {{ define "ssl-cert-file-volumemount-spec" }}
-{{- if and .Values.global.sslCertFile.secretName .Values.global.sslCertFile.secretKey }}
+{{- if and .Values.global.sslCertFileSecretName .Values.global.sslCertFileSecretKey }}
 - name: sslcertfile
   mountPath: /ssl-cert-file
 {{- end }}
 {{- end }}
 
 {{ define "ssl-cert-file-env-spec" }}
-{{- if and .Values.global.sslCertFile.secretName .Values.global.sslCertFile.secretKey }}
+{{- if and .Values.global.sslCertFileSecretName .Values.global.sslCertFileSecretKey }}
 - name: SSL_CERT_FILE
   value: /ssl-cert-file/ca.crt
   {{- end }}

--- a/stable/insights-agent/templates/_specs.yaml
+++ b/stable/insights-agent/templates/_specs.yaml
@@ -62,11 +62,14 @@ tolerations:
 securityContext:
   {{- toYaml . | nindent 2 }}
 {{- end }}
-{{- if not .Config.SkipVolumes }}
+{{- if or (not .Config.SkipVolumes) (and .Values.global.sslCertFile.secretName .Values.global.sslCertFile.secretKey) }}
 volumes:
+{{- end }}
+{{- if not .Config.SkipVolumes }}
 - name: output
   emptyDir: {}
 {{- end }}
+{{ include "ssl-cert-file-volume-spec" . | trim }}
 {{- end }}
 
 {{ define "container-spec" }}
@@ -79,9 +82,14 @@ imagePullSecrets:
 {{- end }}
 resources:
   {{- toYaml .Config.resources | nindent 2 }}
+{{- if and .Values.global.sslCertFile.secretName .Values.global.sslCertFile.secretKey }}
+env:
+{{ include "ssl-cert-file-env-spec" . | trim }}
+{{- end }}
 volumeMounts:
 - name: output
   mountPath: /output
+{{ include "ssl-cert-file-volumemount-spec" . }}
 {{- end }}
 
 {{ define "get-config-container" }}
@@ -140,9 +148,11 @@ initContainers:
   {{- with .Values.uploader.env }}
   {{- toYaml . | nindent 2 }}
   {{- end }}
+  {{ include "ssl-cert-file-env-spec" . | indent 2 }}
   volumeMounts:
   - name: output
     mountPath: /output
+{{ include "ssl-cert-file-volumemount-spec" . | indent 2 }}
   resources:
     {{- toYaml .Values.uploader.resources | nindent 4 }}
   securityContext:
@@ -198,3 +208,28 @@ securityContext:
   value: {{ .Values.global.proxy.no_proxy }}
 {{- end }}
 {{- end }}
+{{ define "ssl-cert-file-volume-spec" }}
+{{- if and .Values.global.sslCertFile.secretName .Values.global.sslCertFile.secretKey }}
+- name: sslcertfile
+  secret:
+    secretName: {{ .Values.global.sslCertFile.secretName }}
+    items:
+    - key: {{ .Values.global.sslCertFile.secretKey }}
+      path: ca.crt
+{{- end }}
+{{- end }}
+
+{{ define "ssl-cert-file-volumemount-spec" }}
+{{- if and .Values.global.sslCertFile.secretName .Values.global.sslCertFile.secretKey }}
+- name: sslcertfile
+  mountPath: /ssl-cert-file
+{{- end }}
+{{- end }}
+
+{{ define "ssl-cert-file-env-spec" }}
+{{- if and .Values.global.sslCertFile.secretName .Values.global.sslCertFile.secretKey }}
+- name: SSL_CERT_FILE
+  value: /ssl-cert-file/ca.crt
+  {{- end }}
+  {{- end }}
+

--- a/stable/insights-agent/templates/_uploader.yaml
+++ b/stable/insights-agent/templates/_uploader.yaml
@@ -48,16 +48,12 @@
   {{- toYaml . | nindent 2 }}
   {{- end }}
   {{ include "proxy-env-spec" . | indent 2 | trim }}
-  {{- if and .Values.global.sslCertFile.secretName .Values.global.sslCertFile.secretKey }}
   {{ include "ssl-cert-file-env-spec" . | indent 2 | trim }}
-  {{- end }}
 
   volumeMounts:
   - name: output
     mountPath: /output
-{{- if and .Values.global.sslCertFile.secretName .Values.global.sslCertFile.secretKey }}
 {{ include "ssl-cert-file-volumemount-spec" . | indent 2 }}
-{{- end }}
   resources:
     {{- toYaml .Values.uploader.resources | nindent 4 }}
   securityContext:

--- a/stable/insights-agent/templates/_uploader.yaml
+++ b/stable/insights-agent/templates/_uploader.yaml
@@ -48,9 +48,16 @@
   {{- toYaml . | nindent 2 }}
   {{- end }}
   {{ include "proxy-env-spec" . | indent 2 | trim }}
+  {{- if and .Values.global.sslCertFile.secretName .Values.global.sslCertFile.secretKey }}
+  {{ include "ssl-cert-file-env-spec" . | indent 2 | trim }}
+  {{- end }}
+
   volumeMounts:
   - name: output
     mountPath: /output
+{{- if and .Values.global.sslCertFile.secretName .Values.global.sslCertFile.secretKey }}
+{{ include "ssl-cert-file-volumemount-spec" . | indent 2 }}
+{{- end }}
   resources:
     {{- toYaml .Values.uploader.resources | nindent 4 }}
   securityContext:

--- a/stable/insights-agent/templates/falco/cronjob.yaml
+++ b/stable/insights-agent/templates/falco/cronjob.yaml
@@ -28,6 +28,7 @@ spec:
               mountPath: /output
             - name: tmp
               mountPath: /tmp
+            {{ include "ssl-cert-file-volumemount-spec" . | indent 12 }}
             command: ["sh"]
             args:
                 - -c

--- a/stable/insights-agent/templates/fleet-installer/job.yaml
+++ b/stable/insights-agent/templates/fleet-installer/job.yaml
@@ -24,7 +24,7 @@ spec:
           - |
             {{ .Files.Get "download-kubectl.sh" | nindent 12 }}
           
-            {{- if and .Values.global.sslCertFile.secretName .Values.global.sslCertFile.secretKey }}
+            {{- if and .Values.global.sslCertFileSecretName .Values.global.sslCertFileSecretKey }}
             export SSL_CERT_FILE='/ssl-cert-file/ca.crt'
             echo "Using SSL certificate file ${SSL_CERT_FILE} from here on..."
             {{- end }}

--- a/stable/insights-agent/templates/fleet-installer/job.yaml
+++ b/stable/insights-agent/templates/fleet-installer/job.yaml
@@ -24,6 +24,10 @@ spec:
           - |
             {{ .Files.Get "download-kubectl.sh" | nindent 12 }}
           
+            {{- if and .Values.global.sslCertFile.secretName .Values.global.sslCertFile.secretKey }}
+            export SSL_CERT_FILE='/ssl-cert-file/ca.crt'
+            echo "Using SSL certificate file ${SSL_CERT_FILE} from here on..."
+            {{- end }}
             echo "Checking if cluster already exists..."
             CLUSTER_FILE="/tmp/cluster.json"
             SECRET_NAME="{{ required "You must specify insights.tokenSecretName for a fleet install" .Values.insights.tokenSecretName }}"
@@ -57,6 +61,7 @@ spec:
         volumeMounts:
         - name: tmp
           mountPath: /tmp
+        {{ include "ssl-cert-file-volumemount-spec" . | indent 8 }}
         securityContext:
           runAsUser: 1000
           readOnlyRootFilesystem: true
@@ -69,4 +74,5 @@ spec:
       volumes:
       - name: tmp
         emptyDir: {}
-{{- end -}}
+      {{ include "ssl-cert-file-volume-spec" . | indent 6 }}
+          {{- end -}}

--- a/stable/insights-agent/templates/install-reporter/job.yaml
+++ b/stable/insights-agent/templates/install-reporter/job.yaml
@@ -40,6 +40,7 @@ spec:
           mountPath: /opt/app/values.json
           subPath: values.json
           readOnly: true
+{{ include "ssl-cert-file-volumemount-spec" . | indent 8 }}
         securityContext:
           runAsUser: 1000
           readOnlyRootFilesystem: true
@@ -50,17 +51,19 @@ spec:
             drop:
               - ALL
         env:
-        - name: FAIRWINDS_TOKEN
-          valueFrom:
-            secretKeyRef:
-              {{ if .Values.insights.tokenSecretName -}}
+          - name: FAIRWINDS_TOKEN
+            valueFrom:
+              secretKeyRef:
+                {{ if .Values.insights.tokenSecretName -}}
               name: {{ .Values.insights.tokenSecretName }}
-              {{ else -}}
+                {{ else -}}
               name: {{ include "insights-agent.fullname" . }}-token
-              {{ end -}}
+                {{ end -}}
               key: token
         {{ include "proxy-env-spec" . | indent 8 | trim }}
+        {{ include "ssl-cert-file-env-spec" . | indent 10 }}
       volumes:
       - name: values
         configMap:
           name: {{ include "insights-agent.fullname" $ }}-values
+{{ include "ssl-cert-file-volume-spec" . | indent 6 }}

--- a/stable/insights-agent/templates/kube-bench/_container.yaml
+++ b/stable/insights-agent/templates/kube-bench/_container.yaml
@@ -26,6 +26,7 @@ volumes:
   hostPath:
     path: "/usr/bin"
     type: Directory
+{{ include "ssl-cert-file-volume-spec" . }}
 containers:
 - image: "{{ (index .Values "kube-bench" "image" "repository") }}:{{ (index .Values "kube-bench" "image" "tag") }}"
   imagePullPolicy: Always

--- a/stable/insights-agent/templates/kube-bench/cronjob.yaml
+++ b/stable/insights-agent/templates/kube-bench/cronjob.yaml
@@ -17,8 +17,9 @@ spec:
         {{ include "job-spec-metadata" . | nindent 8 | trim }}
         spec:
           {{ include "job-template-spec" . | indent 10 | trim }}
-          {{- if or (eq (index .Values "kube-bench" "mode") "daemonsetMaster") (eq (index .Values "kube-bench" "mode") "daemonset") }}
           volumes:
+          {{ include "ssl-cert-file-volume-spec" . | indent 10 }}
+          {{- if or (eq (index .Values "kube-bench" "mode") "daemonsetMaster") (eq (index .Values "kube-bench" "mode") "daemonset") }}
           - name: output
             emptyDir: {}
           containers:

--- a/stable/insights-agent/templates/nova/cronjob.yaml
+++ b/stable/insights-agent/templates/nova/cronjob.yaml
@@ -33,6 +33,7 @@ spec:
               - -v{{ .Config.logLevel }}
             env:
             {{ include "proxy-env-spec" . | indent 12 | trim }}
+            {{ include "ssl-cert-file-env-spec" . | indent 12 }}
             {{ include "security-context" . | indent 12 | trim }}
           {{ include "uploaderContainer" . | indent 10 | trim }}
           volumes:
@@ -43,4 +44,5 @@ spec:
                 name: {{ include "insights-agent.fullname" $ }}-nova-config
             - name: tmp
               emptyDir: {}
-{{- end -}}
+            {{ include "ssl-cert-file-volume-spec" . | indent 12 }}
+                {{- end -}}

--- a/stable/insights-agent/templates/opa/cronjob.yaml
+++ b/stable/insights-agent/templates/opa/cronjob.yaml
@@ -49,6 +49,7 @@ spec:
             - name: FAIRWINDS_CLUSTER
               value: {{ .Values.insights.cluster | quote }}
             {{ include "proxy-env-spec" . | indent 12 | trim }}
+{{ include "ssl-cert-file-env-spec" . | indent 12 }}
             {{ include "security-context" . | indent 12 | trim }}
           {{ include "uploaderContainer" . | indent 10 | trim }}
 {{- end -}}

--- a/stable/insights-agent/templates/right-sizer/agent-cronjob.yaml
+++ b/stable/insights-agent/templates/right-sizer/agent-cronjob.yaml
@@ -21,6 +21,7 @@ spec:
               items:
               - key: report
                 path: right-sizer.json
+          {{ include "ssl-cert-file-volume-spec" . | indent 10 }}
           containers:
           {{ include "uploaderContainer" . | indent 10 | trim }}
 {{- end -}}

--- a/stable/insights-agent/templates/trivy/cronjob.yaml
+++ b/stable/insights-agent/templates/trivy/cronjob.yaml
@@ -34,6 +34,7 @@ spec:
               - "./report.sh"
             env:
             {{ include "proxy-env-spec" . | indent 12 | trim }}
+            {{ include "ssl-cert-file-env-spec" . | indent 12 }}
             {{- range $key, $value := .Values.trivy.env }}
             - name: {{ $key }}
               value: {{ $value | quote }}

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -16,11 +16,10 @@ global:
     # global.proxy.no_proxy -- Annotations to provides a way to exclude traffic destined to certain hosts from using the proxy.
     no_proxy:
 
-  sslCertFile:
-    # global.sslCertFile.secretName -- The name of an existing Secret containing an SSL certificate file to be used when communicating with a self-hosted Insights API.
-    secretName:
-    # global.sslCertFile.secretKey -- The key, within global.sslCertFile.secretName, containing an SSL certificate file to be used when communicating with a self-hosted Insights API.
-    secretKey:
+  # global.sslCertFileSecretName -- The name of an existing Secret containing an SSL certificate file to be used when communicating with a self-hosted Insights API.
+  sslCertFileSecretName:
+  # global.sslCertFileSecretKey -- The key, within global.sslCertFileSecretName, containing an SSL certificate file to be used when communicating with a self-hosted Insights API.
+  sslCertFileSecretKey:
 rbac:
   disabled: false
 

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -16,6 +16,11 @@ global:
     # global.proxy.no_proxy -- Annotations to provides a way to exclude traffic destined to certain hosts from using the proxy.
     no_proxy:
 
+  sslCertFile:
+    # global.sslCertFile.secretName -- The name of an existing Secret containing an SSL certificate file to be used when communicating with a self-hosted Insights API.
+    secretName:
+    # global.sslCertFile.secretKey -- The key, within global.sslCertFile.secretName, containing an SSL certificate file to be used when communicating with a self-hosted Insights API.
+    secretKey:
 rbac:
   disabled: false
 


### PR DESCRIPTION
Note this pR requires [a related insights-agent PR](https://github.com/FairwindsOps/charts/pull/1120) to be merged before the tests here will pass.


**Why This PR?**
Add the ability to use a custom SSL certificate when communicating with the Insights API. THIs is useful for self-hosted Insights that use a self-signed certificate or certificate authority on the API Kubernetes Ingress.

These new chart values are also used by an [identical feature for the insights-admission chart](https://github.com/FairwindsOps/charts/pull/1120).

This change optionally allows mounting a volume from a user-supplied Kubernetes secret, which contains a certificate file. This certificate file is included in the certificates used to validate HTTPS communication, and is only included for containers that talk to the Insights API. A few important notes about how this works:
* The environment variable `SSL_CERT_FILE` is set to the path of the certificate file.
* Go binaries use the file specified by `SSL_CERT_FILE` for certificate validation *in addition to* existing certificate authorities that are part of container images such as via the `openssl-ca-certificates` alpine package. This allows 3rd party Go binaries such as trivy to successfully validate other HTTPS connections, such as downloading the trivy data-file.
* The `curl` command will *only* use the file specified by `SSL_CERT_FILE` for certificate validation. For this reason, the Insights fleet installation Kubernetes job does not set the `SSL_CERT_FILE` environment variable until it has used curl to perform other downloads from the Internet.

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
