### PR TITLE
[helm-release-pruner] add support for tolerations & nodeSelector

### DIFF
--- a/stable/helm-release-pruner/Chart.yaml
+++ b/stable/helm-release-pruner/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v3.2.0
 description: This chart deploys a cronjob that purges stale Helm releases and associated namespaces. Releases are selected based on regex patterns for release name and namespace along with a Bash `date` command date string to define the stale cutoff date and time.
 name: helm-release-pruner
-version: 3.2.7
+version: 3.2.8
 maintainers:
   - name: rbren
   - name: sudermanjr

--- a/stable/helm-release-pruner/README.md
+++ b/stable/helm-release-pruner/README.md
@@ -57,6 +57,8 @@ Chart version 1.0.0 introduced RBacDefinitions with rbac-manager to manage acces
 | job.resources.limits.memory | string | `"32Mi"` |  |
 | job.resources.requests.cpu | string | `"25m"` |  |
 | job.resources.requests.memory | string | `"32M"` |  |
+| job.nodeSelector | object | `{}` | The job nodeSelector |
+| job.tolerations | list | `[]` | The job tolerations |
 | pruneProfiles | list | `[]` | Filters to use to find purge candidates. See example usage in values.yaml for details |
 | rbac_manager.enabled | bool | `false` | If true, creates an RbacDefinition to manage access |
 | rbac_manager.namespaceLabel | string | `""` | Label to match namespaces to grant access to |

--- a/stable/helm-release-pruner/templates/cronjob.yml
+++ b/stable/helm-release-pruner/templates/cronjob.yml
@@ -76,3 +76,11 @@ spec:
                   - ALL
             resources:
               {{- toYaml .Values.job.resources | nindent 14 }}
+          {{- with .Values.job.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.job.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}

--- a/stable/helm-release-pruner/values.yaml
+++ b/stable/helm-release-pruner/values.yaml
@@ -39,6 +39,10 @@ job:
     requests:
       cpu: 25m
       memory: 32M
+  # job.nodeSelector -- The job nodeSelector
+  nodeSelector: {}
+  # job.tolerations -- The job tolerations
+  tolerations: []
 
 # pruneProfiles -- Filters to use to find purge candidates. See example usage in values.yaml for details
 pruneProfiles: []


### PR DESCRIPTION
**Why This PR?**
This changes add the possibility to schedule the Jobs on specific nodes using tolerations & nodeSelector.

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
