### PR TITLE
[incubator/vault-token-injector] Fix bug when specifying custom schedule

### DIFF
--- a/incubator/vault-token-injector/Chart.yaml
+++ b/incubator/vault-token-injector/Chart.yaml
@@ -5,7 +5,7 @@ description: |
 
   This will inject vault tokens and address variables into circle builds on a schedule
 type: application
-version: 3.0.1
+version: 3.0.2
 appVersion: "v1.8.3"
 maintainers:
   - name: transient1

--- a/incubator/vault-token-injector/README.md
+++ b/incubator/vault-token-injector/README.md
@@ -1,4 +1,4 @@
-![Version: 3.0.1](https://img.shields.io/badge/Version-3.0.1-informational?style=flat-square)
+![Version: 3.0.2](https://img.shields.io/badge/Version-3.0.2-informational?style=flat-square)
 
 # Vault Token Injector Chart
 

--- a/incubator/vault-token-injector/ci/test-values.yaml
+++ b/incubator/vault-token-injector/ci/test-values.yaml
@@ -3,6 +3,7 @@ metrics:
   enabled: true
 cronjob:
   enabled: true
+  schedule: '*/30 * * * *'
 deployment:
   probes:
     enabled: false

--- a/incubator/vault-token-injector/templates/cronjob.yaml
+++ b/incubator/vault-token-injector/templates/cronjob.yaml
@@ -76,7 +76,7 @@ spec:
           - name: config
             configMap:
               name: {{ include "vault-token-injector.fullname" . }}
-  schedule: {{ .Values.cronjob.schedule }}
+  schedule: {{ .Values.cronjob.schedule | quote }}
   successfulJobsHistoryLimit: {{ .Values.cronjob.successfulJobsHistoryLimit }}
   suspend: false
 {{- end }}


### PR DESCRIPTION
**Why This PR?**
Currently there's a template error when specifying your own schedule

**Changes**
Changes proposed in this pull request:

* | quote

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.