### PR TITLE
[stable/insights-agent] Image pull secrets in pod spec not containers

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 2.16.2
+* Fix syntax errors around use of imagePullSecrets as part of Containers section of PodSpec to permit use of insights-agent with private container repos
+
 ## 2.16.1
 * Add workload annotion for right-sizer
 

--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 2.15.2
+* Fix syntax errors around use of imagePullSecrets as part of Containers section of PodSpec.
 ## 2.15.1
 * Fix env vars for install-reporter
 

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.16.1
+version: 2.16.2
 appVersion: 9.2.1
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.15.1
+version: 2.15.2
 appVersion: 9.2.1
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:

--- a/stable/insights-agent/templates/_specs.yaml
+++ b/stable/insights-agent/templates/_specs.yaml
@@ -65,6 +65,10 @@ tolerations:
 securityContext:
   {{- toYaml . | nindent 2 }}
 {{- end }}
+{{- with $.Values.cronjobs.imagePullSecret }}
+imagePullSecrets:
+- name: {{ . }}
+{{- end }}
 {{- if or (not .Config.SkipVolumes) (and .Values.global.sslCertFileSecretName .Values.global.sslCertFileSecretKey) }}
 volumes:
 {{- end }}
@@ -79,10 +83,6 @@ volumes:
 name: {{ .Label }}
 image: "{{ .Config.image.repository }}:{{ .Config.image.tag }}"
 imagePullPolicy: Always
-{{- with $.Values.cronjobs.imagePullSecret }}
-imagePullSecrets:
-  - name: {{ . }}
-{{- end }}
 resources:
   {{- toYaml .Config.resources | nindent 2 }}
 {{- if and .Values.global.sslCertFileSecretName .Values.global.sslCertFileSecretKey }}

--- a/stable/insights-agent/templates/_uploader.yaml
+++ b/stable/insights-agent/templates/_uploader.yaml
@@ -2,10 +2,6 @@
 - name: insights-uploader
   image: "{{ .Values.uploader.image.repository }}:{{ .Values.uploader.image.tag }}"
   imagePullPolicy: Always
-  {{- with $.Values.uploader.imagePullSecret }}
-  imagePullSecrets:
-  - name: {{ . }}
-  {{- end }}
   command:
   - ./uploader.sh
   - --datatype

--- a/stable/insights-agent/templates/cronjob-executor/job.yaml
+++ b/stable/insights-agent/templates/cronjob-executor/job.yaml
@@ -19,6 +19,10 @@ spec:
     spec:
       restartPolicy: Never
       serviceAccountName: {{ include "insights-agent.fullname" . }}-cronjob-executor
+      {{- with .Values.cronjobExecutor.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 6 }}
+      {{- end }}
       containers:
       - name: start-job-from-cronjob
         image: "{{ .Values.cronjobExecutor.image.repository }}:{{ .Values.cronjobExecutor.image.tag }}"

--- a/stable/insights-agent/templates/falco/cronjob.yaml
+++ b/stable/insights-agent/templates/falco/cronjob.yaml
@@ -17,10 +17,6 @@ spec:
           - name: {{ .Label }}
             image: "{{ .Values.cronjobExecutor.image.repository }}:{{ .Values.cronjobExecutor.image.tag }}"
             imagePullPolicy: Always
-            {{- with $.Values.cronjobs.imagePullSecret }}
-            imagePullSecrets:
-                - name: {{ . }}
-            {{- end }}
             resources:
               {{- toYaml .Config.resources | nindent 14 }}
             volumeMounts:

--- a/stable/insights-agent/templates/falco/deployment.yaml
+++ b/stable/insights-agent/templates/falco/deployment.yaml
@@ -53,6 +53,10 @@ spec:
     {{- if .Values.falco.priorityClassName }}
       priorityClassName: {{ .Values.falco.priorityClassName }}
     {{- end }}
+    {{- with .Values.falco.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 6 }}
+     {{- end }}
       containers:
       - name: falco-agent
         volumeMounts:

--- a/stable/insights-agent/templates/install-reporter/job.yaml
+++ b/stable/insights-agent/templates/install-reporter/job.yaml
@@ -22,6 +22,10 @@ spec:
     {{- end }}
     spec:
       restartPolicy: Never
+      {{- with .Values.installReporter.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 6 }}
+      {{- end }}
       containers:
       - name: start-job-from-cronjob
         image: "{{ .Values.installReporter.image.repository }}:{{ .Values.installReporter.image.tag }}"


### PR DESCRIPTION
**Why This PR?**
imagePullSecrets were not being handled correctly in helm templates leading to syntax errors when running helm and making it impossible to utilize Fairwinds with a private image repository.

Fixes #1130

**Changes**
* Move area in _specs.yaml where imagePullSecrets are included for CronJobs
* Update templates which directly set imagePullSecrets, in some cases adding the section and in some cases removing it.

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/insights-agent]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
