### PR TITLE
[stable/insights-agent] Fix duplicate key issue

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 2.17.1
+* Fix duplicate key issue when using Kustomize/Flux
+
 ## 2.17.0
 * Allow custom labels and annotations for each report
 

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.17.0
+version: 2.17.1
 appVersion: 9.2.1
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:

--- a/stable/insights-agent/templates/_specs.yaml
+++ b/stable/insights-agent/templates/_specs.yaml
@@ -82,14 +82,12 @@ securityContext:
 imagePullSecrets:
 - name: {{ . }}
 {{- end }}
-{{- if or (not .Config.SkipVolumes) (and .Values.global.sslCertFileSecretName .Values.global.sslCertFileSecretKey) }}
-volumes:
-{{- end }}
 {{- if not .Config.SkipVolumes }}
+volumes:
 - name: output
   emptyDir: {}
-{{- end }}
 {{ include "ssl-cert-file-volume-spec" . | trim }}
+{{- end }}
 {{- end }}
 
 {{ define "container-spec" }}

--- a/stable/insights-agent/templates/_specs.yaml
+++ b/stable/insights-agent/templates/_specs.yaml
@@ -86,7 +86,9 @@ imagePullSecrets:
 volumes:
 - name: output
   emptyDir: {}
-{{ include "ssl-cert-file-volume-spec" . | trim }}
+{{-   if (and .Values.global.sslCertFileSecretName .Values.global.sslCertFileSecretKey) }}
+{{       include "ssl-cert-file-volume-spec" . | trim }}
+{{-   end }}
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
**Why This PR?**
This fixes an issue that Flux users are facing w/ the insights-agent--seems the chart generates a duplicate key with particular sets of values.

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
