### PR TITLE
[stable/insights-agent] Fix awscosts when using IRSA

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 2.17.1
+* Fix an issue with readonly filesystem when awscosts with IRSA is used
+
 ## 2.17.0
 * Allow custom labels and annotations for each report
 

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.17.0
+version: 2.17.1
 appVersion: 9.2.1
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:

--- a/stable/insights-agent/templates/awscosts/cronjob.yaml
+++ b/stable/insights-agent/templates/awscosts/cronjob.yaml
@@ -11,8 +11,12 @@ spec:
         {{ include "job-spec-metadata" . | nindent 8 | trim }}
         spec:
           {{ include "job-template-spec" . | indent 10 | trim }}
+          - name: creds
+            emptyDir: {}
           containers:
           - {{ include "container-spec" . | indent 12 | trim }}
+            - name: creds
+              mountPath: /.aws
             env:
             {{- if .Values.awscosts.secretName }}
             - name: AWS_ACCESS_KEY_ID


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

IRSA seems to want to write to the `/.aws` folder all of a sudden.

**Changes**
Changes proposed in this pull request:
* mount a volume at `/.aws` so it's not readonly

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
