### PR TITLE
[stable/insights-agent] add SkipVolumes to kube-bench

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 ## 2.17.1
+* Fix issue with kube-bench volumes
+
+## 2.17.1
 * Fix duplicate key issue when using Kustomize/Flux
 
 ## 2.17.0

--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-## 2.17.1
+## 2.17.2
 * Fix issue with kube-bench volumes
 
 ## 2.17.1

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.17.1
+version: 2.17.2
 appVersion: 9.2.1
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -239,6 +239,7 @@ kube-bench:
   mode: "cronjob"
   hourInterval: 2
   timeout: 600
+  SkipVolumes: true
   image:
     repository: quay.io/fairwinds/fw-kube-bench
     tag: 0.4


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_
The chart currently breaks for Flux users due to a dupe key

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
