### PR TITLE
[stable/polaris] fix the cert-manager apiVersion override

### DIFF
--- a/stable/polaris/CHANGELOG.md
+++ b/stable/polaris/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this Helm chart will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this chart adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 5.8.1
+* Fix cert manager apiVersion override
+
 ## 5.7.6
 * Patch bump for updating charts CI
 ## 5.7.4

--- a/stable/polaris/Chart.yaml
+++ b/stable/polaris/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Validation of best practices in your Kubernetes clusters
 name: polaris
-version: 5.8.0
+version: 5.8.1
 appVersion: "7.4"
 icon: https://raw.githubusercontent.com/FairwindsOps/polaris/master/pkg/dashboard/assets/favicon-32x32.png
 maintainers:

--- a/stable/polaris/ci/test-values-2.yaml
+++ b/stable/polaris/ci/test-values-2.yaml
@@ -1,0 +1,13 @@
+dashboard:
+  ingress:
+    enabled: true
+    ingressClassName: ingress
+    hosts:
+    - foo.com
+webhook:
+  enabled: true
+  mutate: true
+  mutatingConfigurationAnnotations:
+    test: mutate
+  validatingConfigurationAnnotations:
+    test: validate

--- a/stable/polaris/templates/webhook.cert.yaml
+++ b/stable/polaris/templates/webhook.cert.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.webhook.enable (not .Values.webhook.secretName) -}}
-{{- if .webhook.certManager.apiVersion }}
-apiVersion: .webhook.certManager.apiVersion
+{{- if .Values.webhook.certManager.apiVersion }}
+apiVersion: {{ .Values.webhook.certManager.apiVersion }}
 {{- else if .Capabilities.APIVersions.Has "cert-manager.io/v1" }}
 apiVersion: cert-manager.io/v1
 {{- else if .Capabilities.APIVersions.Has "cert-manager.io/v1alpha2" }}
@@ -28,8 +28,8 @@ spec:
     name: {{ include "polaris.fullname" . }}-selfsigned
   secretName: {{ include "polaris.fullname" . }}
 ---
-{{- if .webhook.certManager.apiVersion }}
-apiVersion: .webhook.certManager.apiVersion
+{{- if .Values.webhook.certManager.apiVersion }}
+apiVersion: {{ .Values.webhook.certManager.apiVersion }}
 {{- else if .Capabilities.APIVersions.Has "cert-manager.io/v1" }}
 apiVersion: cert-manager.io/v1
 {{- else if .Capabilities.APIVersions.Has "cert-manager.io/v1alpha2" }}


### PR DESCRIPTION
**Why This PR?**
The chart is currently broken due to this issue.

**Changes**
Changes proposed in this pull request:

* Fix the templating for certmanager apiVersion
* Add an additional ci/test-values to cover this case

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.