### PR TITLE
[stable/goldilocks] [stable/vpa] Add .Release.Namespace template option

### DIFF
--- a/stable/goldilocks/Chart.yaml
+++ b/stable/goldilocks/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 appVersion: "v4.6.3"
-version: 6.5.2
+version: 6.5.3
 description: |
   A Helm chart for running Fairwinds Goldilocks. See https://github.com/FairwindsOps/goldilocks
 name: goldilocks

--- a/stable/goldilocks/templates/controller-deployment.yaml
+++ b/stable/goldilocks/templates/controller-deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "goldilocks.fullname" . }}-controller
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "goldilocks.name" . }}
     helm.sh/chart: {{ include "goldilocks.chart" . }}

--- a/stable/goldilocks/templates/controller-serviceaccount.yaml
+++ b/stable/goldilocks/templates/controller-serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "controller.serviceAccountName" . }}
+  nameespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "goldilocks.name" . }}
     helm.sh/chart: {{ include "goldilocks.chart" . }}

--- a/stable/goldilocks/templates/controller-serviceaccount.yaml
+++ b/stable/goldilocks/templates/controller-serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "controller.serviceAccountName" . }}
-  nameespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "goldilocks.name" . }}
     helm.sh/chart: {{ include "goldilocks.chart" . }}

--- a/stable/goldilocks/templates/dashboard-deployment.yaml
+++ b/stable/goldilocks/templates/dashboard-deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "goldilocks.fullname" . }}-dashboard
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "goldilocks.name" . }}
     helm.sh/chart: {{ include "goldilocks.chart" . }}

--- a/stable/goldilocks/templates/dashboard-ingress.yaml
+++ b/stable/goldilocks/templates/dashboard-ingress.yaml
@@ -10,6 +10,7 @@ apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}-dashboard
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "goldilocks.name" . }}
     helm.sh/chart: {{ include "goldilocks.chart" . }}

--- a/stable/goldilocks/templates/dashboard-service.yaml
+++ b/stable/goldilocks/templates/dashboard-service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "goldilocks.fullname" . }}-dashboard
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "goldilocks.name" . }}
     helm.sh/chart: {{ include "goldilocks.chart" . }}

--- a/stable/goldilocks/templates/dashboard-serviceaccount.yaml
+++ b/stable/goldilocks/templates/dashboard-serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "dashboard.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "goldilocks.name" . }}
     helm.sh/chart: {{ include "goldilocks.chart" . }}

--- a/stable/goldilocks/templates/vpa-uninstall-hook.yaml
+++ b/stable/goldilocks/templates/vpa-uninstall-hook.yaml
@@ -7,6 +7,7 @@ metadata:
     "helm.sh/hook-delete-policy": "hook-succeeded,before-hook-creation,hook-failed"
     "helm.sh/hook-weight": "-250"
   name: {{ include "goldilocks.fullname" . }}-vpa-uninstall
+  namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -35,6 +36,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ include "goldilocks.fullname" . }}-vpa-uninstall
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "goldilocks.name" . }}
     helm.sh/chart: {{ include "goldilocks.chart" . }}

--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 1.7.1
+version: 1.7.2
 appVersion: 0.13.0
 maintainers:
   - name: sudermanjr

--- a/stable/vpa/templates/admission-controller-certgen.yaml
+++ b/stable/vpa/templates/admission-controller-certgen.yaml
@@ -9,6 +9,7 @@ metadata:
     "helm.sh/hook-delete-policy": "hook-succeeded,before-hook-creation,hook-failed"
     "helm.sh/hook-weight": "-100"
   name: {{ include "vpa.fullname" . }}-certgen
+  namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -37,6 +38,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ include "vpa.fullname" . }}-certgen
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "vpa.name" . }}
     helm.sh/chart: {{ include "vpa.chart" . }}

--- a/stable/vpa/templates/admission-controller-cleanup.yaml
+++ b/stable/vpa/templates/admission-controller-cleanup.yaml
@@ -8,6 +8,7 @@ metadata:
     "helm.sh/hook-delete-policy": "hook-succeeded,before-hook-creation,hook-failed"
     "helm.sh/hook-weight": "-100"
   name: {{ include "vpa.fullname" . }}-cleanup
+  namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -36,6 +37,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ include "vpa.fullname" . }}-cleanup
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "vpa.name" . }}
     helm.sh/chart: {{ include "vpa.chart" . }}

--- a/stable/vpa/templates/admission-controller-deployment.yaml
+++ b/stable/vpa/templates/admission-controller-deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "vpa.fullname" . }}-admission-controller
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: admission-controller
     {{- include "vpa.labels" . | nindent 4 }}

--- a/stable/vpa/templates/admission-controller-service-account.yaml
+++ b/stable/vpa/templates/admission-controller-service-account.yaml
@@ -5,6 +5,7 @@ kind: ServiceAccount
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 metadata:
   name: {{ include "vpa.serviceAccountName" . }}-admission-controller
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "vpa.labels" . | nindent 4 }}
     app.kubernetes.io/component: admission-controller

--- a/stable/vpa/templates/admission-controller-service.yaml
+++ b/stable/vpa/templates/admission-controller-service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: vpa-webhook
+  namespace: {{ .Release.Namespace }}
 spec:
   ports:
     - port: 443

--- a/stable/vpa/templates/recommender-deployment.yaml
+++ b/stable/vpa/templates/recommender-deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "vpa.fullname" . }}-recommender
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: recommender
     {{- include "vpa.labels" . | nindent 4 }}

--- a/stable/vpa/templates/recommender-service-account.yaml
+++ b/stable/vpa/templates/recommender-service-account.yaml
@@ -4,6 +4,7 @@ kind: ServiceAccount
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 metadata:
   name: {{ include "vpa.serviceAccountName" . }}-recommender
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "vpa.labels" . | nindent 4 }}
     app.kubernetes.io/component: recommender

--- a/stable/vpa/templates/tests/crd-available.yaml
+++ b/stable/vpa/templates/tests/crd-available.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: {{ include "vpa.fullname" . }}-checkpoint-crd-available
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "vpa.labels" . | nindent 4 }}
   annotations:
@@ -25,6 +26,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: {{ include "vpa.fullname" . }}-crd-available
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "vpa.labels" . | nindent 4 }}
   annotations:

--- a/stable/vpa/templates/tests/create-vpa.yaml
+++ b/stable/vpa/templates/tests/create-vpa.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: {{ include "vpa.fullname" . }}-test-create-vpa
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "vpa.labels" . | nindent 4 }}
   annotations:

--- a/stable/vpa/templates/tests/metrics.yaml
+++ b/stable/vpa/templates/tests/metrics.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: {{ include "vpa.fullname" . }}-metrics-api-available
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "vpa.labels" . | nindent 4 }}
   annotations:

--- a/stable/vpa/templates/tests/rbac.yaml
+++ b/stable/vpa/templates/tests/rbac.yaml
@@ -6,6 +6,7 @@ metadata:
     "helm.sh/hook-delete-policy": "hook-succeeded,before-hook-creation,hook-failed"
     "helm.sh/hook-weight": "10"
   name: {{ include "vpa.fullname" . }}-test
+  namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/stable/vpa/templates/updater-deployment.yaml
+++ b/stable/vpa/templates/updater-deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "vpa.fullname" . }}-updater
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: updater
     {{- include "vpa.labels" . | nindent 4 }}

--- a/stable/vpa/templates/updater-service-account.yaml
+++ b/stable/vpa/templates/updater-service-account.yaml
@@ -4,6 +4,7 @@ kind: ServiceAccount
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 metadata:
   name: {{ include "vpa.serviceAccountName" . }}-updater
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "vpa.labels" . | nindent 4 }}
     app.kubernetes.io/component: updater


### PR DESCRIPTION
**Why This PR?**
We use [Carvel's Kapp-Controller](https://carvel.dev/kapp-controller/) to deploy our helm charts. If there is template option for `namespace: {{ .Release.Namespace }}` in the charts and sub-charts, kapp-controller puts the helm deployment into the default namespace.

As I understand helm, this should be a noop for normal `helm install` usage.

Fixes #

**Changes**
Changes proposed in this pull request:

* Add `.Release.Namespace` to `goldilocks` and `vpa` charts

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.