### PR TITLE
[stable/goldilocks] Allow changing the default revisionHistoryLimit

### DIFF
--- a/stable/goldilocks/Chart.yaml
+++ b/stable/goldilocks/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 appVersion: "v4.9.0"
-version: 7.0.2
+version: 7.1.0
 kubeVersion: ">= 1.22.0-0"
 description: |
   A Helm chart for running Fairwinds Goldilocks. See https://github.com/FairwindsOps/goldilocks

--- a/stable/goldilocks/Chart.yaml
+++ b/stable/goldilocks/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 appVersion: "v4.9.0"
-version: 7.1.0
+version: 7.1.1
 kubeVersion: ">= 1.22.0-0"
 description: |
   A Helm chart for running Fairwinds Goldilocks. See https://github.com/FairwindsOps/goldilocks

--- a/stable/goldilocks/README.md
+++ b/stable/goldilocks/README.md
@@ -71,6 +71,7 @@ This will completely remove the VPA and then re-install it using the new method.
 | nameOverride | string | `""` |  |
 | fullnameOverride | string | `""` |  |
 | controller.enabled | bool | `true` | Whether or not to install the controller deployment |
+| controller.revisionHistoryLimit | int | `10` | Number of old replicasets to retain, default is 10, 0 will garbage-collect old replicasets |
 | controller.rbac.create | bool | `true` | If set to true, rbac resources will be created for the controller |
 | controller.rbac.enableArgoproj | bool | `true` | If set to true, the clusterrole will give access to argoproj.io resources |
 | controller.rbac.extraRules | list | `[]` | Extra rbac rules for the controller clusterrole |
@@ -93,6 +94,7 @@ This will completely remove the VPA and then re-install it using the new method.
 | controller.deployment.podAnnotations | object | `{}` | Extra annotations for the controller pod |
 | dashboard.basePath | string | `nil` | Path on which the dashboard is served. Defaults to `/` |
 | dashboard.enabled | bool | `true` | If true, the dashboard component will be installed |
+| dashboard.revisionHistoryLimit | int | `10` | Number of old replicasets to retain, default is 10, 0 will garbage-collect old replicasets |
 | dashboard.replicaCount | int | `2` | Number of dashboard pods to run |
 | dashboard.service.type | string | `"ClusterIP"` | The type of the dashboard service |
 | dashboard.service.port | int | `80` | The port to run the dashboard service on |

--- a/stable/goldilocks/templates/controller-deployment.yaml
+++ b/stable/goldilocks/templates/controller-deployment.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   replicas: 1
   {{- if .Values.controller.revisionHistoryLimit }}
-  revisionHistoryLimit: {{ .Values.controller.revisionHistory }}
+  revisionHistoryLimit: {{ .Values.controller.revisionHistoryLimit }}
   {{- end }}
   selector:
     matchLabels:

--- a/stable/goldilocks/templates/controller-deployment.yaml
+++ b/stable/goldilocks/templates/controller-deployment.yaml
@@ -19,6 +19,9 @@ metadata:
   {{- end }}
 spec:
   replicas: 1
+  {{- if .Values.controller.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ .Values.controller.revisionHistory }}
+  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "goldilocks.name" . }}

--- a/stable/goldilocks/templates/dashboard-deployment.yaml
+++ b/stable/goldilocks/templates/dashboard-deployment.yaml
@@ -19,6 +19,9 @@ metadata:
   {{- end }}
 spec:
   replicas: {{ .Values.dashboard.replicaCount }}
+  {{- if .Values.dashboard.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ .Values.dashboard.revisionHistoryLimit }}
+  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "goldilocks.name" . }}

--- a/stable/goldilocks/values.yaml
+++ b/stable/goldilocks/values.yaml
@@ -30,6 +30,8 @@ fullnameOverride: ""
 controller:
   # controller.enabled -- Whether or not to install the controller deployment
   enabled: true
+  # controller.revisionHistoryLimit -- Number of old replicasets to retain, default is 10, 0 will garbage-collect old replicasets
+  revisionHistoryLimit: 10
   rbac:
     # controller.rbac.create -- If set to true, rbac resources will be created for the controller
     create: true
@@ -95,6 +97,8 @@ dashboard:
   basePath: null
   # dashboard.enabled -- If true, the dashboard component will be installed
   enabled: true
+  # dashboard.revisionHistoryLimit -- Number of old replicasets to retain, default is 10, 0 will garbage-collect old replicasets
+  revisionHistoryLimit: 10
   # dashboard.replicaCount -- Number of dashboard pods to run
   replicaCount: 2
   service:


### PR DESCRIPTION
**Why This PR?**
I want to clean up old replica sets so that these don't appear in metrics, OPA violations, ArgoCD UI and so on.
Therefore I want to overwrite the Kubernetes default revision history limit.

See [Kubernetes Clean up Policy](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#clean-up-policy)

Fixes #

**Changes**
Changes proposed in this pull request:

* fix typo in spec.revisionHistoryLimit in controller-deployment.yaml

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
