### PR TITLE
[stable/polaris] use specified certManager apiVersion if set

### DIFF
--- a/stable/polaris/Chart.yaml
+++ b/stable/polaris/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Validation of best practices in your Kubernetes clusters
 name: polaris
-version: 5.7.6
-appVersion: "7.1"
+version: 5.8.0
+appVersion: "7.4"
 icon: https://raw.githubusercontent.com/FairwindsOps/polaris/master/pkg/dashboard/assets/favicon-32x32.png
 maintainers:
   - name: rbren

--- a/stable/polaris/README.md
+++ b/stable/polaris/README.md
@@ -81,6 +81,7 @@ the 0.10.0 version of this chart will only work on kubernetes 1.14.0+
 | webhook.tolerations | list | `[]` | Webhook pod tolerations |
 | webhook.affinity | object | `{}` | Webhook pods affinity |
 | webhook.topologySpreadConstraints | list | `[{"labelSelector":{"matchLabels":{"component":"webhook"}},"maxSkew":1,"topologyKey":"topology.kubernetes.io/zone","whenUnsatisfiable":"ScheduleAnyway"},{"labelSelector":{"matchLabels":{"component":"webhook"}},"maxSkew":1,"topologyKey":"kubernetes.io/hostname","whenUnsatisfiable":"ScheduleAnyway"}]` | Webhook pods topologySpreadConstraints |
+| webhook.certManager.apiVersion | string | `""` | Allows overriding .Capabilities.APIVersions with a specified version. Useful for GitOps. |
 | webhook.caBundle | string | `nil` | CA Bundle to use for Validating Webhook instead of cert-manager |
 | webhook.secretName | string | `nil` | Name of the secret containing a TLS certificate to use if cert-manager is not used. |
 | webhook.failurePolicy | string | `"Fail"` | failurePolicy for the ValidatingWebhookConfiguration |

--- a/stable/polaris/ci/test-values.yaml
+++ b/stable/polaris/ci/test-values.yaml
@@ -11,3 +11,5 @@ webhook:
     test: mutate
   validatingConfigurationAnnotations:
     test: validate
+  certManager:
+    apiVersion: cert-manager.io/v1

--- a/stable/polaris/templates/webhook.cert.yaml
+++ b/stable/polaris/templates/webhook.cert.yaml
@@ -1,5 +1,7 @@
 {{- if and .Values.webhook.enable (not .Values.webhook.secretName) -}}
-{{- if .Capabilities.APIVersions.Has "cert-manager.io/v1" }}
+{{- if .webhook.certManager.apiVersion }}
+apiVersion: .webhook.certManager.apiVersion
+{{- else if .Capabilities.APIVersions.Has "cert-manager.io/v1" }}
 apiVersion: cert-manager.io/v1
 {{- else if .Capabilities.APIVersions.Has "cert-manager.io/v1alpha2" }}
 apiVersion: cert-manager.io/v1alpha2
@@ -26,7 +28,9 @@ spec:
     name: {{ include "polaris.fullname" . }}-selfsigned
   secretName: {{ include "polaris.fullname" . }}
 ---
-{{- if .Capabilities.APIVersions.Has "cert-manager.io/v1" }}
+{{- if .webhook.certManager.apiVersion }}
+apiVersion: .webhook.certManager.apiVersion
+{{- else if .Capabilities.APIVersions.Has "cert-manager.io/v1" }}
 apiVersion: cert-manager.io/v1
 {{- else if .Capabilities.APIVersions.Has "cert-manager.io/v1alpha2" }}
 apiVersion: cert-manager.io/v1alpha2

--- a/stable/polaris/values.yaml
+++ b/stable/polaris/values.yaml
@@ -155,6 +155,9 @@ webhook:
     labelSelector:
       matchLabels:
         component: webhook
+  certManager:
+    # -- Allows overriding .Capabilities.APIVersions with a specified version. Useful for GitOps.
+    apiVersion: ""
   # webhook.caBundle -- CA Bundle to use for Validating Webhook instead of cert-manager
   caBundle: null
   # webhook.secretName -- Name of the secret containing a TLS certificate to use if cert-manager is not used.


### PR DESCRIPTION
**Why This PR?**

Fixes #1187

**Changes**
Changes proposed in this pull request:

* Add a value for cert manager apiVersion
* Update polaris

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.