### PR TITLE
[stable/polaris] Fix for #1059: additionalExemptions

### DIFF
--- a/stable/polaris/CHANGELOG.md
+++ b/stable/polaris/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this Helm chart will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this chart adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 5.7.4
+Added addition exemptions
+* https://github.com/FairwindsOps/charts/issues/1059
+
 ## 5.5.1
 ### Added
 RBAC permission to get and list ClusterRoles, ClusterRoleBindings, Roles, and RoleBindings. These permissions are required by new RBAC related checks:

--- a/stable/polaris/Chart.yaml
+++ b/stable/polaris/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Validation of best practices in your Kubernetes clusters
 name: polaris
-version: 5.7.3
+version: 5.7.4
 appVersion: "7.1"
 icon: https://raw.githubusercontent.com/FairwindsOps/polaris/master/pkg/dashboard/assets/favicon-32x32.png
 maintainers:

--- a/stable/polaris/README.md
+++ b/stable/polaris/README.md
@@ -36,8 +36,8 @@ the 0.10.0 version of this chart will only work on kubernetes 1.14.0+
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | config | string | `nil` | The [polaris configuration](https://github.com/FairwindsOps/polaris#configuration). If not provided then the [default](https://github.com/FairwindsOps/polaris/blob/master/examples/config.yaml) config from Polaris is used. |
-| additionExemptions | string | `nil` | List of additional exemptions to append to the exemptions given in `config` |
 | configUrl | string | `nil` | Use a config from an accessible URL source.  NOTE: `config` & `configUrl` are mutually exclusive.  Setting `configURL` will take precedence over `config`.  Only one may be used. configUrl: https://example.com/config.yaml |
+| additionExemptions | string | `nil` | List of additional exemptions to append to the exemptions given in `config` |
 | image.repository | string | `"quay.io/fairwinds/polaris"` | Image repo |
 | image.tag | string | `""` | The Polaris Image tag to use. Defaults to the Chart's AppVersion |
 | image.pullPolicy | string | `"Always"` | Image pull policy |

--- a/stable/polaris/README.md
+++ b/stable/polaris/README.md
@@ -36,6 +36,7 @@ the 0.10.0 version of this chart will only work on kubernetes 1.14.0+
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | config | string | `nil` | The [polaris configuration](https://github.com/FairwindsOps/polaris#configuration). If not provided then the [default](https://github.com/FairwindsOps/polaris/blob/master/examples/config.yaml) config from Polaris is used. |
+| additionExemptions | string | `nil` | List of additional exemptions to append to the exemptions given in `config` |
 | configUrl | string | `nil` | Use a config from an accessible URL source.  NOTE: `config` & `configUrl` are mutually exclusive.  Setting `configURL` will take precedence over `config`.  Only one may be used. configUrl: https://example.com/config.yaml |
 | image.repository | string | `"quay.io/fairwinds/polaris"` | Image repo |
 | image.tag | string | `""` | The Polaris Image tag to use. Defaults to the Chart's AppVersion |

--- a/stable/polaris/ci/merge-values.yaml
+++ b/stable/polaris/ci/merge-values.yaml
@@ -1,0 +1,66 @@
+# Based upon https://github.com/FairwindsOps/polaris/blob/master/examples/config.yaml
+nameOverride: polaris
+
+config:
+  checks:
+    # reliability
+    deploymentMissingReplicas: warning
+    priorityClassNotSet: ignore
+    tagNotSpecified: danger
+    pullPolicyNotAlways: warning
+    readinessProbeMissing: warning
+    livenessProbeMissing: warning
+    metadataAndNameMismatched: ignore
+    pdbDisruptionsIsZero: warning
+    missingPodDisruptionBudget: ignore
+    topologySpreadConstraint: warning
+
+    # efficiency
+    cpuRequestsMissing: warning
+    cpuLimitsMissing: warning
+    memoryRequestsMissing: warning
+    memoryLimitsMissing: warning
+    # security
+    automountServiceAccountToken: ignore
+    hostIPCSet: danger
+    hostPIDSet: danger
+    linuxHardening: warning
+    missingNetworkPolicy: ignore
+    notReadOnlyRootFilesystem: warning
+    privilegeEscalationAllowed: danger
+    runAsRootAllowed: danger
+    runAsPrivileged: danger
+    dangerousCapabilities: danger
+    insecureCapabilities: warning
+    hostNetworkSet: danger
+    hostPortSet: warning
+    tlsSettingsMissing: warning
+    # These are initially warning and will later be promoted to danger.
+    sensitiveContainerEnvVar: warning
+    sensitiveConfigmapContent: warning
+    clusterrolePodExecAttach: warning
+    rolePodExecAttach: warning
+    clusterrolebindingPodExecAttach: warning
+    rolebindingClusterRolePodExecAttach: warning
+    rolebindingRolePodExecAttach: warning
+    clusterrolebindingClusterAdmin: warning
+    rolebindingClusterAdminClusterRole: warning
+    rolebindingClusterAdminRole: warning
+
+  mutations:
+    - pullPolicyNotAlways
+
+  exemptions:
+    - namespace: kube-system
+      controllerNames:
+        - coredns
+      rules:
+        - automountServiceAccountToken
+        - missingNetworkPolicy
+
+additionalExemptions:
+  - namespace: foo
+    containerName:
+      - bar
+    rules:
+      - privilegeEscalationAllowed

--- a/stable/polaris/templates/configmap.yaml
+++ b/stable/polaris/templates/configmap.yaml
@@ -11,6 +11,12 @@ metadata:
     {{- include "polaris.labels" $ | nindent 4 }}
 data:
   config.yaml: |
-    {{- toYaml . | nindent 4 }}
+    {{- range $key, $value := . }}
+    {{ $key }}:
+    {{- toYaml $value | nindent 6 }}
+    {{- if and (eq $key "exemptions") ($.Values.additionalExemptions) }}
+    {{- toYaml $.Values.additionalExemptions | nindent 6 }}
+    {{- end }}
+    {{- end }}
 {{- end }}
 {{- end }}

--- a/stable/polaris/values.yaml
+++ b/stable/polaris/values.yaml
@@ -5,6 +5,10 @@ config: null
 # configUrl: https://example.com/config.yaml
 configUrl: null
 
+# additionExemptions -- List of additional exemptions to append to the exemptions given in `config`
+additionExemptions: null
+
+
 image:
   # image.repository -- Image repo
   repository: quay.io/fairwinds/polaris


### PR DESCRIPTION
**Why This PR?**
Re-creation of pull-request. Add new optional element for additional exemptions in Polaris Helm chart. 
Fixes #1059 

**Changes**
Changes proposed in this pull request:

* New optional element `additionExemptions`

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
