### PR TITLE
[stable/insights-agent] Add get/list/watch perms for policy and clusterpolicy to kyverno

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-## 2.23.3
+## 2.23.4
 * Add get/list/watch perms for policy and clusterpolicy to kyverno rbac template
 
 ## 2.23.3

--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 2.23.3
+* Add get/list/watch perms for policy and clusterpolicy to kyverno rbac template
 
 ## 2.23.2
 * Start testing on 1.26 and 1.27

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.23.2
+version: 2.23.3
 appVersion: 9.2.1
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.23.3
+version: 2.23.4
 appVersion: 9.2.1
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png

--- a/stable/insights-agent/templates/kyverno/rbac.yaml
+++ b/stable/insights-agent/templates/kyverno/rbac.yaml
@@ -18,6 +18,8 @@ rules:
   resources:
   - customresourcedefinitions
   - namespaces
+  - policies
+  - clusterpolicies
   - policyreports
   - policyreports/status
   - clusterpolicyreports


### PR DESCRIPTION
This PR adds get/watch/list permissions for the following resources:

* `Policy`
* `ClusterPolicy`

which are required by the Kyverno plugin script

**Why This PR?**
_a short description of why this PR is needed_

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
