### PR TITLE
FWIN-586/Investigate-nignx-ingress-critical-vuln-reported-by-insights

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.23.0
+* Add labels for insights-agent
+
 ## 2.22.1
 * Set kubeVersion in the chart manifest
 

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.22.1
+version: 2.23.0
 appVersion: 9.2.1
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png

--- a/stable/insights-agent/templates/_specs.yaml
+++ b/stable/insights-agent/templates/_specs.yaml
@@ -49,10 +49,12 @@ activeDeadlineSeconds: {{ mul .Config.timeout .Values.cronjobs.backoffLimit }}
 
 {{ define "job-spec-metadata" }}
 metadata:
-  {{- with .Config.jobLabels }}
   labels:
+    {{- with .Config.jobLabels }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- end }}
+    app.kubernetes.io/name: {{ .Label }}
+    app.kubernetes.io/part-of: {{ include "insights-agent.fullname" . }}
   annotations:
     cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
   {{- with .Config.jobAnnotations }}


### PR DESCRIPTION
**Why This PR?**
Adding labels that are standard https://kubernetes.io/docs/reference/labels-annotations-taints/#labels-annotations-and-taints-used-on-api-objects

Fixes #
* Add labels to insights
* Bump to chart version

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
