### PR TITLE
[stable/insights-admission] Add the ability to specify the cert-manager apiVersion

### DIFF
--- a/stable/insights-admission/CHANGELOG.md
+++ b/stable/insights-admission/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+
+## 1.6.1
+* Add an apiVersion override for cert-manager apiVersions
+
 ## 1.6.0
 * Add the ability to use a custom SSL certificate to validate communication with a self-hosted Insights API.
 

--- a/stable/insights-admission/Chart.yaml
+++ b/stable/insights-admission/Chart.yaml
@@ -2,9 +2,8 @@ apiVersion: v2
 name: insights-admission
 description: A Validating Webhook Admission Controller that utilizes Fairwinds Insights.
 type: application
-version: 1.6.0
+version: 1.6.1
 appVersion: "1.9"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-admission/icon.png
 maintainers:
   - name: rbren
-  - name: makoscafee

--- a/stable/insights-admission/README.md
+++ b/stable/insights-admission/README.md
@@ -99,4 +99,5 @@ rules:
 | caBundle | string | `""` | If you are providing your own certificate then this is the Certificate Authority for that certificate |
 | secretName | string | `""` | If you are providing your own certificate then this is the name of the secret holding the certificate. |
 | clusterDomain | string | `"cluster.local"` | The base domain to use for cluster DNS |
+| certManagerApiVersion | string | `""` | If secretName is empty, we assume that you use cert-manager to provision the admission controller certificates. This allows pinning the apiVersion rather than using helm capabilities detection. Useful for gitops tools such as ArgoCD |
 | test | object | `{"enabled":false,"image":{"repository":"python","tag":"3.10-alpine"}}` | Used for chart CI only - deploys a test deployment |

--- a/stable/insights-admission/templates/cert.yaml
+++ b/stable/insights-admission/templates/cert.yaml
@@ -1,10 +1,14 @@
 {{- if not .Values.secretName -}}
+{{- if .Values.certManagerApiVersion }}
+apiVersion: {{ .Values.certManagerApiVersion }}
+{{- else }}
 {{- if .Capabilities.APIVersions.Has "cert-manager.io/v1" }}
 apiVersion: cert-manager.io/v1
 {{- else if .Capabilities.APIVersions.Has "cert-manager.io/v1alpha2" }}
 apiVersion: cert-manager.io/v1alpha2
 {{- else }}
 apiVersion: cert-manager.io/v1alpha1
+{{- end }}
 {{- end }}
 kind: Certificate
 metadata:
@@ -20,12 +24,16 @@ spec:
     name: {{ include "insights-admission.fullname" . }}-selfsigned
   secretName: {{ include "insights-admission.fullname" . }}
 ---
+{{- if .Values.certManagerApiVersion }}
+apiVersion: {{ .Values.certManagerApiVersion }}
+{{- else }}
 {{- if .Capabilities.APIVersions.Has "cert-manager.io/v1" }}
 apiVersion: cert-manager.io/v1
 {{- else if .Capabilities.APIVersions.Has "cert-manager.io/v1alpha2" }}
 apiVersion: cert-manager.io/v1alpha2
 {{- else }}
 apiVersion: cert-manager.io/v1alpha1
+{{- end }}
 {{- end }}
 kind: Issuer
 metadata:

--- a/stable/insights-admission/values.yaml
+++ b/stable/insights-admission/values.yaml
@@ -233,6 +233,8 @@ caBundle: ""
 secretName: ""
 # clusterDomain -- The base domain to use for cluster DNS
 clusterDomain: cluster.local
+# certManagerApiVersion -- If secretName is empty, we assume that you use cert-manager to provision the admission controller certificates. This allows pinning the apiVersion rather than using helm capabilities detection. Useful for gitops tools such as ArgoCD
+certManagerApiVersion: ""
 
 # test -- Used for chart CI only - deploys a test deployment
 test:


### PR DESCRIPTION
**Why This PR?**
Sometimes we need to pick an apiVersion, rather than using capabilities detection

**Changes**
Changes proposed in this pull request:

* add a value for certManagerApiVersion

Output from: `helm template . --set certManagerApiVersion=cert-manager.io/v1 --set insights.base64token=foo --set insights.cluster=foo --set insights.organization=foo`

```
# Source: insights-admission/templates/cert.yaml
apiVersion: cert-manager.io/v1
kind: Certificate
metadata:
  name: release-name-insights-admission-cert
spec:
  commonName: release-name-insights-admission.default.svc
  dnsNames:
  - release-name-insights-admission.default.svc
  - release-name-insights-admission.default.svc.cluster.local
  isCA: true
  issuerRef:
    kind: Issuer
    name: release-name-insights-admission-selfsigned
  secretName: release-name-insights-admission
---
# Source: insights-admission/templates/cert.yaml
apiVersion: cert-manager.io/v1
kind: Issuer
metadata:
  name: release-name-insights-admission-selfsigned
spec:
  selfSigned: {}
---
```

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.