### PR TITLE
[stable/insights-admission] bump insights-admission to 1.10

### DIFF
--- a/stable/insights-admission/CHANGELOG.md
+++ b/stable/insights-admission/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.7.0
+* Bump insights-admission to version 1.10
+
 ## 1.6.4
 * Fix HPA metric definition for autoscaling/v2
 

--- a/stable/insights-admission/Chart.yaml
+++ b/stable/insights-admission/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: insights-admission
 description: A Validating Webhook Admission Controller that utilizes Fairwinds Insights.
 type: application
-version: 1.6.4
-appVersion: "1.9"
+version: 1.7.0
+appVersion: "1.10"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-admission/icon.png
 maintainers:
   - name: rbren


### PR DESCRIPTION
**Why This PR?**
Bump insights-admission to 1.10

Fixes #

**Changes**
Changes proposed in this pull request:

* bump insights-admission to 1.10

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
