### PR TITLE
[housekeeping] set kubeVersion on most of the stable chars

### DIFF
--- a/stable/astro/Chart.yaml
+++ b/stable/astro/Chart.yaml
@@ -1,7 +1,8 @@
 name: astro
-version: 1.0.11
+version: 1.0.12
 apiVersion: v1
 appVersion: "1.5.3"
+kubeVersion: ">= 1.22.0-0"
 description: Emit datadog monitors based on kubernetes state.
 keywords:
   - datadog

--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.18.5
+* Set kubeVersion in chart manifest
+
 ## 0.18.4
 * Update application version to 13.2. [See the release notes for more details](https://insights.docs.fairwinds.com/release-notes)
 

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,8 @@ apiVersion: v2
 appVersion: "13.2"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 0.18.4
+version: 0.18.5
+kubeVersion: ">= 1.22.0-0"
 maintainers:
   - name: rbren
   - name: mhoss019

--- a/stable/gemini/Chart.yaml
+++ b/stable/gemini/Chart.yaml
@@ -1,8 +1,9 @@
 apiVersion: v1
 description: Automated backup and restore of PersistentVolumes using the VolumeSnapshot API
 name: gemini
-version: 2.1.1
+version: 2.1.2
 appVersion: "2.0"
+kubeVersion: ">= 1.22.0-0"
 maintainers:
   - name: rbren
     email: robertb@fairwinds.com

--- a/stable/goldilocks/Chart.yaml
+++ b/stable/goldilocks/Chart.yaml
@@ -1,6 +1,7 @@
 apiVersion: v2
 appVersion: "v4.9.0"
-version: 7.0.0
+version: 7.0.1
+kubeVersion: ">= 1.22.0-0"
 description: |
   A Helm chart for running Fairwinds Goldilocks. See https://github.com/FairwindsOps/goldilocks
 name: goldilocks

--- a/stable/helm-release-pruner/Chart.yaml
+++ b/stable/helm-release-pruner/Chart.yaml
@@ -2,7 +2,8 @@ apiVersion: v1
 appVersion: v3.2.0
 description: This chart deploys a cronjob that purges stale Helm releases and associated namespaces. Releases are selected based on regex patterns for release name and namespace along with a Bash `date` command date string to define the stale cutoff date and time.
 name: helm-release-pruner
-version: 3.2.10
+version: 3.2.11
+kubeVersion: ">= 1.22.0-0"
 maintainers:
   - name: rbren
   - name: sudermanjr

--- a/stable/insights-admission/CHANGELOG.md
+++ b/stable/insights-admission/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.8.3
+* Set kubeVersion in chart manifest
+
 ## 1.8.2
 * Fix cert duration to not trigger ArgoCD out-of-sync
 

--- a/stable/insights-admission/Chart.yaml
+++ b/stable/insights-admission/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: insights-admission
 description: A Validating Webhook Admission Controller that utilizes Fairwinds Insights.
 type: application
-version: 1.8.2
+version: 1.8.3
 appVersion: "1.11"
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-admission/icon.png

--- a/stable/insights-admission/Chart.yaml
+++ b/stable/insights-admission/Chart.yaml
@@ -4,6 +4,7 @@ description: A Validating Webhook Admission Controller that utilizes Fairwinds I
 type: application
 version: 1.8.2
 appVersion: "1.11"
+kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-admission/icon.png
 maintainers:
   - name: rbren

--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.22.1
+* Set kubeVersion in the chart manifest
+
 ## 2.22.0
 * Add Kyverno plugin
 

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,8 +1,9 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.22.0
+version: 2.22.1
 appVersion: 9.2.1
+kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:
   - name: rbren

--- a/stable/polaris/CHANGELOG.md
+++ b/stable/polaris/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this Helm chart will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this chart adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 5.11.1
+* set kubeVersion in the chart manifest
+
 ## 5.9.0
 * Update Polaris version to 8.0
 

--- a/stable/polaris/Chart.yaml
+++ b/stable/polaris/Chart.yaml
@@ -1,8 +1,9 @@
 apiVersion: v1
 description: Validation of best practices in your Kubernetes clusters
 name: polaris
-version: 5.11.0
+version: 5.11.1
 appVersion: "8.4"
+kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/polaris/master/pkg/dashboard/assets/favicon-32x32.png
 maintainers:
   - name: rbren

--- a/stable/rbac-manager/Chart.yaml
+++ b/stable/rbac-manager/Chart.yaml
@@ -1,7 +1,8 @@
 apiVersion: v1
 name: rbac-manager
-version: 1.17.2
+version: 1.17.3
 appVersion: 1.6.4
+kubeVersion: ">= 1.22.0-0"
 description: A Kubernetes operator that simplifies the management of Role Bindings and Service Accounts.
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/rbac-manager/icon.png
 keywords:

--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -3,7 +3,8 @@ name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
 version: 2.2.0
-appVersion: 0.13.0
+appVersion: 0.13.1
+kubeVersion: ">= 1.22.0-0"
 maintainers:
   - name: sudermanjr
 home: https://github.com/FairwindsOps/charts/tree/master/stable/vpa

--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -3,8 +3,7 @@ name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
 version: 2.2.0
-appVersion: 0.13.1
-kubeVersion: ">= 1.22.0-0"
+appVersion: 0.13.0
 maintainers:
   - name: sudermanjr
 home: https://github.com/FairwindsOps/charts/tree/master/stable/vpa


### PR DESCRIPTION
**Why This PR?**
Set an initial kubeVersion for most of the stable charts. Partly because it's good practice, partly because it's required for Rancher marketplace.

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.