### PR TITLE
[stable/polaris] fix annotations reference on validatingwebhookconfigurations

### DIFF
--- a/stable/polaris/CHANGELOG.md
+++ b/stable/polaris/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this Helm chart will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this chart adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 5.8.2
+* Fix webhook annotations reference
+
 ## 5.8.1
 * Fix cert manager apiVersion override
 

--- a/stable/polaris/Chart.yaml
+++ b/stable/polaris/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Validation of best practices in your Kubernetes clusters
 name: polaris
-version: 5.8.1
+version: 5.8.2
 appVersion: "7.4"
 icon: https://raw.githubusercontent.com/FairwindsOps/polaris/master/pkg/dashboard/assets/favicon-32x32.png
 maintainers:

--- a/stable/polaris/ci/test-values-2.yaml
+++ b/stable/polaris/ci/test-values-2.yaml
@@ -7,7 +7,3 @@ dashboard:
 webhook:
   enabled: true
   mutate: true
-  mutatingConfigurationAnnotations:
-    test: mutate
-  validatingConfigurationAnnotations:
-    test: validate

--- a/stable/polaris/templates/mutate-webhook.configuration.yaml
+++ b/stable/polaris/templates/mutate-webhook.configuration.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- if not .Values.webhook.secretName }}
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "polaris.fullname" . }}-cert
     {{- end }}
-    {{- range $key, $value := .Values.webhooks.validatingConfigurationAnnotations }}
+    {{- range $key, $value := .Values.webhook.validatingConfigurationAnnotations }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
 webhooks:

--- a/stable/polaris/templates/validate-webhook.configuration.yaml
+++ b/stable/polaris/templates/validate-webhook.configuration.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- if not .Values.webhook.secretName }}
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "polaris.fullname" . }}-cert
     {{- end }}
-    {{- range $key, $value := .Values.webhooks.validatingConfigurationAnnotations }}
+    {{- range $key, $value := .Values.webhook.validatingConfigurationAnnotations }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
 webhooks:


### PR DESCRIPTION
**Why This PR?**
```
helm install polaris fairwinds-stable/polaris --namespace polaris --create-namespace   --set dashboard.enable=false   --set webhook.enable=true
Error: INSTALLATION FAILED: template: polaris/templates/validate-webhook.configuration.yaml:10:37: executing "polaris/templates/validate-webhook.configuration.yaml" at <.Values.webhooks.validatingConfigurationAnnotations>: nil pointer evaluating interface {}.validatingConfigurationAnnotations
```

**Changes**
Changes proposed in this pull request:

* Fix reference to annotations
* Update second test file to cover this issue

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.