### PR TITLE
[stable/insights-agent] update plugin versions

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 2.14.0
+* Update versions for polaris, goldilocks, pluto, prometheus, trivy, and uploader
 
 ## 2.13.0
 * Run fleet installer as part of normal setup instead of as a pre-install/pre-upgrade hook

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.13.0
+version: 2.14.0
 appVersion: 9.2.1
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -26,7 +26,7 @@ rbac:
 uploader:
   image:
     repository: quay.io/fairwinds/insights-uploader
-    tag: "0.4"
+    tag: "0.5"
   imagePullSecret: ""
   sendFailures: true
   resources:
@@ -77,7 +77,7 @@ polaris:
     disabled: false
   image:
     repository: quay.io/fairwinds/polaris
-    tag: "7.3"
+    tag: "7.4"
   resources:
     requests:
       cpu: 100m
@@ -112,7 +112,7 @@ goldilocks:
   timeout: 300
   image:
     repository: us-docker.pkg.dev/fairwinds-ops/oss/goldilocks
-    tag: "v4.6"
+    tag: "v4.7"
   controller:
     flags:
       on-by-default: true
@@ -267,7 +267,7 @@ trivy:
   env:
   image:
     repository: quay.io/fairwinds/fw-trivy
-    tag: "0.24"
+    tag: "0.25"
   serviceAccount:
     annotations:
   resources:
@@ -282,7 +282,7 @@ pluto:
   targetVersions: ""
   image:
     repository: us-docker.pkg.dev/fairwinds-ops/oss/pluto
-    tag: "v5.13"
+    tag: "v5.16"
   resources:
     requests:
       cpu: 100m
@@ -296,7 +296,7 @@ prometheus-metrics:
   address: "http://prometheus-server"
   image:
     repository: quay.io/fairwinds/prometheus-collector
-    tag: "1.1"
+    tag: "1.3"
   resources:
     requests:
       cpu: 100m


### PR DESCRIPTION
**Why This PR?**
We're behind on a few versions in insights-agent

**Changes**
Changes proposed in this pull request:
* Update versions for polaris, goldilocks, pluto, prometheus, trivy, and uploader

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
