### PR TITLE
[stable/insights-agent] Update kube-state-metrics repository away from GCR

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 2.17.2
+* Update registry for kube-state-metrics
+
 ## 2.17.1
 * Fix duplicate key issue when using Kustomize/Flux
 

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.17.2
+version: 2.17.3
 appVersion: 9.2.1
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.17.3
+version: 2.17.4
 appVersion: 9.2.1
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.17.1
+version: 2.17.2
 appVersion: 9.2.1
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:

--- a/stable/insights-agent/requirements.yaml
+++ b/stable/insights-agent/requirements.yaml
@@ -5,7 +5,7 @@ dependencies:
   condition: goldilocks.enabled
 - name: prometheus
   repository: https://prometheus-community.github.io/helm-charts
-  version: '15.8.7' # TODO: when updating this, remove the pinned version for kube-state-metrics in values.yaml
+  version: '15.8.7'  # TODO: when updating this, remove the pinned version for kube-state-metrics in values.yaml
   condition: prometheus-metrics.installPrometheusServer
 - name: insights-admission
   repository: https://charts.fairwinds.com/stable

--- a/stable/insights-agent/requirements.yaml
+++ b/stable/insights-agent/requirements.yaml
@@ -5,7 +5,7 @@ dependencies:
   condition: goldilocks.enabled
 - name: prometheus
   repository: https://prometheus-community.github.io/helm-charts
-  version: '15.8.7'
+  version: '15.8.7' # TODO: when updating this, remove the pinned version for kube-state-metrics in values.yaml
   condition: prometheus-metrics.installPrometheusServer
 - name: insights-admission
   repository: https://charts.fairwinds.com/stable

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -344,7 +344,7 @@ prometheus:
       pullPolicy: Always
       registry: registry.k8s.io
       repository: kube-state-metrics/kube-state-metrics
-      tag: "v2.4.1" # TODO: remove this once we update to the latest p8s chart
+      tag: "v2.4.1"  # TODO: remove this once we update to the latest p8s chart
     resources:
       requests:
         cpu: 10m

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -344,7 +344,7 @@ prometheus:
       pullPolicy: Always
       registry: registry.k8s.io
       repository: kube-state-metrics/kube-state-metrics
-      tag: "v2.6.0" # TODO: remove this once we update to the latest p8s chart
+      tag: "v2.4.1" # TODO: remove this once we update to the latest p8s chart
     resources:
       requests:
         cpu: 10m

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -342,8 +342,8 @@ prometheus:
   kube-state-metrics:
     image:
       pullPolicy: Always
-      registry: registry.k8s.io
-      repository: kube-state-metrics/kube-state-metrics
+      registry: ""
+      repository: registry.k8s.io/kube-state-metrics/kube-state-metrics
       tag: "v2.4.1"  # TODO: remove this once we update to the latest p8s chart
     resources:
       requests:

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -342,6 +342,9 @@ prometheus:
   kube-state-metrics:
     image:
       pullPolicy: Always
+      registry: registry.k8s.io
+      repository: kube-state-metrics/kube-state-metrics
+      tag: "v2.6.0" # TODO: remove this once we update to the latest p8s chart
     resources:
       requests:
         cpu: 10m


### PR DESCRIPTION
**Why This PR?**
GCR repos are being deprecated

**Changes**
Changes proposed in this pull request:
* hard-code new registry for ksm

Alternatively, we could update the p8s subchart, but we need to do some more extensive testing first. I put a TODO

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
