### PR TITLE
[stable/insights-agent] Remove hooks from insights-agent

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## 2.12.0
 * Run fleet installer as part of normal setup instead of as a pre-install/pre-upgrade hook
 
+This is a **breaking change** for users of fleet-installer on Kubernetes 1.21 and earlier.
+Now, the fleet-installer Job uses a `ttl` to remove itself instead of a helm-hook. `ttl` is
+only available as of 1.22.
+
 ## 2.11.1
 * Changed the backend for the fleet installer test
 

--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.12.0
+* Run fleet installer as part of normal setup instead of as a pre-install/pre-upgrade hook
+
 ## 2.11.1
 * Changed the backend for the fleet installer test
 

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.11.1
+version: 2.12.0
 appVersion: 9.2.1
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.12.0
+version: 2.13.0
 appVersion: 9.2.1
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:

--- a/stable/insights-agent/templates/fleet-installer/admin-secret.yaml
+++ b/stable/insights-agent/templates/fleet-installer/admin-secret.yaml
@@ -3,10 +3,6 @@ apiVersion: v1
 kind: Secret
 metadata:
   name:  {{ default ( printf "%s-api-token" (include "insights-agent.fullname" .) ) .Values.insights.apiTokenSecretName }}
-  annotations:
-    "helm.sh/hook-weight": "5"
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
 stringData:
   token: {{ .Values.insights.apiToken | quote }}
 {{ end }}

--- a/stable/insights-agent/templates/fleet-installer/job.yaml
+++ b/stable/insights-agent/templates/fleet-installer/job.yaml
@@ -4,9 +4,6 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   {{- include "metadata" . }}
-    "helm.sh/hook-weight": "10"
-    "helm.sh/hook": "pre-install,pre-upgrade"
-    # "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
 spec:
   ttlSecondsAfterFinished: 3000
   backoffLimit: {{ .Values.cronjobs.backoffLimit }}

--- a/stable/insights-agent/templates/fleet-installer/rbac.yaml
+++ b/stable/insights-agent/templates/fleet-installer/rbac.yaml
@@ -12,10 +12,6 @@ metadata:
   name: {{ include "insights-agent.fullname" . }}-fleet-installer
   labels:
     app: insights-agent
-  annotations:
-    "helm.sh/hook-weight": "2"
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
 rules:
 - apiGroups: [""]
   resources: ["secrets"]
@@ -27,10 +23,6 @@ metadata:
   name: {{ include "insights-agent.fullname" . }}-fleet-installer
   labels:
     app: insights-agent
-  annotations:
-    "helm.sh/hook-weight": "3"
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/stable/insights-agent/templates/fleet-installer/rbac.yaml
+++ b/stable/insights-agent/templates/fleet-installer/rbac.yaml
@@ -5,10 +5,6 @@ metadata:
   name: {{ include "insights-agent.fullname" . }}-fleet-installer
   labels:
     app: insights-agent
-  annotations:
-    "helm.sh/hook-weight": "1"
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Fleet installer is causing problems in some environments. Hypothesis is that helm hooks are being finicky.

**Changes**
Changes proposed in this pull request:

* remove pre-upgrade/pre-install hooks from insights-agent chart

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
