### PR TITLE
[stable/insights-admission] Change cert-duration so that it doesn't trigger an out-of-sync on argocd

### DIFF
--- a/stable/insights-admission/CHANGELOG.md
+++ b/stable/insights-admission/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.8.2
+* Fix cert duration to not trigger ArgoCD out-of-sync
+
 ## 1.8.1
 * Add explicit default cert duration.
 ## 1.8.0

--- a/stable/insights-admission/Chart.yaml
+++ b/stable/insights-admission/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: insights-admission
 description: A Validating Webhook Admission Controller that utilizes Fairwinds Insights.
 type: application
-version: 1.8.1
+version: 1.8.2
 appVersion: "1.11"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-admission/icon.png
 maintainers:

--- a/stable/insights-admission/templates/cert.yaml
+++ b/stable/insights-admission/templates/cert.yaml
@@ -23,8 +23,8 @@ spec:
     kind: Issuer
     name: {{ include "insights-admission.fullname" . }}-selfsigned
   secretName: {{ include "insights-admission.fullname" . }}
-  duration: 2160h
-  renewBefore: 360h
+  duration: 2160h0m0s
+  renewBefore: 360h0m0s
 ---
 {{- if .Values.certManagerApiVersion }}
 apiVersion: {{ .Values.certManagerApiVersion }}


### PR DESCRIPTION
**Why This PR?**
The current configuration triggers an out-of-sync in argoCD

**Changes**
Changes proposed in this pull request:

* Change 2160h to 2160h0m0s

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.


![Screenshot 2023-07-11 at 12 24 28 PM](https://github.com/FairwindsOps/charts/assets/7624765/13e96997-6f55-49a0-8e04-8c21fcc80698)
