### PR TITLE
FWI-4644 - [stable/insights-agent] bump workloads plugin version

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.23.1
+* Bumped workload version to `2.5` which exports controllers `PodLabels` and `PodAnnotations`
+
 ## 2.23.0
 * Add labels for insights-agent
 
@@ -99,7 +102,7 @@
 * Fix syntax errors around use of imagePullSecrets as part of Containers section of PodSpec to permit use of insights-agent with private container repos
 
 ## 2.16.1
-* Add workload annotion for right-sizer
+* Add workload annotation for right-sizer
 
 ## 2.16.0
 * Add namespace allowlist to trivy

--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 2.23.1
-* Bumped workload version to `2.5` which exports controllers `PodLabels` and `PodAnnotations`
+* Bumped `workloads` plugin version to `2.5` which exports controllers `PodLabels` and `PodAnnotations`
 
 ## 2.23.0
 * Add labels for insights-agent

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.23.0
+version: 2.23.1
 appVersion: 9.2.1
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -204,7 +204,7 @@ workloads:
   timeout: 300
   image:
     repository: quay.io/fairwinds/workloads
-    tag: "2.4"
+    tag: "2.5"
   resources:
     requests:
       cpu: 100m


### PR DESCRIPTION
**Why This PR?**
Bumped workloads plugin version to `2.5` which exports controllers `PodLabels` and `PodAnnotations`

Fixes internal FWI-4644

**Changes**
Changes proposed in this pull request:

* bump workloads plugin version

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
