### PR TITLE
[stable/polaris] Fix tiny bug in docs

### DIFF
--- a/stable/polaris/Chart.yaml
+++ b/stable/polaris/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Validation of best practices in your Kubernetes clusters
 name: polaris
-version: 5.12.0
+version: 5.12.1
 appVersion: "8.4"
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/polaris/master/pkg/dashboard/assets/favicon-32x32.png

--- a/stable/polaris/README.md
+++ b/stable/polaris/README.md
@@ -37,7 +37,7 @@ the 0.10.0 version of this chart will only work on kubernetes 1.14.0+
 |-----|------|---------|-------------|
 | config | string | `nil` | The [polaris configuration](https://github.com/FairwindsOps/polaris#configuration). If not provided then the [default](https://github.com/FairwindsOps/polaris/blob/master/examples/config.yaml) config from Polaris is used. |
 | configUrl | string | `nil` | Use a config from an accessible URL source.  NOTE: `config` & `configUrl` are mutually exclusive.  Setting `configURL` will take precedence over `config`.  Only one may be used. configUrl: https://example.com/config.yaml |
-| additionExemptions | string | `nil` | List of additional exemptions to append to the exemptions given in `config` |
+| additionalExemptions | string | `nil` | List of additional exemptions to append to the exemptions given in `config` |
 | image.repository | string | `"quay.io/fairwinds/polaris"` | Image repo |
 | image.tag | string | `""` | The Polaris Image tag to use. Defaults to the Chart's AppVersion |
 | image.pullPolicy | string | `"Always"` | Image pull policy |

--- a/stable/polaris/values.yaml
+++ b/stable/polaris/values.yaml
@@ -5,8 +5,8 @@ config: null
 # configUrl: https://example.com/config.yaml
 configUrl: null
 
-# additionExemptions -- List of additional exemptions to append to the exemptions given in `config`
-additionExemptions: null
+# additionalExemptions -- List of additional exemptions to append to the exemptions given in `config`
+additionalExemptions: null
 
 
 image:


### PR DESCRIPTION
**Why This PR?**
A tiny, tiny bug in the docs which cost me about 15 minutes to find :)

**Changes**
Just changes the word `additionExemptions` to `additionalExemptions`
**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.