### PR TITLE
[stable/insights-agent] Upgrade trivy docker image to 0.26.1

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 2.18.1
+* Upgrade trivy image to 0.26.1
+
 ## 2.18.0
 * Update prometheus subchart to latest minor version
 

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.18.0
+version: 2.18.1
 appVersion: 9.2.1
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -273,7 +273,7 @@ trivy:
   env:
   image:
     repository: quay.io/fairwinds/fw-trivy
-    tag: "0.26"
+    tag: "0.26.1"
   serviceAccount:
     annotations:
   resources:


### PR DESCRIPTION
**Why This PR?**
Fix bug causing trivy to not scan any images.

Fixes #1152 

**Changes**
Changes proposed in this pull request:

* Upgrade trivy to 0.26.1

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
