### PR TITLE
[stable/insights-admission] Explicit default cert duration

### DIFF
--- a/stable/insights-admission/CHANGELOG.md
+++ b/stable/insights-admission/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 1.8.1
+* Add explicit default cert duration.
 ## 1.8.0
 * Bump insights-admission to version 1.11
 * See [changelog](https://github.com/FairwindsOps/insights-plugins/blob/main/plugins/admission/CHANGELOG.md) for details on new polaris checks and severities, which may block deployments

--- a/stable/insights-admission/Chart.yaml
+++ b/stable/insights-admission/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: insights-admission
 description: A Validating Webhook Admission Controller that utilizes Fairwinds Insights.
 type: application
-version: 1.8.0
+version: 1.8.1
 appVersion: "1.11"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-admission/icon.png
 maintainers:

--- a/stable/insights-admission/templates/cert.yaml
+++ b/stable/insights-admission/templates/cert.yaml
@@ -23,6 +23,8 @@ spec:
     kind: Issuer
     name: {{ include "insights-admission.fullname" . }}-selfsigned
   secretName: {{ include "insights-admission.fullname" . }}
+  duration: 2160h
+  renewBefore: 360h
 ---
 {{- if .Values.certManagerApiVersion }}
 apiVersion: {{ .Values.certManagerApiVersion }}


### PR DESCRIPTION
Some policy engines check for the presence of the value of the duration field to ensure certificates don't have a longer duration than 100days. Leaving the value out can cause an insights install to fail.

**Why This PR?**
_a short description of why this PR is needed_

Fixes #

**Changes**
Changes proposed in this pull request:

* set a default duration explicitly on the cert generated by insights-admission.
*

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
