### PR TITLE
[stable/fairwinds-insights] Bump repoScanJob.insightsCIVersion to 5.1 which will add new polaris …

### DIFF
--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.14.0
+* Update `repoScanJob.insightsCIVersion` to `5.1` which will add new polaris findings 
+
 ## 0.13.0
 * Added cloud costs update cron job
 

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "12.13"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 0.13.0
+version: 0.14.0
 maintainers:
   - name: rbren
   - name: mhoss019

--- a/stable/fairwinds-insights/README.md
+++ b/stable/fairwinds-insights/README.md
@@ -230,7 +230,7 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | automatedPullRequestJob.nodeSelector | object | `{}` |  |
 | automatedPullRequestJob.tolerations | list | `[]` |  |
 | repoScanJob.enabled | bool | `false` |  |
-| repoScanJob.insightsCIVersion | string | `"5.0"` |  |
+| repoScanJob.insightsCIVersion | string | `"5.1"` |  |
 | repoScanJob.hpa.enabled | bool | `true` |  |
 | repoScanJob.hpa.min | int | `2` |  |
 | repoScanJob.hpa.max | int | `6` |  |

--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -686,7 +686,7 @@ automatedPullRequestJob:
 
 repoScanJob:
   enabled: false
-  insightsCIVersion: "5.0"
+  insightsCIVersion: "5.1"
   hpa:
     enabled: true
     min: 2


### PR DESCRIPTION
**Why This PR?**
Bump `repoScanJob.insightsCIVersion` to `5.1` which will add new Polaris findings

Fixes internal [FWI-4286](https://fairwinds.myjetbrains.com/youtrack/issue/FWI-4286/charts-Update-fairwinds-insights)

**Changes**
Changes proposed in this pull request:

* bump CI plugin for auto-scan

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
