### PR TITLE
[stable/insights-agent] update polaris version and admission chart version

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.20.0
+* Update polaris to 8.0
+
 ## 2.19.0
 * Update version of aws costs to 1.3
 
@@ -83,7 +86,6 @@ only available as of 1.22.
 
 ## 2.10.1
 * Update Goldilocks, Nova, Pluto, and Polaris
-
 
 ## 2.10.0
 * BUmp insights-admission to chart 1.5.* (to use app 1.9)

--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 2.20.0
-* Update polaris to 8.0
+* Update polaris to 8.0 and admission to 1.7
 
 ## 2.19.0
 * Update version of aws costs to 1.3

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.19.0
+version: 2.20.0
 appVersion: 9.2.1
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:

--- a/stable/insights-agent/requirements.yaml
+++ b/stable/insights-agent/requirements.yaml
@@ -9,7 +9,7 @@ dependencies:
   condition: prometheus-metrics.installPrometheusServer
 - name: insights-admission
   repository: https://charts.fairwinds.com/stable
-  version: '1.6.*'
+  version: '1.7.*'
   condition: admission.enabled
 - name: falco
   repository: https://falcosecurity.github.io/charts

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -80,7 +80,7 @@ polaris:
     disabled: false
   image:
     repository: quay.io/fairwinds/polaris
-    tag: "7.4"
+    tag: "8.0"
   resources:
     requests:
       cpu: 100m


### PR DESCRIPTION
**Why This PR?**
update insights agent (polaris and admission)

Fixes internal FWI-4255

**Changes**
Changes proposed in this pull request:

* Updates polaris to polaris 8.0
* Updates admission chart to 1.7

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
