### PR TITLE
[stable/vpa] Update container image registry to registry.k8s.io

### DIFF
--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 1.6.1
+version: 1.6.2
 appVersion: 0.11.0
 maintainers:
   - name: sudermanjr

--- a/stable/vpa/README.md
+++ b/stable/vpa/README.md
@@ -75,7 +75,7 @@ recommender:
 | recommender.extraArgs | object | `{"pod-recommendation-min-cpu-millicores":15,"pod-recommendation-min-memory-mb":100,"v":"4"}` | A set of key-value flags to be passed to the recommender |
 | recommender.replicaCount | int | `1` |  |
 | recommender.podDisruptionBudget | object | `{}` | This is the setting for the pod disruption budget |
-| recommender.image.repository | string | `"k8s.gcr.io/autoscaling/vpa-recommender"` | The location of the recommender image |
+| recommender.image.repository | string | `"registry.k8s.io/autoscaling/vpa-recommender"` | The location of the recommender image |
 | recommender.image.pullPolicy | string | `"Always"` | The pull policy for the recommender image. Recommend not changing this |
 | recommender.image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion |
 | recommender.podAnnotations | object | `{}` | Annotations to add to the recommender pod |
@@ -91,7 +91,7 @@ recommender:
 | updater.extraArgs | object | `{}` | A key-value map of flags to pass to the updater |
 | updater.replicaCount | int | `1` |  |
 | updater.podDisruptionBudget | object | `{}` | This is the setting for the pod disruption budget |
-| updater.image.repository | string | `"k8s.gcr.io/autoscaling/vpa-updater"` | The location of the updater image |
+| updater.image.repository | string | `"registry.k8s.io/autoscaling/vpa-updater"` | The location of the updater image |
 | updater.image.pullPolicy | string | `"Always"` | The pull policy for the updater image. Recommend not changing this |
 | updater.image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion |
 | updater.podAnnotations | object | `{}` | Annotations to add to the updater pod |
@@ -124,7 +124,7 @@ recommender:
 | admissionController.cleanupOnDelete.affinity | object | `{}` |  |
 | admissionController.replicaCount | int | `1` |  |
 | admissionController.podDisruptionBudget | object | `{}` | This is the setting for the pod disruption budget |
-| admissionController.image.repository | string | `"k8s.gcr.io/autoscaling/vpa-admission-controller"` | The location of the vpa admission controller image |
+| admissionController.image.repository | string | `"registry.k8s.io/autoscaling/vpa-admission-controller"` | The location of the vpa admission controller image |
 | admissionController.image.pullPolicy | string | `"Always"` | The pull policy for the admission controller image. Recommend not changing this |
 | admissionController.image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion |
 | admissionController.podAnnotations | object | `{}` | Annotations to add to the admission controller pod |

--- a/stable/vpa/values.yaml
+++ b/stable/vpa/values.yaml
@@ -40,7 +40,7 @@ recommender:
     # maxUnavailable: 1
   image:
     # recommender.image.repository -- The location of the recommender image
-    repository: k8s.gcr.io/autoscaling/vpa-recommender
+    repository: registry.k8s.io/autoscaling/vpa-recommender
     # recommender.image.pullPolicy -- The pull policy for the recommender image. Recommend not changing this
     pullPolicy: Always
     # recommender.image.tag -- Overrides the image tag whose default is the chart appVersion
@@ -78,7 +78,7 @@ updater:
     # maxUnavailable: 1
   image:
     # updater.image.repository -- The location of the updater image
-    repository: k8s.gcr.io/autoscaling/vpa-updater
+    repository: registry.k8s.io/autoscaling/vpa-updater
     # updater.image.pullPolicy -- The pull policy for the updater image. Recommend not changing this
     pullPolicy: Always
     # updater.image.tag -- Overrides the image tag whose default is the chart appVersion
@@ -147,7 +147,7 @@ admissionController:
     # maxUnavailable: 1
   image:
     # admissionController.image.repository -- The location of the vpa admission controller image
-    repository: k8s.gcr.io/autoscaling/vpa-admission-controller
+    repository: registry.k8s.io/autoscaling/vpa-admission-controller
     # admissionController.image.pullPolicy -- The pull policy for the admission controller image. Recommend not changing this
     pullPolicy: Always
     # admissionController.image.tag -- Overrides the image tag whose default is the chart appVersion


### PR DESCRIPTION
**Why This PR?**
k8s.gcr.io Image Registry Will Be Frozen From the 3rd of April 2023. Additional details [here](https://kubernetes.io/blog/2023/02/06/k8s-gcr-io-freeze-announcement/)

Fixes #1083 

**Changes**
Changes proposed in this pull request:

* Update `README.md` with `registry.k8s.io` for all VPA images
* Update`values.yaml` with `registry.k8s.io` for all VPA images
* Bump version in `Charts.yaml`

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.

Tests:

```sh
» docker pull registry.k8s.io/autoscaling/vpa-recommender:0.11.0                                                                                                                      
registry.k8s.io/autoscaling/vpa-recommender:0.11.0:                               resolved       |++++++++++++++++++++++++++++++++++++++|
index-sha256:3c7eac4dd972e1af2dd649c63ba62c3d79a7bae2efb16ca2cd371c56d0956673:    done           |++++++++++++++++++++++++++++++++++++++|
manifest-sha256:c56bd86916e680bb89f146170cb899f298069f4ee0cfa08a813b7f15287eb6b4: done           |++++++++++++++++++++++++++++++++++++++|
config-sha256:3755cdfa51be3be9bf2bf4e7341832f92e6951fd748749f13deeb8c24bf7dcd7:   done           |++++++++++++++++++++++++++++++++++++++|
elapsed: 0.4 s                                                                    total:   0.0 B (0.0 B/s)

» docker pull registry.k8s.io/autoscaling/vpa-updater:0.11.0                                                                                                                           
registry.k8s.io/autoscaling/vpa-updater:0.11.0:                                   resolved       |++++++++++++++++++++++++++++++++++++++|
index-sha256:e4a8f7409792fc940d7e25b3f7ee11b5c83487bd9a09b9d67fa015aebdc13a93:    done           |++++++++++++++++++++++++++++++++++++++|
manifest-sha256:f4e91b81df294f74ec69646e63cce7177f979620660935b5c9a795dd5dd9c8a3: done           |++++++++++++++++++++++++++++++++++++++|
config-sha256:4ba2d8a544ea969339b55e4459a769344fb3cc0f10e4d97c20bb9685ba78a436:   done           |++++++++++++++++++++++++++++++++++++++|
layer-sha256:372cb29096d3855d0e8ebbf33f84a80d059da73c7d4b9f1587837cf86c741c58:    done           |++++++++++++++++++++++++++++++++++++++|
elapsed: 6.8 s                                                                    total:  15.0 M (2.2 MiB/s)

» docker pull registry.k8s.io/autoscaling/vpa-admission-controller:0.11.0                                                                                                              
registry.k8s.io/autoscaling/vpa-admission-controller:0.11.0:                      resolved       |++++++++++++++++++++++++++++++++++++++|
index-sha256:6454037d6f5c73b083d2fc59dfa730406f14d962e1a39d277834b350c00f2909:    done           |++++++++++++++++++++++++++++++++++++++|
manifest-sha256:0085bd739ed5fc5cc3a7162d994e75df150871d6a8a593abed2d3c7938b93140: done           |++++++++++++++++++++++++++++++++++++++|
config-sha256:95aa75e9142333f5e8237f976c40a7af2bcb8e5cf32a43134dc5b53def9390a9:   done           |++++++++++++++++++++++++++++++++++++++|
layer-sha256:98e64bde0140602055c412664bee7103cfe624b57d1f06dae7eda327b144180d:    done           |++++++++++++++++++++++++++++++++++++++|
elapsed: 6.7 s                                                                    total:  14.5 M (2.2 MiB/s)
```