### PR TITLE
[incubator/datadog-apm] bump hpa to v2

### DIFF
--- a/incubator/datadog-apm/Chart.yaml
+++ b/incubator/datadog-apm/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: datadog-apm
 description: A modified chart that only installs the datadog-apm agent
 type: application
-version: 0.0.11
+version: 0.0.12
 appVersion: 7.40.0
 maintainers:
   - name: sudermanjr

--- a/incubator/datadog-apm/templates/cluster-agent-hpa.yaml
+++ b/incubator/datadog-apm/templates/cluster-agent-hpa.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.clusterAgent.hpa.enabled -}}
 ---
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "datadog-apm.fullname" . }}-hpa


### PR DESCRIPTION
**Why This PR?**
Bumps the HPA apiVersion to v2

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
