### PR TITLE
[stable/polaris] update polaris to 8.2

### DIFF
--- a/stable/polaris/Chart.yaml
+++ b/stable/polaris/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Validation of best practices in your Kubernetes clusters
 name: polaris
-version: 5.10.1
-appVersion: "8.0"
+version: 5.10.2
+appVersion: "8.2"
 icon: https://raw.githubusercontent.com/FairwindsOps/polaris/master/pkg/dashboard/assets/favicon-32x32.png
 maintainers:
   - name: rbren


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_
This re-upgrades polaris to 8.2 now that we've fixed webhook issues in 8.2.4


**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
