### PR TITLE
[stable/vpa] Bump vpa to 0.14.0 and update metrics-server subchart

### DIFF
--- a/stable/vpa/Chart.lock
+++ b/stable/vpa/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: metrics-server
   repository: https://kubernetes-sigs.github.io/metrics-server/
-  version: 3.10.0
-digest: sha256:0a1ceadffa31a28b452eddff98027bcc4df9894d22f2e74ccbfa1828477db27c
-generated: "2023-06-05T09:00:56.207403385+02:00"
+  version: 3.11.0
+digest: sha256:8e75a50c785978534cc73098c2c0d9f366060e8799348a794c819f986a133029
+generated: "2023-08-16T10:36:48.403971-06:00"

--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 2.3.0
-appVersion: 0.13.0
+version: 2.4.0
+appVersion: 0.14.0
 maintainers:
   - name: sudermanjr
 home: https://github.com/FairwindsOps/charts/tree/master/stable/vpa
@@ -18,4 +18,4 @@ dependencies:
     condition: metrics-server.enabled
     name: metrics-server
     repository: https://kubernetes-sigs.github.io/metrics-server/
-    version: "3.10.0"
+    version: "3.11.0"


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Update the vpa version

**Changes**
Changes proposed in this pull request:

* Update vpa to 0.14.0 - [release notes](https://github.com/kubernetes/autoscaler/releases?q=vertical&expanded=true)
* Update metrics-server subchart to 3.11.0

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.