### PR TITLE
[stable/rbac-manager] Fix rbac-manager for openshift and okd

### DIFF
--- a/stable/rbac-manager/Chart.yaml
+++ b/stable/rbac-manager/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rbac-manager
-version: 1.17.0
+version: 1.17.1
 appVersion: 1.6.1
 description: A Kubernetes operator that simplifies the management of Role Bindings and Service Accounts.
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/rbac-manager/icon.png

--- a/stable/rbac-manager/templates/clusterrole.yaml
+++ b/stable/rbac-manager/templates/clusterrole.yaml
@@ -41,3 +41,9 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - rbacmanager.reactiveops.io
+    resources:
+      - rbacdefinitions/finalizers
+    verbs:
+      - "*"


### PR DESCRIPTION
**Why This PR?**
OKD and openshift use something called `OwnerReferencesPermissionEnforcement` that requires this addition to the clusterrole to function

Fixes https://github.com/FairwindsOps/charts/issues/1228

**Changes**
Changes proposed in this pull request:

* Add some permissions

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.