### PR TITLE
[stable/vpa] Add configurable value for tests.securityContext

### DIFF
--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 1.7.1
+version: 1.7.2
 appVersion: 0.13.0
 maintainers:
   - name: sudermanjr

--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 1.7.2
+version: 1.7.3
 appVersion: 0.13.0
 maintainers:
   - name: sudermanjr

--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 1.7.3
+version: 1.7.5
 appVersion: 0.13.0
 maintainers:
   - name: sudermanjr

--- a/stable/vpa/README.md
+++ b/stable/vpa/README.md
@@ -137,3 +137,4 @@ recommender:
 | admissionController.nodeSelector | object | `{}` |  |
 | admissionController.tolerations | list | `[]` |  |
 | admissionController.affinity | object | `{}` |  |
+| tests.securityContext | object | `{}` | The security context for the containers running as helm hook tests |

--- a/stable/vpa/README.md
+++ b/stable/vpa/README.md
@@ -137,4 +137,4 @@ recommender:
 | admissionController.nodeSelector | object | `{}` |  |
 | admissionController.tolerations | list | `[]` |  |
 | admissionController.affinity | object | `{}` |  |
-| tests.securityContext | object | `{}` | The security context for the containers run as helm hook tests |
+| tests.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":10324}` | The security context for the containers run as helm hook tests |

--- a/stable/vpa/README.md
+++ b/stable/vpa/README.md
@@ -137,4 +137,4 @@ recommender:
 | admissionController.nodeSelector | object | `{}` |  |
 | admissionController.tolerations | list | `[]` |  |
 | admissionController.affinity | object | `{}` |  |
-| tests.securityContext | object | `{}` | The security context for the containers running as helm hook tests |
+| tests.securityContext | object | `{}` | The security context for the containers run as helm hook tests |

--- a/stable/vpa/ci/test-values.yaml
+++ b/stable/vpa/ci/test-values.yaml
@@ -23,11 +23,3 @@ admissionController:
 podLabels:
   app: test
   foo: bar
-tests:
-  securityContext:
-    runAsUser: 1984
-    runAsGroup: 1984
-    allowPrivilegeEscalation: false
-    capabilities:
-      drop:
-        - "ALL"

--- a/stable/vpa/ci/test-values.yaml
+++ b/stable/vpa/ci/test-values.yaml
@@ -23,3 +23,11 @@ admissionController:
 podLabels:
   app: test
   foo: bar
+tests:
+  securityContext:
+    runAsUser: 1984
+    runAsGroup: 1984
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - "ALL"

--- a/stable/vpa/templates/tests/crd-available.yaml
+++ b/stable/vpa/templates/tests/crd-available.yaml
@@ -14,8 +14,10 @@ spec:
   serviceAccountName:  {{ include "vpa.fullname" . }}-test
   containers:
     - name: test
+      {{- if .Values.tests }}
       securityContext:
       {{- toYaml .Values.tests.securityContext | nindent 8 }}
+      {{- end }}
       image: quay.io/reactiveops/ci-images:v11-alpine
       command: ['kubectl']
       args:
@@ -39,8 +41,10 @@ spec:
   serviceAccountName: {{ include "vpa.fullname" . }}-test
   containers:
     - name: test
+      {{- if .Values.tests }}
       securityContext:
       {{- toYaml .Values.tests.securityContext | nindent 8 }}
+      {{- end }}
       image: quay.io/reactiveops/ci-images:v11-alpine
       command: ['kubectl']
       args:

--- a/stable/vpa/templates/tests/crd-available.yaml
+++ b/stable/vpa/templates/tests/crd-available.yaml
@@ -14,7 +14,7 @@ spec:
   containers:
     - name: test
       securityContext:
-        {{- toYaml .Values.tests.securityContext | nindent 8 }}
+      {{- toYaml .Values.tests.securityContext | nindent 6 }}
       image: quay.io/reactiveops/ci-images:v11-alpine
       command: ['kubectl']
       args:
@@ -38,7 +38,7 @@ spec:
   containers:
     - name: test
       securityContext:
-        {{- toYaml .Values.tests.securityContext | nindent 8 }}
+      {{- toYaml .Values.tests.securityContext | nindent 6 }}
       image: quay.io/reactiveops/ci-images:v11-alpine
       command: ['kubectl']
       args:

--- a/stable/vpa/templates/tests/crd-available.yaml
+++ b/stable/vpa/templates/tests/crd-available.yaml
@@ -15,7 +15,7 @@ spec:
   containers:
     - name: test
       securityContext:
-      {{- toYaml .Values.tests.securityContext | nindent 6 }}
+      {{- toYaml .Values.tests.securityContext | nindent 8 }}
       image: quay.io/reactiveops/ci-images:v11-alpine
       command: ['kubectl']
       args:
@@ -40,7 +40,7 @@ spec:
   containers:
     - name: test
       securityContext:
-      {{- toYaml .Values.tests.securityContext | nindent 6 }}
+      {{- toYaml .Values.tests.securityContext | nindent 8 }}
       image: quay.io/reactiveops/ci-images:v11-alpine
       command: ['kubectl']
       args:

--- a/stable/vpa/templates/tests/crd-available.yaml
+++ b/stable/vpa/templates/tests/crd-available.yaml
@@ -13,6 +13,8 @@ spec:
   serviceAccountName:  {{ include "vpa.fullname" . }}-test
   containers:
     - name: test
+      securityContext:
+        {{- toYaml .Values.tests.securityContext | nindent 8 }}
       image: quay.io/reactiveops/ci-images:v11-alpine
       command: ['kubectl']
       args:
@@ -35,6 +37,8 @@ spec:
   serviceAccountName: {{ include "vpa.fullname" . }}-test
   containers:
     - name: test
+      securityContext:
+        {{- toYaml .Values.tests.securityContext | nindent 8 }}
       image: quay.io/reactiveops/ci-images:v11-alpine
       command: ['kubectl']
       args:

--- a/stable/vpa/templates/tests/create-vpa.yaml
+++ b/stable/vpa/templates/tests/create-vpa.yaml
@@ -14,8 +14,10 @@ spec:
   serviceAccountName: {{ include "vpa.fullname" . }}-test
   containers:
     - name: test
+      {{- if .Values.tests }}
       securityContext:
       {{- toYaml .Values.tests.securityContext | nindent 8 }}
+      {{- end }}
       image: quay.io/reactiveops/ci-images:v11-alpine
       command: ['bash']
       args:

--- a/stable/vpa/templates/tests/create-vpa.yaml
+++ b/stable/vpa/templates/tests/create-vpa.yaml
@@ -14,7 +14,7 @@ spec:
   containers:
     - name: test
       securityContext:
-        {{- toYaml .Values.tests.securityContext | nindent 8 }}
+      {{- toYaml .Values.tests.securityContext | nindent 6 }}
       image: quay.io/reactiveops/ci-images:v11-alpine
       command: ['bash']
       args:

--- a/stable/vpa/templates/tests/create-vpa.yaml
+++ b/stable/vpa/templates/tests/create-vpa.yaml
@@ -15,7 +15,7 @@ spec:
   containers:
     - name: test
       securityContext:
-      {{- toYaml .Values.tests.securityContext | nindent 6 }}
+      {{- toYaml .Values.tests.securityContext | nindent 8 }}
       image: quay.io/reactiveops/ci-images:v11-alpine
       command: ['bash']
       args:

--- a/stable/vpa/templates/tests/create-vpa.yaml
+++ b/stable/vpa/templates/tests/create-vpa.yaml
@@ -13,6 +13,8 @@ spec:
   serviceAccountName: {{ include "vpa.fullname" . }}-test
   containers:
     - name: test
+      securityContext:
+        {{- toYaml .Values.tests.securityContext | nindent 8 }}
       image: quay.io/reactiveops/ci-images:v11-alpine
       command: ['bash']
       args:

--- a/stable/vpa/templates/tests/metrics.yaml
+++ b/stable/vpa/templates/tests/metrics.yaml
@@ -14,6 +14,8 @@ spec:
   serviceAccountName: {{ include "vpa.fullname" . }}-test
   containers:
     - name: test
+      securityContext:
+        {{- toYaml .Values.tests.securityContext | nindent 8 }}
       image: quay.io/reactiveops/ci-images:v11-alpine
       command: ['kubectl']
       args:

--- a/stable/vpa/templates/tests/metrics.yaml
+++ b/stable/vpa/templates/tests/metrics.yaml
@@ -16,7 +16,7 @@ spec:
   containers:
     - name: test
       securityContext:
-      {{- toYaml .Values.tests.securityContext | nindent 6 }}
+      {{- toYaml .Values.tests.securityContext | nindent 8 }}
       image: quay.io/reactiveops/ci-images:v11-alpine
       command: ['kubectl']
       args:

--- a/stable/vpa/templates/tests/metrics.yaml
+++ b/stable/vpa/templates/tests/metrics.yaml
@@ -15,7 +15,7 @@ spec:
   containers:
     - name: test
       securityContext:
-        {{- toYaml .Values.tests.securityContext | nindent 8 }}
+      {{- toYaml .Values.tests.securityContext | nindent 6 }}
       image: quay.io/reactiveops/ci-images:v11-alpine
       command: ['kubectl']
       args:

--- a/stable/vpa/templates/tests/metrics.yaml
+++ b/stable/vpa/templates/tests/metrics.yaml
@@ -15,8 +15,10 @@ spec:
   serviceAccountName: {{ include "vpa.fullname" . }}-test
   containers:
     - name: test
+      {{- if .Values.tests }}
       securityContext:
       {{- toYaml .Values.tests.securityContext | nindent 8 }}
+      {{- end }}
       image: quay.io/reactiveops/ci-images:v11-alpine
       command: ['kubectl']
       args:

--- a/stable/vpa/values.yaml
+++ b/stable/vpa/values.yaml
@@ -183,5 +183,5 @@ admissionController:
   affinity: {}
 
 tests:
-   # tests.securityContext -- The security context for the containers run as helm hook tests
-   securityContext: {}
+  # tests.securityContext -- The security context for the containers run as helm hook tests
+  securityContext: {}

--- a/stable/vpa/values.yaml
+++ b/stable/vpa/values.yaml
@@ -184,4 +184,11 @@ admissionController:
 
 tests:
   # tests.securityContext -- The security context for the containers run as helm hook tests
-  securityContext: {}
+  securityContext:
+    readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
+    runAsNonRoot: true
+    runAsUser: 10324
+    capabilities:
+      drop:
+        - ALL

--- a/stable/vpa/values.yaml
+++ b/stable/vpa/values.yaml
@@ -181,3 +181,7 @@ admissionController:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+
+tests:
+   # tests.securityContext -- The security context for the containers run as helm hook tests
+   securityContext: {}


### PR DESCRIPTION
**Why This PR?**

This PR enables configuration for securityContext in the pods run as helm tests.

Fixes https://github.com/FairwindsOps/charts/issues/1143

**Changes**
Changes proposed in this pull request:

* add configuration for securityContext for vpa/templates/tests

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
