### PR TITLE
[stable/goldilocks] update VPA subchart for goldilocks

### DIFF
--- a/stable/goldilocks/Chart.yaml
+++ b/stable/goldilocks/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 appVersion: "v4.6.3"
-version: 6.5.1
+version: 6.5.2
 description: |
   A Helm chart for running Fairwinds Goldilocks. See https://github.com/FairwindsOps/goldilocks
 name: goldilocks
@@ -15,7 +15,7 @@ keywords:
   - kubernetes
 dependencies:
   - name: vpa
-    version: 1.6.0
+    version: 1.7.0
     repository: https://charts.fairwinds.com/stable
     condition: vpa.enabled
   - name: metrics-server


### PR DESCRIPTION
**Why This PR?**
Updates VPA subchart, which fixes support for 1.25

**Changes**
Changes proposed in this pull request:
* update vpa subchart to pull in VPA 0.13

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
