### PR TITLE
[stable/vpa] fix comment typo in vpa values.yaml file

### DIFF
--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 1.6.1
+version: 1.6.2
 appVersion: 0.11.0
 maintainers:
   - name: sudermanjr

--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 1.7.2
+version: 1.7.3
 appVersion: 0.13.0
 maintainers:
   - name: sudermanjr

--- a/stable/vpa/README.md
+++ b/stable/vpa/README.md
@@ -80,8 +80,7 @@ recommender:
 | recommender.image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion |
 | recommender.podAnnotations | object | `{}` | Annotations to add to the recommender pod |
 | recommender.podLabels | object | `{}` | Labels to add to the recommender pod |
-| recommender.podSecurityContext.runAsNonRoot | bool | `true` |  |
-| recommender.podSecurityContext.runAsUser | int | `65534` |  |
+| recommender.podSecurityContext | object | `{"runAsNonRoot":true,"runAsUser":65534}` | The security context for the recommender pod |
 | recommender.securityContext | object | `{}` | The security context for the containers inside the recommender pod |
 | recommender.resources | object | `{"limits":{"cpu":"200m","memory":"1000Mi"},"requests":{"cpu":"50m","memory":"500Mi"}}` | The resources block for the recommender pod |
 | recommender.nodeSelector | object | `{}` |  |
@@ -96,8 +95,7 @@ recommender:
 | updater.image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion |
 | updater.podAnnotations | object | `{}` | Annotations to add to the updater pod |
 | updater.podLabels | object | `{}` | Labels to add to the updater pod |
-| updater.podSecurityContext.runAsNonRoot | bool | `true` |  |
-| updater.podSecurityContext.runAsUser | int | `65534` |  |
+| updater.podSecurityContext | object | `{"runAsNonRoot":true,"runAsUser":65534}` | The security context for the updater pod |
 | updater.securityContext | object | `{}` | The security context for the containers inside the updater pod |
 | updater.resources | object | `{"limits":{"cpu":"200m","memory":"1000Mi"},"requests":{"cpu":"50m","memory":"500Mi"}}` | The resources block for the updater pod |
 | updater.nodeSelector | object | `{}` |  |
@@ -129,8 +127,7 @@ recommender:
 | admissionController.image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion |
 | admissionController.podAnnotations | object | `{}` | Annotations to add to the admission controller pod |
 | admissionController.podLabels | object | `{}` | Labels to add to the admission controller pod |
-| admissionController.podSecurityContext.runAsNonRoot | bool | `true` |  |
-| admissionController.podSecurityContext.runAsUser | int | `65534` |  |
+| admissionController.podSecurityContext | object | `{"runAsNonRoot":true,"runAsUser":65534}` | The security context for the admission controller pod |
 | admissionController.securityContext | object | `{}` | The security context for the containers inside the admission controller pod |
 | admissionController.resources | object | `{"limits":{"cpu":"200m","memory":"500Mi"},"requests":{"cpu":"50m","memory":"200Mi"}}` | The resources block for the admission controller pod |
 | admissionController.tlsSecretKeys | list | `[]` | The keys in the vpa-tls-certs secret to map in to the admission controller |

--- a/stable/vpa/values.yaml
+++ b/stable/vpa/values.yaml
@@ -49,7 +49,7 @@ recommender:
   podAnnotations: {}
   # recommender.podLabels -- Labels to add to the recommender pod
   podLabels: {}
-  # recommender.podSecurityContetxt -- The security context for the recommender pod
+  # recommender.podSecurityContext -- The security context for the recommender pod
   podSecurityContext:
     runAsNonRoot: true
     runAsUser: 65534
@@ -87,7 +87,7 @@ updater:
   podAnnotations: {}
   # updater.podLabels -- Labels to add to the updater pod
   podLabels: {}
-  # updater.podSecurityContetxt -- The security context for the updater pod
+  # updater.podSecurityContext -- The security context for the updater pod
   podSecurityContext:
     runAsNonRoot: true
     runAsUser: 65534
@@ -156,7 +156,7 @@ admissionController:
   podAnnotations: {}
   # admissionController.podLabels -- Labels to add to the admission controller pod
   podLabels: {}
-  # admissionController.podSecurityContetxt -- The security context for the admission controller pod
+  # admissionController.podSecurityContext -- The security context for the admission controller pod
   podSecurityContext:
     runAsNonRoot: true
     runAsUser: 65534


### PR DESCRIPTION
**Why This PR?**
Fixes a minor typo in vpa `values.yaml` file. `podSecurityContetxt` -> `podSecurityContext `


**Changes**
Changes proposed in this pull request:

* `podSecurityContetxt` -> `podSecurityContext `

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
