### PR TITLE
FWI-4309 - [stable/insights-agent] bump polaris on agent

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.20.4
+* Update polaris to 8.2
+
 ## 2.20.3
 * Add configurable values and sensible defaults to install-reporter
 

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.20.3
+version: 2.20.4
 appVersion: 9.2.1
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -90,7 +90,7 @@ polaris:
     disabled: false
   image:
     repository: quay.io/fairwinds/polaris
-    tag: "8.0"
+    tag: "8.2"
   resources:
     requests:
       cpu: 100m


### PR DESCRIPTION
**Why This PR?**
bump polaris to 8.2 on agent

✅  [8.2.3 released](https://github.com/FairwindsOps/polaris/releases/tag/8.2.3)  - ~before merging - make sure polaris plugin 8.2.3 is released~

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
