### PR TITLE
[incubator/datadog-apm] change handling of additional envVars

### DIFF
--- a/incubator/datadog-apm/Chart.yaml
+++ b/incubator/datadog-apm/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: datadog-apm
 description: A modified chart that only installs the datadog-apm agent
 type: application
-version: 0.0.11
+version: 0.1.0
 appVersion: 7.40.0
 maintainers:
   - name: sudermanjr

--- a/incubator/datadog-apm/Chart.yaml
+++ b/incubator/datadog-apm/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: datadog-apm
 description: A modified chart that only installs the datadog-apm agent
 type: application
-version: 0.0.10
+version: 0.0.11
 appVersion: 7.40.0
 maintainers:
   - name: sudermanjr

--- a/incubator/datadog-apm/Chart.yaml
+++ b/incubator/datadog-apm/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: datadog-apm
 description: A modified chart that only installs the datadog-apm agent
 type: application
-version: 0.1.0
+version: 0.0.11
 appVersion: 7.40.0
 maintainers:
   - name: sudermanjr

--- a/incubator/datadog-apm/templates/_helpers.tpl
+++ b/incubator/datadog-apm/templates/_helpers.tpl
@@ -109,3 +109,34 @@ Create the name of the service account to use
 {{- default "default" .Values.clusterAgent.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Returns env vars correctly quoted and valueFrom respected
+*/}}
+{{- define "additional-env-entries" -}}
+{{- if . -}}
+{{- range . }}
+- name: {{ .name }}
+{{- if .value }}
+  value: {{ .value | quote }}
+{{- else }}
+  valueFrom:
+{{ toYaml .valueFrom | indent 4 }}
+{{- end }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Returns env vars correctly quoted and valueFrom respected, defined in a dict
+*/}}
+{{- define "additional-env-dict-entries" -}}
+{{- range $key, $value := . }}
+- name: {{ $key }}
+{{- if kindIs "map" $value }}
+{{ toYaml $value | indent 2 }}
+{{- else }}
+  value: {{ $value | quote }}
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/incubator/datadog-apm/templates/cluster-agent-deployment.yaml
+++ b/incubator/datadog-apm/templates/cluster-agent-deployment.yaml
@@ -173,10 +173,8 @@ spec:
             value: {{ .Values.clusterAgent.apm.nonLocalTraffic | quote }}
           - name: DD_APM_RECEIVER_PORT
             value: {{ .Values.clusterAgent.apm.receiverPort | quote }}
-        {{- range $name, $keyname := .Values.clusterAgent.additionalEnvVars }}
-          - name: {{ $name }}
-            value: {{ $keyname | quote }}
-        {{- end }}
+        {{- include "additional-env-entries" .Values.clusterAgent.additionalEnvVars | indent 10 }}
+        {{- include "additional-env-dict-entries" .Values.clusterAgent.additionalEnvDict | indent 10 }}
 {{- if .Values.clusterAgent.env }}
 {{ toYaml .Values.clusterAgent.env | indent 10 }}
 {{- end }}

--- a/incubator/datadog-apm/templates/cluster-agent-pdb.yaml
+++ b/incubator/datadog-apm/templates/cluster-agent-pdb.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.clusterAgent.createPodDisruptionBudget -}}
 ---
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "datadog-apm.fullname" . }}-cluster-agent


### PR DESCRIPTION
**Why This PR?**
Passing in additional env vars was not working according to datadog's standards. This fixes that and matches how datadog parses env vars and allows easier use of examples in datadog's documentation. 

Fixes #

**Changes**
Changes proposed in this pull request:

* adds section to helpers.tpl to handle additional envvars for the cluster agent. 
* includes apiversion bump for PDB resource and kube 1.25

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
