### PR TITLE
[stable/insights-agent] custom labels and annotations for each report

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 2.17.0
+* Allow custom labels and annotations for each report
+
 ## 2.16.2
 * Fix syntax errors around use of imagePullSecrets as part of Containers section of PodSpec to permit use of insights-agent with private container repos
 

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.16.2
+version: 2.17.0
 appVersion: 9.2.1
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:

--- a/stable/insights-agent/README.md
+++ b/stable/insights-agent/README.md
@@ -94,6 +94,10 @@ Parameter | Description | Default
 `{report}.image.tag` | Image tag to use for the report |
 `{report}.securityContext` | Pod securityContext for the CronJob | {}
 `{report}.containerSecurityContext` | Container securityContext for the CronJob | {}
+`{report}.labels` | labels for the CronJob | {}
+`{report}.annotations` | annotations for the CronJob | {}
+`{report}.jobLabels` | labels for the Jobs created by the CronJob | {}
+`{report}.jobAnnotations` | annotations for the Jobs created by the CronJob | {}
 `polaris.config` | A custom [polaris configuration](https://polaris.docs.fairwinds.com/customization/configuration/)
 `polaris.extraArgs` | A string of custom arguments to pass to the polaris CLI, e.g. `--disallow-annotation-exemptions=true` | 
 `kube-hunter.logLevel` | DEFAULT, INFO, or WARNING | `INFO`

--- a/stable/insights-agent/ci/test-values.yaml
+++ b/stable/insights-agent/ci/test-values.yaml
@@ -22,6 +22,14 @@ goldilocks:
 
 opa:
   enabled: true
+  labels:
+    foo: bar
+  annotations:
+    beez: baz
+  jobLabels:
+    bagel: everything
+  jobAnnotations:
+    flip: flop
   resources:
     requests:
       cpu: 50m

--- a/stable/insights-agent/templates/_specs.yaml
+++ b/stable/insights-agent/templates/_specs.yaml
@@ -2,9 +2,15 @@
   name: {{ .Label }}
   labels:
     app: insights-agent
+  {{- with .Config.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   annotations:
     polaris.fairwinds.com/memoryLimitsMissing-exempt: "true"
     polaris.fairwinds.com/cpuLimitsMissing-exempt: "true"
+  {{- with .Config.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- if .Values.cronjobs.disableServiceMesh }}
     linkerd.io/inject: disabled
     sidecar.istio.io/inject: "false"
@@ -43,11 +49,18 @@ activeDeadlineSeconds: {{ mul .Config.timeout .Values.cronjobs.backoffLimit }}
 
 {{ define "job-spec-metadata" }}
 metadata:
+  {{- with .Config.jobLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   annotations:
     cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
-    {{- if .Values.global.customWorkloadAnnotations }}
+  {{- with .Config.jobAnnotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- if .Values.global.customWorkloadAnnotations }}
     {{- toYaml .Values.global.customWorkloadAnnotations | nindent 4 }}
-    {{- end }}
+  {{- end }}
 {{- end }}
 
 {{ define "job-template-spec" }}


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Per request

**Changes**
Changes proposed in this pull request:
* four new values that can be set for each report, setting labels/annotations for the CronJob or its jobs
*

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
