### PR TITLE
[stable/vpa] feat: expose probe definitions

### DIFF
--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 2.1.1
+version: 2.2.0
 appVersion: 0.13.0
 maintainers:
   - name: sudermanjr

--- a/stable/vpa/README.md
+++ b/stable/vpa/README.md
@@ -123,6 +123,8 @@ recommender:
 | recommender.podLabels | object | `{}` | Labels to add to the recommender pod |
 | recommender.podSecurityContext | object | `{"runAsNonRoot":true,"runAsUser":65534}` | The security context for the recommender pod |
 | recommender.securityContext | object | `{}` | The security context for the containers inside the recommender pod |
+| recommender.livenessProbe | object | `{"failureThreshold":6,"httpGet":{"path":"/health-check","port":"metrics","scheme":"HTTP"},"periodSeconds":5,"successThreshold":1,"timeoutSeconds":3}` | The liveness probe definition inside the recommender pod |
+| recommender.readinessProbe | object | `{"failureThreshold":120,"httpGet":{"path":"/health-check","port":"metrics","scheme":"HTTP"},"periodSeconds":5,"successThreshold":1,"timeoutSeconds":3}` | The readiness probe definition inside the recommender pod |
 | recommender.resources | object | `{"limits":{"cpu":"200m","memory":"1000Mi"},"requests":{"cpu":"50m","memory":"500Mi"}}` | The resources block for the recommender pod |
 | recommender.nodeSelector | object | `{}` |  |
 | recommender.tolerations | list | `[]` |  |
@@ -139,6 +141,8 @@ recommender:
 | updater.podLabels | object | `{}` | Labels to add to the updater pod |
 | updater.podSecurityContext | object | `{"runAsNonRoot":true,"runAsUser":65534}` | The security context for the updater pod |
 | updater.securityContext | object | `{}` | The security context for the containers inside the updater pod |
+| updater.livenessProbe | object | `{"failureThreshold":6,"httpGet":{"path":"/health-check","port":"metrics","scheme":"HTTP"},"periodSeconds":5,"successThreshold":1,"timeoutSeconds":3}` | The liveness probe definition inside the updater pod |
+| updater.readinessProbe | object | `{"failureThreshold":120,"httpGet":{"path":"/health-check","port":"metrics","scheme":"HTTP"},"periodSeconds":5,"successThreshold":1,"timeoutSeconds":3}` | The readiness probe definition inside the updater pod |
 | updater.resources | object | `{"limits":{"cpu":"200m","memory":"1000Mi"},"requests":{"cpu":"50m","memory":"500Mi"}}` | The resources block for the updater pod |
 | updater.nodeSelector | object | `{}` |  |
 | updater.tolerations | list | `[]` |  |
@@ -171,6 +175,8 @@ recommender:
 | admissionController.podLabels | object | `{}` | Labels to add to the admission controller pod |
 | admissionController.podSecurityContext | object | `{"runAsNonRoot":true,"runAsUser":65534}` | The security context for the admission controller pod |
 | admissionController.securityContext | object | `{}` | The security context for the containers inside the admission controller pod |
+| admissionController.livenessProbe | object | `{"failureThreshold":6,"httpGet":{"path":"/health-check","port":"metrics","scheme":"HTTP"},"periodSeconds":5,"successThreshold":1,"timeoutSeconds":3}` | The liveness probe definition inside the admission controller pod |
+| admissionController.readinessProbe | object | `{"failureThreshold":120,"httpGet":{"path":"/health-check","port":"metrics","scheme":"HTTP"},"periodSeconds":5,"successThreshold":1,"timeoutSeconds":3}` | The readiness probe definition inside the admission controller pod |
 | admissionController.resources | object | `{"limits":{"cpu":"200m","memory":"500Mi"},"requests":{"cpu":"50m","memory":"200Mi"}}` | The resources block for the admission controller pod |
 | admissionController.tlsSecretKeys | list | `[]` | The keys in the vpa-tls-certs secret to map in to the admission controller |
 | admissionController.nodeSelector | object | `{}` |  |

--- a/stable/vpa/templates/admission-controller-deployment.yaml
+++ b/stable/vpa/templates/admission-controller-deployment.yaml
@@ -58,24 +58,14 @@ spec:
             - name: tls-certs
               mountPath: "/etc/tls-certs"
               readOnly: true
+          {{- if .Values.admissionController.livenessProbe }}
           livenessProbe:
-            failureThreshold: 6
-            httpGet:
-              path: /health-check
-              port: metrics
-              scheme: HTTP
-            periodSeconds: 5
-            successThreshold: 1
-            timeoutSeconds: 3
+            {{- toYaml .Values.admissionController.livenessProbe | nindent 12 }}
+          {{- end }}
+          {{- if .Values.admissionController.readinessProbe }}
           readinessProbe:
-            failureThreshold: 120
-            httpGet:
-              path: /health-check
-              port: metrics
-              scheme: HTTP
-            periodSeconds: 5
-            successThreshold: 1
-            timeoutSeconds: 3
+            {{- toYaml .Values.admissionController.readinessProbe | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 8000

--- a/stable/vpa/templates/recommender-deployment.yaml
+++ b/stable/vpa/templates/recommender-deployment.yaml
@@ -47,24 +47,14 @@ spec:
             - --{{ $key }}={{ $value }}
           {{- end }}
           {{- end }}
+          {{- if .Values.recommender.livenessProbe }}
           livenessProbe:
-            failureThreshold: 6
-            httpGet:
-              path: /health-check
-              port: metrics
-              scheme: HTTP
-            periodSeconds: 5
-            successThreshold: 1
-            timeoutSeconds: 3
+            {{- toYaml .Values.recommender.livenessProbe | nindent 12 }}
+          {{- end }}
+          {{- if .Values.recommender.readinessProbe }}
           readinessProbe:
-            failureThreshold: 120
-            httpGet:
-              path: /health-check
-              port: metrics
-              scheme: HTTP
-            periodSeconds: 5
-            successThreshold: 1
-            timeoutSeconds: 3
+            {{- toYaml .Values.recommender.readinessProbe | nindent 12 }}
+          {{- end }}
           ports:
             - name: metrics
               containerPort: 8942

--- a/stable/vpa/templates/updater-deployment.yaml
+++ b/stable/vpa/templates/updater-deployment.yaml
@@ -52,24 +52,14 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+          {{- if .Values.updater.livenessProbe }}
           livenessProbe:
-            failureThreshold: 6
-            httpGet:
-              path: /health-check
-              port: metrics
-              scheme: HTTP
-            periodSeconds: 5
-            successThreshold: 1
-            timeoutSeconds: 3
+            {{- toYaml .Values.updater.livenessProbe | nindent 12 }}
+          {{- end }}
+          {{- if .Values.updater.readinessProbe }}
           readinessProbe:
-            failureThreshold: 120
-            httpGet:
-              path: /health-check
-              port: metrics
-              scheme: HTTP
-            periodSeconds: 5
-            successThreshold: 1
-            timeoutSeconds: 3
+            {{- toYaml .Values.updater.readinessProbe | nindent 12 }}
+          {{- end }}
           ports:
             - name: metrics
               containerPort: 8943

--- a/stable/vpa/values.yaml
+++ b/stable/vpa/values.yaml
@@ -56,6 +56,26 @@ recommender:
     runAsUser: 65534
   # recommender.securityContext -- The security context for the containers inside the recommender pod
   securityContext: {}
+  # recommender.livenessProbe -- The liveness probe definition inside the recommender pod
+  livenessProbe:
+    failureThreshold: 6
+    httpGet:
+      path: /health-check
+      port: metrics
+      scheme: HTTP
+    periodSeconds: 5
+    successThreshold: 1
+    timeoutSeconds: 3
+  # recommender.readinessProbe -- The readiness probe definition inside the recommender pod
+  readinessProbe:
+    failureThreshold: 120
+    httpGet:
+      path: /health-check
+      port: metrics
+      scheme: HTTP
+    periodSeconds: 5
+    successThreshold: 1
+    timeoutSeconds: 3
   # recommender.resources -- The resources block for the recommender pod
   resources:
     limits:
@@ -99,6 +119,26 @@ updater:
     runAsUser: 65534
   # updater.securityContext -- The security context for the containers inside the updater pod
   securityContext: {}
+  # updater.livenessProbe -- The liveness probe definition inside the updater pod
+  livenessProbe:
+    failureThreshold: 6
+    httpGet:
+      path: /health-check
+      port: metrics
+      scheme: HTTP
+    periodSeconds: 5
+    successThreshold: 1
+    timeoutSeconds: 3
+  # updater.readinessProbe -- The readiness probe definition inside the updater pod
+  readinessProbe:
+    failureThreshold: 120
+    httpGet:
+      path: /health-check
+      port: metrics
+      scheme: HTTP
+    periodSeconds: 5
+    successThreshold: 1
+    timeoutSeconds: 3
   # updater.resources -- The resources block for the updater pod
   resources:
     limits:
@@ -176,6 +216,26 @@ admissionController:
     runAsUser: 65534
   # admissionController.securityContext -- The security context for the containers inside the admission controller pod
   securityContext: {}
+  # admissionController.livenessProbe -- The liveness probe definition inside the admission controller pod
+  livenessProbe:
+    failureThreshold: 6
+    httpGet:
+      path: /health-check
+      port: metrics
+      scheme: HTTP
+    periodSeconds: 5
+    successThreshold: 1
+    timeoutSeconds: 3
+  # admissionController.readinessProbe -- The readiness probe definition inside the admission controller pod
+  readinessProbe:
+    failureThreshold: 120
+    httpGet:
+      path: /health-check
+      port: metrics
+      scheme: HTTP
+    periodSeconds: 5
+    successThreshold: 1
+    timeoutSeconds: 3
   # admissionController.resources -- The resources block for the admission controller pod
   resources:
     limits:


### PR DESCRIPTION
**Why This PR?**

At high scale, the VPA pods can take more time to start.
I need to tweak the probe configurations for it to start correctly.

Fixes #

**Changes**
Changes proposed in this pull request:

* Expose liveness and readiness probes definitions for all pods

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
