### PR TITLE
[stable/polaris] Add the ability to annotate the webhook configurations

### DIFF
--- a/stable/polaris/Chart.yaml
+++ b/stable/polaris/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Validation of best practices in your Kubernetes clusters
 name: polaris
-version: 5.7.4
+version: 5.7.5
 appVersion: "7.1"
 icon: https://raw.githubusercontent.com/FairwindsOps/polaris/master/pkg/dashboard/assets/favicon-32x32.png
 maintainers:

--- a/stable/polaris/README.md
+++ b/stable/polaris/README.md
@@ -96,6 +96,8 @@ the 0.10.0 version of this chart will only work on kubernetes 1.14.0+
 | webhook.disallowExemptions | bool | `false` | Disallow any exemption |
 | webhook.disallowConfigExemptions | bool | `false` | Disallow exemptions that are configured in the config file |
 | webhook.disallowAnnotationExemptions | bool | `false` | Disallow exemptions that are configured via annotations |
+| webhook.mutatingConfigurationAnnotations | object | `{}` |  |
+| webhook.validatingConfigurationAnnotations | object | `{}` |  |
 | audit.enable | bool | `false` | Runs a one-time audit. This is used internally at Fairwinds, and may not be useful for others. |
 | audit.cleanup | bool | `false` | Whether to delete the namespace once the audit is finished. |
 | audit.outputURL | string | `""` | A URL which will receive a POST request with audit results. |

--- a/stable/polaris/ci/test-values.yaml
+++ b/stable/polaris/ci/test-values.yaml
@@ -7,3 +7,7 @@ dashboard:
 webhook:
   enabled: true
   mutate: true
+  mutatingConfigurationAnnotations:
+    test: mutate
+  validatingConfigurationAnnotations:
+    test: validate

--- a/stable/polaris/templates/mutate-webhook.configuration.yaml
+++ b/stable/polaris/templates/mutate-webhook.configuration.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- if not .Values.webhook.secretName }}
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "polaris.fullname" . }}-cert
     {{- end }}
-    {{- range $key, $value := .Values.webhooks.service.annotations }}
+    {{- range $key, $value := .Values.webhooks.validatingConfigurationAnnotations }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
 webhooks:

--- a/stable/polaris/templates/mutate-webhook.configuration.yaml
+++ b/stable/polaris/templates/mutate-webhook.configuration.yaml
@@ -3,10 +3,13 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: polaris-mutate-webhook
-  {{- if not .Values.webhook.secretName }}
   annotations:
+    {{- if not .Values.webhook.secretName }}
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "polaris.fullname" . }}-cert
-  {{- end }}
+    {{- end }}
+    {{- range $key, $value := .Values.webhooks.service.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
 webhooks:
 - admissionReviewVersions:
   - v1

--- a/stable/polaris/templates/validate-webhook.configuration.yaml
+++ b/stable/polaris/templates/validate-webhook.configuration.yaml
@@ -5,8 +5,12 @@ metadata:
   name: polaris-validate-webhook
   {{- if not .Values.webhook.secretName }}
   annotations:
+    {{- if not .Values.webhook.secretName }}
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "polaris.fullname" . }}-cert
-  {{- end }}
+    {{- end }}
+    {{- range $key, $value := .Values.webhooks.service.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
 webhooks:
 - admissionReviewVersions:
   - v1

--- a/stable/polaris/templates/validate-webhook.configuration.yaml
+++ b/stable/polaris/templates/validate-webhook.configuration.yaml
@@ -3,7 +3,6 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: polaris-validate-webhook
-  {{- if not .Values.webhook.secretName }}
   annotations:
     {{- if not .Values.webhook.secretName }}
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "polaris.fullname" . }}-cert

--- a/stable/polaris/templates/validate-webhook.configuration.yaml
+++ b/stable/polaris/templates/validate-webhook.configuration.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- if not .Values.webhook.secretName }}
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "polaris.fullname" . }}-cert
     {{- end }}
-    {{- range $key, $value := .Values.webhooks.service.annotations }}
+    {{- range $key, $value := .Values.webhooks.validatingConfigurationAnnotations }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
 webhooks:

--- a/stable/polaris/values.yaml
+++ b/stable/polaris/values.yaml
@@ -231,6 +231,8 @@ webhook:
   disallowConfigExemptions: false
   # webhook.disallowAnnotationExemptions -- Disallow exemptions that are configured via annotations
   disallowAnnotationExemptions: false
+  mutatingConfigurationAnnotations: {}
+  validatingConfigurationAnnotations: {}
 
 audit:
   # audit.enable -- Runs a one-time audit. This is used internally at Fairwinds, and may not be useful for others.


### PR DESCRIPTION
**Why This PR?**
For certain deploy systems, the ability to annotate these resources is necessary

Fixes #1182

**Changes**
Changes proposed in this pull request:

* Add two values - webhook.mutatingConfigurationAnnotations and webhook.validatingConfigurationAnnotations

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.