### PR TITLE
[stable/*] start testing on 1.26 and 1.27

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,12 +131,6 @@ workflows:
       - lint-scripts
       - lint-charts
       - rok8s/kubernetes_e2e_tests:
-          name: "End-To-End Kubernetes 1.23"
-          kind_node_image: "kindest/node:v1.23.13@sha256:ef453bb7c79f0e3caba88d2067d4196f427794086a7d0df8df4f019d5e336b61"
-          executor:
-            name: ci-images-large
-          <<: *kind_configuration_helm3
-      - rok8s/kubernetes_e2e_tests:
           name: "End-To-End Kubernetes 1.24"
           kind_node_image: "kindest/node:v1.24.7@sha256:577c630ce8e509131eab1aea12c022190978dd2f745aac5eb1fe65c0807eb315"
           executor:
@@ -145,6 +139,18 @@ workflows:
       - rok8s/kubernetes_e2e_tests:
           name: "End-To-End Kubernetes 1.25"
           kind_node_image: "kindest/node:v1.25.3@sha256:f52781bc0d7a19fb6c405c2af83abfeb311f130707a0e219175677e366cc45d1"
+          executor:
+            name: ci-images-large
+          <<: *kind_configuration_helm3
+      - rok8s/kubernetes_e2e_tests:
+          name: "End-To-End Kubernetes 1.26"
+          kind_node_image: "kindest/node:v1.26.6@sha256:6e2d8b28a5b601defe327b98bd1c2d1930b49e5d8c512e1895099e4504007adb"
+          executor:
+            name: ci-images-large
+          <<: *kind_configuration_helm3
+      - rok8s/kubernetes_e2e_tests:
+          name: "End-To-End Kubernetes 1.27"
+          kind_node_image: "kindest/node:v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72"
           executor:
             name: ci-images-large
           <<: *kind_configuration_helm3

--- a/stable/astro/Chart.yaml
+++ b/stable/astro/Chart.yaml
@@ -1,5 +1,5 @@
 name: astro
-version: 1.0.12
+version: 1.0.13
 apiVersion: v1
 appVersion: "1.5.3"
 kubeVersion: ">= 1.22.0-0"

--- a/stable/aws-iam-authenticator/Chart.yaml
+++ b/stable/aws-iam-authenticator/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: v0.5.9
 description: Install and configure aws-iam-authenticator on your cluster.
 name: aws-iam-authenticator
-version: v1.7.5
+version: v1.7.6
 maintainers:
   - name: sudermanjr

--- a/stable/ecr-cleanup/Chart.yaml
+++ b/stable/ecr-cleanup/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: "0.1.7"
-version: 1.2.6
+version: 1.2.7
 description: A Helm chart to run ecr cleanup controller
 name: ecr-cleanup
 maintainers:

--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.18.7
+* Start testing on 1.26 and 1.27
+
 ## 0.18.6
 * Update application version to 13.3. [See the release notes for more details](https://insights.docs.fairwinds.com/release-notes)
 

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "13.3"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 0.18.6
+version: 0.18.7
 kubeVersion: ">= 1.22.0-0"
 maintainers:
   - name: rbren

--- a/stable/fairwinds-insights/templates/hpa-api.yaml
+++ b/stable/fairwinds-insights/templates/hpa-api.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.api.hpa.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "fairwinds-insights.fullname" . }}-api-hpa

--- a/stable/fairwinds-insights/templates/hpa-automated-pr-job.yaml
+++ b/stable/fairwinds-insights/templates/hpa-automated-pr-job.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.automatedPullRequestJob.enabled .Values.automatedPullRequestJob.hpa.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "fairwinds-insights.fullname" . }}-automated-pr-job-hpa

--- a/stable/fairwinds-insights/templates/hpa-dashboard.yaml
+++ b/stable/fairwinds-insights/templates/hpa-dashboard.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.dashboard.hpa.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "fairwinds-insights.fullname" . }}-dashboard

--- a/stable/fairwinds-insights/templates/hpa-open-api.yaml
+++ b/stable/fairwinds-insights/templates/hpa-open-api.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.openApi.hpa.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "fairwinds-insights.fullname" . }}-open-api-hpa

--- a/stable/fairwinds-insights/templates/hpa-repo-scan-job.yaml
+++ b/stable/fairwinds-insights/templates/hpa-repo-scan-job.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.repoScanJob.enabled .Values.repoScanJob.hpa.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "fairwinds-insights.fullname" . }}-repo-scan-job-hpa

--- a/stable/fairwinds-insights/templates/hpa-reportjob.yaml
+++ b/stable/fairwinds-insights/templates/hpa-reportjob.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.reportjob.hpa.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "fairwinds-insights.fullname" . }}-reportjob-hpa

--- a/stable/gemini/Chart.yaml
+++ b/stable/gemini/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Automated backup and restore of PersistentVolumes using the VolumeSnapshot API
 name: gemini
-version: 2.1.2
+version: 2.1.3
 appVersion: "2.0"
 kubeVersion: ">= 1.22.0-0"
 maintainers:

--- a/stable/gke-node-termination-handler/Chart.yaml
+++ b/stable/gke-node-termination-handler/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: "1.0"
 description: This helm chart provides an adapter for translating GCE node termination events to graceful pod terminations in Kubernetes.
 name: gke-node-termination-handler
-version: 1.2.6
+version: 1.2.7
 maintainers:
   - name: sudermanjr

--- a/stable/goldilocks/Chart.yaml
+++ b/stable/goldilocks/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 appVersion: "v4.9.0"
-version: 7.0.1
+version: 7.0.2
 kubeVersion: ">= 1.22.0-0"
 description: |
   A Helm chart for running Fairwinds Goldilocks. See https://github.com/FairwindsOps/goldilocks

--- a/stable/helm-release-pruner/Chart.yaml
+++ b/stable/helm-release-pruner/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v3.2.0
 description: This chart deploys a cronjob that purges stale Helm releases and associated namespaces. Releases are selected based on regex patterns for release name and namespace along with a Bash `date` command date string to define the stale cutoff date and time.
 name: helm-release-pruner
-version: 3.2.11
+version: 3.2.12
 kubeVersion: ">= 1.22.0-0"
 maintainers:
   - name: rbren

--- a/stable/insights-admission/CHANGELOG.md
+++ b/stable/insights-admission/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.8.4
+* Start testing on 1.26 and 1.27
+
 ## 1.8.3
 * Set kubeVersion in chart manifest
 

--- a/stable/insights-admission/Chart.yaml
+++ b/stable/insights-admission/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: insights-admission
 description: A Validating Webhook Admission Controller that utilizes Fairwinds Insights.
 type: application
-version: 1.8.3
+version: 1.8.4
 appVersion: "1.11"
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-admission/icon.png

--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.23.2
+* Start testing on 1.26 and 1.27
+
 ## 2.23.1
 * Bumped `workloads` plugin version to `2.5` which exports controllers `PodLabels` and `PodAnnotations`
 

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.23.1
+version: 2.23.2
 appVersion: 9.2.1
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png

--- a/stable/polaris/Chart.yaml
+++ b/stable/polaris/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Validation of best practices in your Kubernetes clusters
 name: polaris
-version: 5.11.1
+version: 5.11.2
 appVersion: "8.4"
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/polaris/master/pkg/dashboard/assets/favicon-32x32.png

--- a/stable/rbac-manager/Chart.yaml
+++ b/stable/rbac-manager/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rbac-manager
-version: 1.17.3
+version: 1.17.4
 appVersion: 1.6.4
 kubeVersion: ">= 1.22.0-0"
 description: A Kubernetes operator that simplifies the management of Role Bindings and Service Accounts.

--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 2.2.0
+version: 2.2.1
 appVersion: 0.13.0
 maintainers:
   - name: sudermanjr
@@ -13,7 +13,6 @@ sources:
 # CronJobs batch/v1 were introduced in K8s 1.21
 # The VPA admission controller requests them from 0.12.0 forward
 kubeVersion: ">= 1.21.0-0"
-
 dependencies:
   - alias: metrics-server
     condition: metrics-server.enabled


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_
We need to test on the latest versions of k8s

Fixes #

**Changes**
Changes proposed in this pull request:
*  add 1.26 and 1.27 to tests
* remove 1.23

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
