### PR TITLE
[stable/insights-agent] Default runAsGroups for cronjobs

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 2.20.7
+* Add default runAsGroup for cronjob templates
 ## 2.20.6
 * Add default runAsGroups for right-sizer and cronjob-executor
 ## 2.20.5

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
 version: 2.21.1
-version: 2.21.0
 appVersion: 9.2.1
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.20.6
+version: 2.20.7
 appVersion: 9.2.1
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:

--- a/stable/insights-agent/templates/_specs.yaml
+++ b/stable/insights-agent/templates/_specs.yaml
@@ -174,6 +174,7 @@ initContainers:
   securityContext:
     runAsNonRoot: true
     runAsUser: 1000
+    runAsGroup: 1000
     allowPrivilegeEscalation: false
     readOnlyRootFilesystem: true
     privileged: false
@@ -192,6 +193,7 @@ securityContext:
   privileged: false
   runAsNonRoot: true
   runAsUser: 10324
+  runAsGroup: 10324
   capabilities:
     drop:
       - ALL


### PR DESCRIPTION
**Why This PR?**
Add default runasGroup to cronjobs. 

Fixes #

**Changes**
Changes proposed in this pull request:

* Adds default runAsGroup for cronjobs. 
*

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
