### PR TITLE
[stable/vpa] Allow changing the default revisionHistoryLimit

### DIFF
--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 2.2.1
+version: 2.3.0
 appVersion: 0.13.0
 maintainers:
   - name: sudermanjr

--- a/stable/vpa/README.md
+++ b/stable/vpa/README.md
@@ -115,6 +115,7 @@ recommender:
 | recommender.enabled | bool | `true` | If true, the vpa recommender component will be installed. |
 | recommender.extraArgs | object | `{"pod-recommendation-min-cpu-millicores":15,"pod-recommendation-min-memory-mb":100,"v":"4"}` | A set of key-value flags to be passed to the recommender |
 | recommender.replicaCount | int | `1` |  |
+| recommender.revisionHistoryLimit | int | `10` | The number of old replicasets to retain, default is 10, 0 will garbage-collect old replicasets |
 | recommender.podDisruptionBudget | object | `{}` | This is the setting for the pod disruption budget |
 | recommender.image.repository | string | `"registry.k8s.io/autoscaling/vpa-recommender"` | The location of the recommender image |
 | recommender.image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion |
@@ -133,6 +134,7 @@ recommender:
 | updater.enabled | bool | `true` | If true, the updater component will be deployed |
 | updater.extraArgs | object | `{}` | A key-value map of flags to pass to the updater |
 | updater.replicaCount | int | `1` |  |
+| updater.revisionHistoryLimit | int | `10` | The number of old replicasets to retain, default is 10, 0 will garbage-collect old replicasets |
 | updater.podDisruptionBudget | object | `{}` | This is the setting for the pod disruption budget |
 | updater.image.repository | string | `"registry.k8s.io/autoscaling/vpa-updater"` | The location of the updater image |
 | updater.image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion |
@@ -167,6 +169,7 @@ recommender:
 | admissionController.mutatingWebhookConfiguration.objectSelector | object | `{}` | The objectSelector can filter object on e.g. labels |
 | admissionController.mutatingWebhookConfiguration.timeoutSeconds | int | `30` |  |
 | admissionController.replicaCount | int | `1` |  |
+| admissionController.revisionHistoryLimit | int | `10` | The number of old replicasets to retain, default is 10, 0 will garbage-collect old replicasets |
 | admissionController.podDisruptionBudget | object | `{}` | This is the setting for the pod disruption budget |
 | admissionController.image.repository | string | `"registry.k8s.io/autoscaling/vpa-admission-controller"` | The location of the vpa admission controller image |
 | admissionController.image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion |

--- a/stable/vpa/templates/admission-controller-deployment.yaml
+++ b/stable/vpa/templates/admission-controller-deployment.yaml
@@ -8,6 +8,9 @@ metadata:
     {{- include "vpa.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.admissionController.replicaCount }}
+  {{- if .Values.admissionController.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ .Values.admissionController.revisionHistoryLimit }}
+  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/component: admission-controller

--- a/stable/vpa/templates/recommender-deployment.yaml
+++ b/stable/vpa/templates/recommender-deployment.yaml
@@ -8,6 +8,9 @@ metadata:
     {{- include "vpa.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.recommender.replicaCount }}
+  {{- if .Values.recommender.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ .Values.recommender.revisionHistoryLimit }}
+  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/component: recommender

--- a/stable/vpa/templates/updater-deployment.yaml
+++ b/stable/vpa/templates/updater-deployment.yaml
@@ -8,6 +8,9 @@ metadata:
     {{- include "vpa.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.updater.replicaCount }}
+  {{- if .Values.updater.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ .Values.updater.revisionHistoryLimit }}
+  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/component: updater

--- a/stable/vpa/values.yaml
+++ b/stable/vpa/values.yaml
@@ -36,6 +36,8 @@ recommender:
     pod-recommendation-min-cpu-millicores: 15
     pod-recommendation-min-memory-mb: 100
   replicaCount: 1
+  # recommender.revisionHistoryLimit -- The number of old replicasets to retain, default is 10, 0 will garbage-collect old replicasets
+  revisionHistoryLimit: 10
   # recommender.podDisruptionBudget -- This is the setting for the pod disruption budget
   podDisruptionBudget: {}
     # maxUnavailable: 1
@@ -99,6 +101,8 @@ updater:
   # updater.extraArgs -- A key-value map of flags to pass to the updater
   extraArgs: {}
   replicaCount: 1
+  # updater.revisionHistoryLimit -- The number of old replicasets to retain, default is 10, 0 will garbage-collect old replicasets
+  revisionHistoryLimit: 10
   # updater.podDisruptionBudget -- This is the setting for the pod disruption budget
   podDisruptionBudget: {}
     # maxUnavailable: 1
@@ -196,6 +200,8 @@ admissionController:
     timeoutSeconds: 30
 
   replicaCount: 1
+  # admissionController.revisionHistoryLimit -- The number of old replicasets to retain, default is 10, 0 will garbage-collect old replicasets
+  revisionHistoryLimit: 10
   # admissionController.podDisruptionBudget -- This is the setting for the pod disruption budget
   podDisruptionBudget: {}
     # maxUnavailable: 1


### PR DESCRIPTION
**Why This PR?**
I want to clean up old replica sets so that these don't appear in metrics, OPA violations, ArgoCD UI and so on.
Therefore I want to overwrite the Kubernetes default revision history limit.

Fixes #

**Changes**
Changes proposed in this pull request:

* add values admissionController.revisionHistoryLimit, recommender.revisionHistoryLimit, updater.revisionHistoryLimit
* add spec.revisionHistoryLimit to recommender-deployment.yaml, updater-deployment.yaml, admission-controller-deployment.yaml

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/vpa]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
