### PR TITLE
[stable/insights-agent] Add new test to prevent issues with jobs

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 2.20.2
+* Adds test that deletes existing jobs upon `helm test`
 
 ## 2.20.1
 * Fix an issue with readonly filesystem when awscosts with IRSA is used

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.20.1
+version: 2.20.2
 appVersion: 9.2.1
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:

--- a/stable/insights-agent/templates/test/delete-job-pod.yaml
+++ b/stable/insights-agent/templates/test/delete-job-pod.yaml
@@ -24,7 +24,7 @@ spec:
         - |
           {{ .Files.Get "download-kubectl.sh" | nindent 10 }}
           sleep 15
-          kubectl delete jobs `kubectl get jobs -o custom-columns=:.metadata.name`
+          kubectl delete jobs `kubectl get jobs -n {{ Release.Namespace }} -o custom-columns=:.metadata.name`
       resources:
         limits:
           cpu: 1

--- a/stable/insights-agent/templates/test/delete-job-pod.yaml
+++ b/stable/insights-agent/templates/test/delete-job-pod.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "insights-agent.fullname" . }}-delete-jobs
+  labels:
+    app: insights-agent
+    component: test-job
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-weight": "1"
+    {{- with .Values.global.customWorkloadAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  serviceAccountName: {{ include "insights-agent.fullname" . }}-cronjob-executor
+  restartPolicy: Never
+  containers:
+    - name: test
+      image: '{{.Values.cronjobExecutor.image.repository}}:{{.Values.cronjobExecutor.image.tag}}'
+      imagePullPolicy: Always
+      command: ["sh"]
+      args:
+        - -c
+        - |
+          {{ .Files.Get "download-kubectl.sh" | nindent 10 }}
+          sleep 15
+          kubectl delete jobs `kubectl get jobs -o custom-columns=:.metadata.name`
+      resources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 50m
+          memory: 128Mi
+      volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+      securityContext:
+        runAsUser: 1000
+        allowPrivilegeEscalation: false
+        privileged: false
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+        capabilities:
+          drop:
+            - ALL
+  volumes:
+    - name: tmp
+      emptyDir: {}

--- a/stable/insights-agent/templates/test/delete-job-pod.yaml
+++ b/stable/insights-agent/templates/test/delete-job-pod.yaml
@@ -24,7 +24,7 @@ spec:
         - |
           {{ .Files.Get "download-kubectl.sh" | nindent 10 }}
           sleep 15
-          kubectl delete jobs `kubectl get jobs -n {{ Release.Namespace }} -o custom-columns=:.metadata.name`
+          kubectl delete jobs `kubectl get jobs -n {{ .Release.Namespace }} -o custom-columns=:.metadata.name`
       resources:
         limits:
           cpu: 1


### PR DESCRIPTION
**Why This PR?**
Tests fail when job specs are modified on the insights-agent chart. 

**Changes**

*Adds a helm test that delete existing jobs so that our tests handle changes to job specs appropriately.

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
