### PR TITLE
[stable/vpa] Switch image container registry to registry.k8s.io

### DIFF
--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 1.6.1
+version: 1.6.2
 appVersion: 0.11.0
 maintainers:
   - name: sudermanjr

--- a/stable/vpa/README.md
+++ b/stable/vpa/README.md
@@ -75,7 +75,7 @@ recommender:
 | recommender.extraArgs | object | `{"pod-recommendation-min-cpu-millicores":15,"pod-recommendation-min-memory-mb":100,"v":"4"}` | A set of key-value flags to be passed to the recommender |
 | recommender.replicaCount | int | `1` |  |
 | recommender.podDisruptionBudget | object | `{}` | This is the setting for the pod disruption budget |
-| recommender.image.repository | string | `"k8s.gcr.io/autoscaling/vpa-recommender"` | The location of the recommender image |
+| recommender.image.repository | string | `"registry.k8s.io/autoscaling/vpa-recommender"` | The location of the recommender image |
 | recommender.image.pullPolicy | string | `"Always"` | The pull policy for the recommender image. Recommend not changing this |
 | recommender.image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion |
 | recommender.podAnnotations | object | `{}` | Annotations to add to the recommender pod |
@@ -91,7 +91,7 @@ recommender:
 | updater.extraArgs | object | `{}` | A key-value map of flags to pass to the updater |
 | updater.replicaCount | int | `1` |  |
 | updater.podDisruptionBudget | object | `{}` | This is the setting for the pod disruption budget |
-| updater.image.repository | string | `"k8s.gcr.io/autoscaling/vpa-updater"` | The location of the updater image |
+| updater.image.repository | string | `"registry.k8s.io/autoscaling/vpa-updater"` | The location of the updater image |
 | updater.image.pullPolicy | string | `"Always"` | The pull policy for the updater image. Recommend not changing this |
 | updater.image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion |
 | updater.podAnnotations | object | `{}` | Annotations to add to the updater pod |
@@ -124,7 +124,7 @@ recommender:
 | admissionController.cleanupOnDelete.affinity | object | `{}` |  |
 | admissionController.replicaCount | int | `1` |  |
 | admissionController.podDisruptionBudget | object | `{}` | This is the setting for the pod disruption budget |
-| admissionController.image.repository | string | `"k8s.gcr.io/autoscaling/vpa-admission-controller"` | The location of the vpa admission controller image |
+| admissionController.image.repository | string | `"registry.k8s.io/autoscaling/vpa-admission-controller"` | The location of the vpa admission controller image |
 | admissionController.image.pullPolicy | string | `"Always"` | The pull policy for the admission controller image. Recommend not changing this |
 | admissionController.image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion |
 | admissionController.podAnnotations | object | `{}` | Annotations to add to the admission controller pod |

--- a/stable/vpa/values.yaml
+++ b/stable/vpa/values.yaml
@@ -40,7 +40,7 @@ recommender:
     # maxUnavailable: 1
   image:
     # recommender.image.repository -- The location of the recommender image
-    repository: k8s.gcr.io/autoscaling/vpa-recommender
+    repository: registry.k8s.io/autoscaling/vpa-recommender
     # recommender.image.pullPolicy -- The pull policy for the recommender image. Recommend not changing this
     pullPolicy: Always
     # recommender.image.tag -- Overrides the image tag whose default is the chart appVersion
@@ -147,7 +147,7 @@ admissionController:
     # maxUnavailable: 1
   image:
     # admissionController.image.repository -- The location of the vpa admission controller image
-    repository: k8s.gcr.io/autoscaling/vpa-admission-controller
+    repository: registry.k8s.io/autoscaling/vpa-admission-controller
     # admissionController.image.pullPolicy -- The pull policy for the admission controller image. Recommend not changing this
     pullPolicy: Always
     # admissionController.image.tag -- Overrides the image tag whose default is the chart appVersion

--- a/stable/vpa/values.yaml
+++ b/stable/vpa/values.yaml
@@ -78,7 +78,7 @@ updater:
     # maxUnavailable: 1
   image:
     # updater.image.repository -- The location of the updater image
-    repository: k8s.gcr.io/autoscaling/vpa-updater
+    repository: registry.k8s.io/autoscaling/vpa-updater
     # updater.image.pullPolicy -- The pull policy for the updater image. Recommend not changing this
     pullPolicy: Always
     # updater.image.tag -- Overrides the image tag whose default is the chart appVersion


### PR DESCRIPTION
**Why This PR?**
Based off of upstream k8s switch: https://kubernetes.io/blog/2022/11/28/registry-k8s-io-faster-cheaper-ga/

VPA Demo Manifests already use this new registry: https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/deploy/updater-deployment.yaml

Fixes #https://github.com/FairwindsOps/charts/issues/1083

**Changes**
Changes proposed in this pull request:

* Switches registry from `k8s.gcr.io` to `registry.k8s.io`

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
