### PR TITLE
[stable/polaris] Add ingress defaultbackend pointing to dashboard service

### DIFF
--- a/stable/polaris/Chart.yaml
+++ b/stable/polaris/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Validation of best practices in your Kubernetes clusters
 name: polaris
-version: 5.10.2
+version: 5.10.3
 appVersion: "8.2"
 icon: https://raw.githubusercontent.com/FairwindsOps/polaris/master/pkg/dashboard/assets/favicon-32x32.png
 maintainers:

--- a/stable/polaris/README.md
+++ b/stable/polaris/README.md
@@ -68,6 +68,7 @@ the 0.10.0 version of this chart will only work on kubernetes 1.14.0+
 | dashboard.ingress.hosts | list | `[]` | Web ingress hostnames |
 | dashboard.ingress.annotations | object | `{}` | Web ingress annotations |
 | dashboard.ingress.tls | list | `[]` | Ingress TLS configuration |
+| dashboard.ingress.defaultBackendEnabled | bool | `false` | DefaultBackend is required by GKE container native load balancer, set to true for this use case |
 | dashboard.priorityClassName | string | `nil` | Priority Class name to be used in deployment if provided. |
 | dashboard.disallowExemptions | bool | `false` | Disallow any exemption |
 | dashboard.disallowConfigExemptions | bool | `false` | Disallow exemptions that are configured in the config file |

--- a/stable/polaris/templates/ingress.yaml
+++ b/stable/polaris/templates/ingress.yaml
@@ -20,6 +20,13 @@ spec:
 {{- if and (.Values.dashboard.ingress.ingressClassName) (.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress") }}
   ingressClassName: {{ .Values.dashboard.ingress.ingressClassName }}
 {{- end }}
+{{- if .Values.dashboard.ingress.defaultBackendEnabled }}
+  defaultBackend:
+    service:
+      name: {{ $serviceName }}
+      port:
+        number: 80
+{{- end }}
   rules:
   {{- range .Values.dashboard.ingress.hosts }}
   - host: {{ . }}

--- a/stable/polaris/values.yaml
+++ b/stable/polaris/values.yaml
@@ -108,6 +108,8 @@ dashboard:
     annotations: {}
     # dashboard.ingress.tls -- Ingress TLS configuration
     tls: []
+    # dashboard.ingress.defaultBackendEnabled -- DefaultBackend is required by GKE container native load balancer, set to true for this use case
+    defaultBackendEnabled: false
   # dashboard.priorityClassName -- Priority Class name to be used in deployment if provided.
   priorityClassName:
   # dashboard.disallowExemptions -- Disallow any exemption


### PR DESCRIPTION
**Why This PR?**
This is required by GKE container native load balancer option. If not set, GKE will default to Kube-system namespace which end up with a 404

Fixes #

**Changes**
Add `defaultBackendEnabled` option in `values.yaml` file. If set to true, will add defaultBackend in dashboard ingress manifest

*
*

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.

**test:**
```sh
helm template stable/polaris -s templates/ingress.yaml --set dashboard.ingress.enabled=true --set dashboard.ingress.defaultBackendEnabled=true
```
Output:
```yaml
# Source: polaris/templates/ingress.yaml
apiVersion: networking.k8s.io/v1beta1
kind: Ingress
metadata:
  annotations:
  labels:
    app.kubernetes.io/name: polaris
    helm.sh/chart: polaris-5.10.0
    app.kubernetes.io/instance: release-name
  name: polaris
spec:
  defaultBackend:
    service:
      name: release-name-polaris-dashboard
      port:
        number: 80
  rules:
```
