### PR TITLE
[stable/insights-agent] update prometheus

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 2.18.0
+* Update prometheus subchart to latest version
+
 ## 2.17.4
 * Update registry for kube-state-metrics
 

--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 ## 2.18.0
-* Update prometheus subchart to latest version
+* Update prometheus subchart to latest minor version
 
 ## 2.17.4
 * Update registry for kube-state-metrics

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.17.4
+version: 2.18.0
 appVersion: 9.2.1
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:

--- a/stable/insights-agent/requirements.yaml
+++ b/stable/insights-agent/requirements.yaml
@@ -5,7 +5,7 @@ dependencies:
   condition: goldilocks.enabled
 - name: prometheus
   repository: https://prometheus-community.github.io/helm-charts
-  version: '15.9.1'
+  version: '15.9.1'  # TODO: when updating this, remove the pinned version for kube-state-metrics in values.yaml
   condition: prometheus-metrics.installPrometheusServer
 - name: insights-admission
   repository: https://charts.fairwinds.com/stable

--- a/stable/insights-agent/requirements.yaml
+++ b/stable/insights-agent/requirements.yaml
@@ -5,7 +5,7 @@ dependencies:
   condition: goldilocks.enabled
 - name: prometheus
   repository: https://prometheus-community.github.io/helm-charts
-  version: '22.4.1'
+  version: '15.9.1'
   condition: prometheus-metrics.installPrometheusServer
 - name: insights-admission
   repository: https://charts.fairwinds.com/stable

--- a/stable/insights-agent/requirements.yaml
+++ b/stable/insights-agent/requirements.yaml
@@ -5,7 +5,7 @@ dependencies:
   condition: goldilocks.enabled
 - name: prometheus
   repository: https://prometheus-community.github.io/helm-charts
-  version: '15.8.7'  # TODO: when updating this, remove the pinned version for kube-state-metrics in values.yaml
+  version: '22.4.1'
   condition: prometheus-metrics.installPrometheusServer
 - name: insights-admission
   repository: https://charts.fairwinds.com/stable

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -343,9 +343,6 @@ prometheus:
   kube-state-metrics:
     image:
       pullPolicy: Always
-      registry: ""
-      repository: registry.k8s.io/kube-state-metrics/kube-state-metrics
-      tag: "v2.4.1"  # TODO: remove this once we update to the latest p8s chart
     resources:
       requests:
         cpu: 10m

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -343,6 +343,9 @@ prometheus:
   kube-state-metrics:
     image:
       pullPolicy: Always
+      registry: ""
+      repository: registry.k8s.io/kube-state-metrics/kube-state-metrics
+      tag: "v2.4.1"  # TODO: remove this once we update to the latest p8s chart
     resources:
       requests:
         cpu: 10m


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_
We were falling behind on the p8s chart--this updates to latest.

Also seems to fix deprecated PDB issues in newer k8s versions

Everything seems to be working OK on a KIND cluster

**Changes**
Changes proposed in this pull request:
* update p8s
*

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
