### PR TITLE
[stable/insights-agent] Default run as groups

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 2.20.6
+* Add default runAsGroups for right-sizer and cronjob-executor
 ## 2.20.5
 * Update trivy plugin to [v0.27](https://github.com/FairwindsOps/insights-plugins/blob/main/plugins/trivy/CHANGELOG.md#0270)
 

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.20.5
+version: 2.20.6
 appVersion: 9.2.1
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:

--- a/stable/insights-agent/templates/cronjob-executor/job.yaml
+++ b/stable/insights-agent/templates/cronjob-executor/job.yaml
@@ -48,6 +48,7 @@ spec:
           mountPath: /tmp
         securityContext:
           runAsUser: 1000
+          runAsGroup: 1000
           readOnlyRootFilesystem: true
           allowPrivilegeEscalation: false
           privileged: false

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -487,6 +487,7 @@ right-sizer:
     allowPrivilegeEscalation: false
     runAsNonRoot: true
     runAsUser: 1200
+    runAsGroup: 1200
     capabilities:
       drop:
         - ALL


### PR DESCRIPTION
**Why This PR?**
We don't set a default runAsGroup, and some tools check to make sure the field is present. 

Fixes #

**Changes**
Changes proposed in this pull request:

* adds default runAsGroup to right-sizer controller
* adds default runAsGroup to cronjob-executor

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
