### PR TITLE
[stable/insights-agent] Update goldilocks subchart for insights-agent to update VPA

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 2.14.1
+* Update Goldilocks chart version to 6.5.*
+
 ## 2.14.0
 * Update versions for polaris, goldilocks, pluto, prometheus, trivy, and uploader
 

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.14.0
+version: 2.14.1
 appVersion: 9.2.1
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:

--- a/stable/insights-agent/requirements.yaml
+++ b/stable/insights-agent/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: goldilocks
   repository: https://charts.fairwinds.com/stable
-  version: '6.3.*'
+  version: '6.5.*'
   condition: goldilocks.enabled
 - name: prometheus
   repository: https://prometheus-community.github.io/helm-charts


### PR DESCRIPTION
**Why This PR?**
Updates goldilocks subchart, which [updated VPA subchart](https://github.com/FairwindsOps/charts/pull/1135), which fixes support for K8S 1.25

**Changes**
Changes proposed in this pull request:

* Update goldilocks subchart to pull in goldilocks 6.5.*

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
