### PR TITLE
[stable/polaris] Add Deployment annotations

### DIFF
--- a/stable/polaris/Chart.yaml
+++ b/stable/polaris/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Validation of best practices in your Kubernetes clusters
 name: polaris
-version: 5.11.3
+version: 5.12.0
 appVersion: "8.4"
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/polaris/master/pkg/dashboard/assets/favicon-32x32.png

--- a/stable/polaris/Chart.yaml
+++ b/stable/polaris/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Validation of best practices in your Kubernetes clusters
 name: polaris
-version: 5.11.2
+version: 5.11.3
 appVersion: "8.4"
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/polaris/master/pkg/dashboard/assets/favicon-32x32.png

--- a/stable/polaris/Chart.yaml
+++ b/stable/polaris/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Validation of best practices in your Kubernetes clusters
 name: polaris
-version: 5.11.1
+version: 5.11.2
 appVersion: "8.4"
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/polaris/master/pkg/dashboard/assets/favicon-32x32.png

--- a/stable/polaris/README.md
+++ b/stable/polaris/README.md
@@ -53,6 +53,7 @@ the 0.10.0 version of this chart will only work on kubernetes 1.14.0+
 | dashboard.replicas | int | `2` | Number of replicas to run. |
 | dashboard.logLevel | string | `"Info"` | Set the logging level for the Dashboard command |
 | dashboard.podAdditionalLabels | object | `{}` | Custom additional labels on dashboard pods. |
+| dashboard.deploymentAnnotations | object | `{}` | Custom additional annotations on dashboard Deployment. |
 | dashboard.resources | object | `{"limits":{"cpu":"150m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | Requests and limits for the dashboard |
 | dashboard.extraContainers | list | `[]` | allows injecting additional containers. |
 | dashboard.service.type | string | `"ClusterIP"` | Service Type |
@@ -93,6 +94,7 @@ the 0.10.0 version of this chart will only work on kubernetes 1.14.0+
 | webhook.mutatingRules | list | `[]` | An array of additional rules for the MutatingWebhookConfiguration. Each requires a set of apiGroups, apiVersions, operations, resources, and a scope. |
 | webhook.defaultRules | list | `[{"apiGroups":["apps"],"apiVersions":["v1","v1beta1","v1beta2"],"operations":["CREATE","UPDATE"],"resources":["daemonsets","deployments","statefulsets"],"scope":"Namespaced"},{"apiGroups":["batch"],"apiVersions":["v1","v1beta1"],"operations":["CREATE","UPDATE"],"resources":["jobs","cronjobs"],"scope":"Namespaced"},{"apiGroups":[""],"apiVersions":["v1"],"operations":["CREATE","UPDATE"],"resources":["pods","replicationcontrollers"],"scope":"Namespaced"}]` | An array of rules for common types for the ValidatingWebhookConfiguration |
 | webhook.podAdditionalLabels | object | `{}` | Custom additional labels on webhook pods. |
+| webhook.deploymentAnnotations | object | `{}` | Custom additional annotations on webhook Deployment. |
 | webhook.resources | object | `{"limits":{"cpu":"100m","memory":"128Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | Requests and limits for the webhook. |
 | webhook.priorityClassName | string | `nil` | Priority Class name to be used in deployment if provided. |
 | webhook.disallowExemptions | bool | `false` | Disallow any exemption |

--- a/stable/polaris/ci/test-values.yaml
+++ b/stable/polaris/ci/test-values.yaml
@@ -4,6 +4,8 @@ dashboard:
     ingressClassName: ingress
     hosts:
     - foo.com
+  deploymentAnnotations:
+    foo: bar
 webhook:
   enabled: true
   mutate: true
@@ -13,3 +15,5 @@ webhook:
     test: validate
   certManager:
     apiVersion: cert-manager.io/v1
+  deploymentAnnotations:
+    foo: bar

--- a/stable/polaris/templates/dashboard.deployment.yaml
+++ b/stable/polaris/templates/dashboard.deployment.yaml
@@ -9,6 +9,10 @@ metadata:
   labels:
     {{- include "polaris.labels" . | nindent 4 }}
     component: dashboard
+  {{- with .Values.dashboard.deploymentAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{.Values.dashboard.replicas}}
   selector:
@@ -97,7 +101,7 @@ spec:
         {{- with .Values.dashboard.containerSecurityContext }}
         securityContext:
         {{- toYaml . | nindent 12 }}
-        {{- end }}                 
+        {{- end }}
         {{- if not .Values.configUrl }}
         {{- with .Values.config }}
         volumeMounts:

--- a/stable/polaris/templates/webhook.deployment.yaml
+++ b/stable/polaris/templates/webhook.deployment.yaml
@@ -9,6 +9,10 @@ metadata:
   labels:
     {{- include "polaris.labels" . | nindent 4 }}
     component: webhook
+  {{- with .Values.webhook.deploymentAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.webhook.replicas }}
   selector:

--- a/stable/polaris/values.yaml
+++ b/stable/polaris/values.yaml
@@ -47,6 +47,8 @@ dashboard:
   logLevel: Info
   # dashboard.podAdditionalLabels -- Custom additional labels on dashboard pods.
   podAdditionalLabels: {}
+  # dashboard.deploymentAnnotations -- Custom additional annotations on dashboard Deployment.
+  deploymentAnnotations: {}
   # dashboard.resources -- Requests and limits for the dashboard
   resources:
     requests:
@@ -220,6 +222,8 @@ webhook:
     scope: Namespaced
   # webhook.podAdditionalLabels -- Custom additional labels on webhook pods.
   podAdditionalLabels: {}
+  # webhook.deploymentAnnotations -- Custom additional annotations on webhook Deployment.
+  deploymentAnnotations: {}
   # webhook.resources -- Requests and limits for the webhook.
   resources:
     requests:


### PR DESCRIPTION
**Why This PR?**

In order to add annotations to Deployments, I added custom values.

**Changes**
Changes proposed in this pull request:

* Add annotations to webhook/dashboard Deployments

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
