### PR TITLE
[stable/vpa] Fix the kubeVersion to allow pre-release versions

### DIFF
--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 2.0.0
+version: 2.0.1
 appVersion: 0.13.0
 maintainers:
   - name: sudermanjr
@@ -12,7 +12,7 @@ sources:
   - https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler
 # CronJobs batch/v1 were introduced in K8s 1.21
 # The VPA admission controller requests them from 0.12.0 forward
-kubeVersion: ">= 1.21.0"
+kubeVersion: ">= 1.21.0-0"
 
 dependencies:
   - alias: metrics-server


### PR DESCRIPTION
**Why This PR?**

EKS uses pre-release versioning for their cluster versions.

https://github.com/helm/helm/issues/10375

Fixes #1221

**Changes**
Changes proposed in this pull request:

* Change `>= 1.21.0` to `1.21.0-0` as per the referenced issue

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.