### PR TITLE
[stable/goldilocks] deps: bump vpa chart to 2.2.0

### DIFF
--- a/stable/goldilocks/.gitignore
+++ b/stable/goldilocks/.gitignore
@@ -1,2 +1,1 @@
-Chart.lock
 charts/

--- a/stable/goldilocks/Chart.lock
+++ b/stable/goldilocks/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: vpa
+  repository: https://charts.fairwinds.com/stable
+  version: 2.2.0
+- name: metrics-server
+  repository: https://charts.bitnami.com/bitnami
+  version: 6.4.1
+digest: sha256:65dfffdd82f5d6603ee038a3fa3a501efddd36ea79338c8b403e13916f53da51
+generated: "2023-07-20T15:27:42.2213269Z"

--- a/stable/goldilocks/Chart.yaml
+++ b/stable/goldilocks/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 appVersion: "v4.9.0"
-version: 6.8.0
+version: 7.0.0
 description: |
   A Helm chart for running Fairwinds Goldilocks. See https://github.com/FairwindsOps/goldilocks
 name: goldilocks
@@ -15,7 +15,7 @@ keywords:
   - kubernetes
 dependencies:
   - name: vpa
-    version: 1.7.5
+    version: 2.2.0
     repository: https://charts.fairwinds.com/stable
     condition: vpa.enabled
   - name: metrics-server

--- a/stable/goldilocks/README.md
+++ b/stable/goldilocks/README.md
@@ -23,6 +23,10 @@ Fairwinds has published a chart for installing VPA [in our stable repo](https://
 
 ## Major Version Upgrade Notes
 
+## Upgrading from v6.x.x to v7.x.x
+
+In this change, the VPA helm chart was upgraded to the latest version, including a major bump. We recommend you to check [the VPA Helm chart changelog](https://github.com/FairwindsOps/charts/tree/master/stable/vpa#breaking-upgrading-from--v17x-to-200) to ensure a smooth upgrade.
+
 ## *BREAKING* Upgrading from v4.x.x to v5.x.x
 
 The new chart version includes [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) configuration for the `networking.k8s.io/v1` Kubernetes API.

--- a/stable/goldilocks/README.md.gotmpl
+++ b/stable/goldilocks/README.md.gotmpl
@@ -23,6 +23,10 @@ Fairwinds has published a chart for installing VPA [in our stable repo](https://
 
 ## Major Version Upgrade Notes
 
+## Upgrading from v6.x.x to v7.x.x
+
+In this change, the VPA helm chart was upgraded to the latest version, including a major bump. We recommend you to check [the VPA Helm chart changelog](https://github.com/FairwindsOps/charts/tree/master/stable/vpa#breaking-upgrading-from--v17x-to-200) to ensure a smooth upgrade.
+
 ## *BREAKING* Upgrading from v4.x.x to v5.x.x
 
 The new chart version includes [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) configuration for the `networking.k8s.io/v1` Kubernetes API.


### PR DESCRIPTION
**Why This PR?**
VPA chart was recently updated

**Changes**
Changes proposed in this pull request:

* Upgrade Goldilocks VPA chart dependency to 2.2.0

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
