### PR TITLE
[stable/goldilocks] Allow changing the default revisionHistoryLimit

### DIFF
--- a/stable/goldilocks/Chart.yaml
+++ b/stable/goldilocks/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 appVersion: "v4.9.0"
-version: 7.1.0
+version: 7.1.1
 kubeVersion: ">= 1.22.0-0"
 description: |
   A Helm chart for running Fairwinds Goldilocks. See https://github.com/FairwindsOps/goldilocks

--- a/stable/goldilocks/templates/controller-deployment.yaml
+++ b/stable/goldilocks/templates/controller-deployment.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   replicas: 1
   {{- if .Values.controller.revisionHistoryLimit }}
-  revisionHistoryLimit: {{ .Values.controller.revisionHistory }}
+  revisionHistoryLimit: {{ .Values.controller.revisionHistoryLimit }}
   {{- end }}
   selector:
     matchLabels:


### PR DESCRIPTION
**Why This PR?**
I want to clean up old replica sets so that these don't appear in metrics, OPA violations, ArgoCD UI and so on.
Therefore I want to overwrite the Kubernetes default revision history limit.

See [Kubernetes Clean up Policy](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#clean-up-policy)

Fixes #

**Changes**
Changes proposed in this pull request:

* fix typo in spec.revisionHistoryLimit in controller-deployment.yaml

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
