### PR TITLE
[incubator/vault-token-injector] Allow using a cronjob

### DIFF
--- a/incubator/vault-token-injector/Chart.yaml
+++ b/incubator/vault-token-injector/Chart.yaml
@@ -5,8 +5,8 @@ description: |
 
   This will inject vault tokens and address variables into circle builds on a schedule
 type: application
-version: 2.3.0
-appVersion: "v1.8.1"
+version: 3.0.0
+appVersion: "v1.8.2"
 maintainers:
   - name: transient1
   - name: sudermanjr

--- a/incubator/vault-token-injector/README.md
+++ b/incubator/vault-token-injector/README.md
@@ -1,4 +1,4 @@
-![Version: 2.3.0](https://img.shields.io/badge/Version-2.3.0-informational?style=flat-square)
+![Version: 3.0.0](https://img.shields.io/badge/Version-3.0.0-informational?style=flat-square)
 
 # Vault Token Injector Chart
 
@@ -16,21 +16,29 @@ Chart version 2.0.0 introduced a metrics endpoint by default.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| replicaCount | int | `1` | We currently only support a single instance |
+| deployment.enabled | bool | `true` | If true, will be run as a deployment. Technically both cronjob and deployment can be enabled at the same time, but why? |
+| deployment.replicaCount | int | `1` | We currently only recommend a single instance |
+| deployment.probes.liveness.enabled | bool | `false` | If true, a liveness probe will be set on the deployment pods. This probe fails if any errors are encountered. |
+| deployment.metrics.enabled | bool | `true` | If true, a prometheus endpoint will be enabled on port 4329 |
+| deployment.metrics.service.enabled | bool | `true` |  |
+| deployment.metrics.serviceMonitor.enabled | bool | `false` |  |
+| deployment.metrics.serviceMonitor.interval | string | `"60s"` |  |
+| deployment.metrics.serviceMonitor.scrapeTimeout | string | `"30s"` |  |
+| deployment.metrics.serviceMonitor.labels | object | `{}` |  |
+| cronjob.enabled | bool | `false` | If true, will be run as a cronjob. Technically both cronjob and deployment can be enabled at the same time, but why? |
+| cronjob.schedule | string | `"7 * * * *"` | The schedule for the cronjob |
+| cronjob.failedJobsHistoryLimit | int | `1` | The number of failed jobs to keep around |
+| cronjob.activeDeadlineSeconds | int | `120` | The amount of time to allow the job to run |
+| cronjob.backoffLimit | int | `1` | the cronjob backoffLimit |
+| cronjob.successfulJobsHistoryLimit | int | `1` | The number of successful jobs to keep around |
+| cronjob.restartPolicy | string | `"OnFailure"` | restartPolicy |
 | circleToken | string | `"replaceme"` | A token for interacting with CircleCI |
 | tfCloudToken | string | `"replaceme"` | A token for interacting with TFCloud |
 | existingSecret | string | `""` | An existing secret that contains the environment variables CIRCLEC_CI_TOKEN and TFCLOUD_TOKEN |
 | vaultAddress | string | `"https://vault.example.com"` | The vault address to get tokens from |
 | vaultTokenFile | string | `""` | A file containing a vault token. Optional. |
 | config | object | `{"circleci":[{"env_variable":"VAULT_TOKEN","name":"FairwindsOps/example","vault_role":"some-vault-role"}],"vaultAddress":"https://vault.example.com"}` | The configuration of the vault-token-injector |
-| metrics.enabled | bool | `true` | If true, a prometheus endpoint will be enabled on port 4329 |
-| metrics.service.enabled | bool | `true` |  |
-| metrics.serviceMonitor.enabled | bool | `false` |  |
-| metrics.serviceMonitor.interval | string | `"60s"` |  |
-| metrics.serviceMonitor.scrapeTimeout | string | `"30s"` |  |
-| metrics.serviceMonitor.labels | object | `{}` |  |
 | logLevel | int | `1` | The klog log level (1-10). WARNING: Log level 10 will print secrets to logs |
-| probes.liveness.enabled | bool | `false` |  |
 | image.repository | string | `"us-docker.pkg.dev/fairwinds-ops/oss/vault-token-injector"` | The image repository to pull the vault-token-injector image from |
 | image.pullPolicy | string | `"Always"` | This is recommended to be set as Always |
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |

--- a/incubator/vault-token-injector/ci/test-values.yaml
+++ b/incubator/vault-token-injector/ci/test-values.yaml
@@ -1,3 +1,8 @@
 testing: true
 metrics:
   enabled: true
+cronjob:
+  enabled: true
+deployment:
+  probes:
+    enabled: false

--- a/incubator/vault-token-injector/templates/cronjob.yaml
+++ b/incubator/vault-token-injector/templates/cronjob.yaml
@@ -1,0 +1,82 @@
+{{- if .Values.cronjob.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  labels:
+    {{- include "vault-token-injector.labels" . | nindent 4 }}
+  name: {{ include "vault-token-injector.fullname" . }}
+spec:
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: {{ .Values.cronjob.failedJobsHistoryLimit }}
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: {{ .Values.cronjob.activeDeadlineSeconds }}
+      backoffLimit: {{ .Values.cronjob.backoffLimit }}
+      template:
+        metadata:
+          annotations:
+          {{- with .Values.podAnnotations }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+            checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+          labels:
+            {{- include "vault-token-injector.selectorLabels" . | nindent 12 }}
+        spec:
+          restartPolicy: {{ .Values.cronjob.restartPolicy }}
+          {{- with .Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          serviceAccountName: {{ include "vault-token-injector.serviceAccountName" . }}
+          securityContext:
+            {{- toYaml .Values.podSecurityContext | nindent 12 }}
+          containers:
+            - name: {{ .Chart.Name }}
+              securityContext:
+                {{- toYaml .Values.securityContext | nindent 16 }}
+              image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+              imagePullPolicy: {{ .Values.image.pullPolicy }}
+              resources:
+                {{- toYaml .Values.resources | nindent 16 }}
+              args:
+                - -c
+                - /config/config.yaml
+                - -v{{ .Values.logLevel }}
+                - --run-once
+              volumeMounts:
+              - name: config
+                mountPath: /config
+              envFrom:
+              - secretRef:
+                  {{- if .Values.existingSecret }}
+                  name: {{ .Values.existingSecret }}
+                  {{- else }}
+                  name: {{ include "vault-token-injector.fullname" . }}
+                  {{- end }}
+              env:
+              - name: "VAULT_ADDR"
+                value: {{ .Values.vaultAddress | quote }}
+              {{- if .Values.vaultTokenFile }}
+              - name: "VAULT_TOKEN_FILE"
+                value: {{ .Values.vaultTokenFile | quote }}
+              {{- end }}
+          {{- with .Values.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.affinity }}
+          affinity:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumes:
+          - name: config
+            configMap:
+              name: {{ include "vault-token-injector.fullname" . }}
+  schedule: {{ .Values.cronjob.schedule }}
+  successfulJobsHistoryLimit: {{ .Values.cronjob.successfulJobsHistoryLimit }}
+  suspend: false
+{{- end }}

--- a/incubator/vault-token-injector/templates/deployment.yaml
+++ b/incubator/vault-token-injector/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.deployment.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -38,8 +39,8 @@ spec:
             - -c
             - /config/config.yaml
             - -v{{ .Values.logLevel }}
-            - --enable-metrics={{ .Values.metrics.enabled }}
-          {{- if .Values.metrics.enabled }}
+            - --enable-metrics={{ .Values.deployment.metrics.enabled }}
+          {{- if .Values.deployment.metrics.enabled }}
           ports:
           - containerPort: 4329
             name: metrics
@@ -61,7 +62,7 @@ spec:
           - name: "VAULT_TOKEN_FILE"
             value: {{ .Values.vaultTokenFile | quote }}
           {{- end }}
-          {{- if .Values.probes.liveness.enabled }}
+          {{- if .Values.deployment.probes.liveness.enabled }}
           livenessProbe:
             httpGet:
               path: /health
@@ -83,3 +84,4 @@ spec:
       - name: config
         configMap:
           name: {{ include "vault-token-injector.fullname" . }}
+{{- end }}

--- a/incubator/vault-token-injector/templates/service.yaml
+++ b/incubator/vault-token-injector/templates/service.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.metrics.enabled .Values.metrics.service.enabled }}
+{{- if and .Values.deployment.metrics.enabled .Values.deployment.metrics.service.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/incubator/vault-token-injector/templates/servicemontor.yaml
+++ b/incubator/vault-token-injector/templates/servicemontor.yaml
@@ -1,11 +1,11 @@
-{{- if .Values.metrics.serviceMonitor.enabled }}
+{{- if .Values.deployment.metrics.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "vault-token-injector.fullname" . }}
   labels:
     {{- include "vault-token-injector.labels" . | nindent 4 }}
-    {{- with .Values.metrics.serviceMonitor.labels }}
+    {{- with .Values.deployment.metrics.serviceMonitor.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
@@ -19,6 +19,6 @@ spec:
   endpoints:
   - targetPort: 4329
     path: /metrics
-    interval: {{ .Values.metrics.serviceMonitor.interval }}
-    scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
+    interval: {{ .Values.deployment.metrics.serviceMonitor.interval }}
+    scrapeTimeout: {{ .Values.deployment.metrics.serviceMonitor.scrapeTimeout }}
 {{- end }}

--- a/incubator/vault-token-injector/values.yaml
+++ b/incubator/vault-token-injector/values.yaml
@@ -1,5 +1,38 @@
-# -- We currently only support a single instance
-replicaCount: 1
+deployment:
+  # -- If true, will be run as a deployment. Technically both cronjob and deployment can be enabled at the same time, but why?
+  enabled: true
+  # -- We currently only recommend a single instance
+  replicaCount: 1
+  probes:
+    liveness:
+      # -- If true, a liveness probe will be set on the deployment pods. This probe fails if any errors are encountered.
+      enabled: false
+  metrics:
+    # -- If true, a prometheus endpoint will be enabled on port 4329
+    enabled: true
+    service:
+      enabled: true
+    serviceMonitor:
+      enabled: false
+      interval: 60s
+      scrapeTimeout: 30s
+      labels: {}
+
+cronjob:
+  # -- If true, will be run as a cronjob. Technically both cronjob and deployment can be enabled at the same time, but why?
+  enabled: false
+  # -- The schedule for the cronjob
+  schedule: '7 * * * *'
+  # -- The number of failed jobs to keep around
+  failedJobsHistoryLimit: 1
+  # -- The amount of time to allow the job to run
+  activeDeadlineSeconds: 120
+  # -- the cronjob backoffLimit
+  backoffLimit: 1
+  # -- The number of successful jobs to keep around
+  successfulJobsHistoryLimit: 1
+  # -- restartPolicy
+  restartPolicy: OnFailure
 
 # -- A token for interacting with CircleCI
 circleToken: replaceme
@@ -24,23 +57,8 @@ config:
     vault_role: some-vault-role
     env_variable: VAULT_TOKEN
 
-metrics:
-  # -- If true, a prometheus endpoint will be enabled on port 4329
-  enabled: true
-  service:
-    enabled: true
-  serviceMonitor:
-    enabled: false
-    interval: 60s
-    scrapeTimeout: 30s
-    labels: {}
-
 # -- The klog log level (1-10). WARNING: Log level 10 will print secrets to logs
 logLevel: 1
-
-probes:
-  liveness:
-    enabled: false
 
 image:
   # -- The image repository to pull the vault-token-injector image from


### PR DESCRIPTION
**Why This PR?**
Sometimes, the best way to run a regular task is a cronjob

**Changes**
Changes proposed in this pull request:

* Add the ability to run as a cronjob
* reorganize a few things
* Update versions

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.