### PR TITLE
[stable/insights-agent] insights-uploader runAsGroup

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 2.21.3
+* set default runAsGroup for uploader container
 ## 2.21.2
 * Update changelog
 

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.21.2
+version: 2.21.3
 appVersion: 9.2.1
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:

--- a/stable/insights-agent/templates/_uploader.yaml
+++ b/stable/insights-agent/templates/_uploader.yaml
@@ -55,6 +55,7 @@
   securityContext:
     runAsNonRoot: true
     runAsUser: 1000
+    runAsGroup: 1000
     allowPrivilegeEscalation: false
     readOnlyRootFilesystem: true
     privileged: false


### PR DESCRIPTION
**Why This PR?**
set a default runAsGroup for the uploader container. 

Fixes #

**Changes**
Changes proposed in this pull request:

* set a default runAsGroup for the uploader container. 
*

**Checklist:**

* [ ] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [ ] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
