### PR TITLE
[stable/insights-agent] add namespace allowlist for trivy

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 2.16.0
+* Add namespace allowlist to trivy
+
 ## 2.15.1
 * Fix env vars for install-reporter
 

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.15.1
+version: 2.16.0
 appVersion: 9.2.1
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:

--- a/stable/insights-agent/README.md
+++ b/stable/insights-agent/README.md
@@ -105,7 +105,8 @@ Parameter | Description | Default
 `trivy.privateImages.dockerConfigSecret` | Name of a secret containing a docker `config.json` | ""
 `trivy.maxConcurrentScans` | Maximum number of scans to run concurrently | 1
 `trivy.maxScansPerRun` | Maximum number of images to scan on a single run | 20
-`trivy.namespaceBlacklist` | Specifies which namespaces to not scan, takes an array of namespaces for example: `--set trivy.namespaceBlacklist="{kube-system,default}"` | nil
+`trivy.namespaceAllowlist` | Specifies which namespaces to scan, takes an array of namespaces for example: `--set trivy.namespaceAllowlist="{kube-system,default}"` | []
+`trivy.namespaceBlocklist` | Specifies which namespaces to not scan, takes an array of namespaces for example: `--set trivy.namespaceBlocklist="{kube-system,default}"` | []
 `trivy.serviceAccount.annotations` | Annotations to add to the Trivy service account, e.g. `eks.amazonaws.com/role-arn: arn:aws:iam::ACCOUNT_ID:role/IAM_ROLE_NAME` for accessing private images | nil
 `trivy.env` | A map of environment variables that will be set for the trivy container. | `nil`
 `opa.role` | Specifies which ClusterRole to grant the OPA agent access to | view

--- a/stable/insights-agent/templates/trivy/cronjob.yaml
+++ b/stable/insights-agent/templates/trivy/cronjob.yaml
@@ -66,7 +66,7 @@ spec:
               value: {{ .Values.trivy.ignoreUnfixed | quote }}
             - name: MAX_CONCURRENT_SCANS
               value: {{ .Values.trivy.maxConcurrentScans | quote }}
-            - name: NAMESPACE_BLACKLIST
+            - name: NAMESPACE_BLOCKLIST
               value: {{ join "," ( concat .Values.trivy.namespaceBlacklist .Values.trivy.namespaceBlocklist ) | lower }}
             - name: NAMESPACE_ALLOWLIST
               value: {{ join "," .Values.trivy.namespaceAllowlist | lower }}

--- a/stable/insights-agent/templates/trivy/cronjob.yaml
+++ b/stable/insights-agent/templates/trivy/cronjob.yaml
@@ -66,8 +66,13 @@ spec:
               value: {{ .Values.trivy.ignoreUnfixed | quote }}
             - name: MAX_CONCURRENT_SCANS
               value: {{ .Values.trivy.maxConcurrentScans | quote }}
+            {{- if .Values.trivy.namespaceBlocklist }}
             - name: NAMESPACE_BLOCKLIST
               value: {{ join "," ( concat .Values.trivy.namespaceBlacklist .Values.trivy.namespaceBlocklist ) | lower }}
+            {{- else }}
+            - name: NAMESPACE_BLOCKLIST
+              value: {{ join "," .Values.trivy.namespaceBlacklist | lower }}
+            {{- end }}
             - name: NAMESPACE_ALLOWLIST
               value: {{ join "," .Values.trivy.namespaceAllowlist | lower }}
             {{ include "security-context" . | indent 12 | trim }}

--- a/stable/insights-agent/templates/trivy/cronjob.yaml
+++ b/stable/insights-agent/templates/trivy/cronjob.yaml
@@ -66,10 +66,10 @@ spec:
               value: {{ .Values.trivy.ignoreUnfixed | quote }}
             - name: MAX_CONCURRENT_SCANS
               value: {{ .Values.trivy.maxConcurrentScans | quote }}
-            {{ if .Values.trivy.namespaceBlacklist }}
             - name: NAMESPACE_BLACKLIST
-              value: {{ join "," .Values.trivy.namespaceBlacklist | lower }}
-            {{ end }}
+              value: {{ join "," ( concat .Values.trivy.namespaceBlacklist .Values.trivy.namespaceBlocklist ) | lower }}
+            - name: NAMESPACE_ALLOWLIST
+              value: {{ join "," .Values.trivy.namespaceAllowlist | lower }}
             {{ include "security-context" . | indent 12 | trim }}
           {{ include "uploaderContainer" . | indent 10 | trim }}
 {{- end -}}

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -258,6 +258,8 @@ kube-bench:
 trivy:
   enabled: false
   namespaceBlacklist: []
+  namespaceBlocklist: []
+  namespaceAllowlist: []
   ignoreUnfixed: false
   schedule: "rand * * * *"
   privateImages:
@@ -270,7 +272,7 @@ trivy:
   env:
   image:
     repository: quay.io/fairwinds/fw-trivy
-    tag: "0.25"
+    tag: "0.26"
   serviceAccount:
     annotations:
   resources:


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Supports changes here: https://github.com/FairwindsOps/insights-plugins/pull/775/files#diff-9350b9d62cf3b9dbc7ebda54c885ea73f19951e08263a9161f8b18cfef44e752

**Changes**
Changes proposed in this pull request:
* Adds support for namespace allowlist in trivy
*

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
