### PR TITLE
[stable/vpa] Created capability to add annotations to vpa deployments and fixed pdb labels

### DIFF
--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 2.3.1
+version: 2.4.1
 appVersion: 0.13.0
 maintainers:
   - name: sudermanjr

--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -3,7 +3,7 @@ name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
 version: 2.4.1
-appVersion: 0.13.0
+appVersion: 0.14.0
 maintainers:
   - name: sudermanjr
 home: https://github.com/FairwindsOps/charts/tree/master/stable/vpa

--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 2.3.0
+version: 2.3.1
 appVersion: 0.13.0
 maintainers:
   - name: sudermanjr

--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 2.4.1
+version: 2.5.0
 appVersion: 0.14.0
 maintainers:
   - name: sudermanjr

--- a/stable/vpa/README.md
+++ b/stable/vpa/README.md
@@ -113,6 +113,7 @@ recommender:
 | serviceAccount.name | string | `""` | The base name of the service account to use (appended with the component). If not set and create is true, a name is generated using the fullname template and appended for each component |
 | serviceAccount.automountServiceAccountToken | bool | `true` | Automount API credentials for the Service Account |
 | recommender.enabled | bool | `true` | If true, the vpa recommender component will be installed. |
+| recommender.annotations | object | `{}` | Annotations to add to the recommender deployment |
 | recommender.extraArgs | object | `{"pod-recommendation-min-cpu-millicores":15,"pod-recommendation-min-memory-mb":100,"v":"4"}` | A set of key-value flags to be passed to the recommender |
 | recommender.replicaCount | int | `1` |  |
 | recommender.revisionHistoryLimit | int | `10` | The number of old replicasets to retain, default is 10, 0 will garbage-collect old replicasets |
@@ -132,6 +133,7 @@ recommender:
 | recommender.affinity | object | `{}` |  |
 | recommender.podMonitor | object | `{"annotations":{},"enabled":false,"labels":{}}` | Enables a prometheus operator podMonitor for the recommender |
 | updater.enabled | bool | `true` | If true, the updater component will be deployed |
+| updater.annotations | object | `{}` | Annotations to add to the updater deployment |
 | updater.extraArgs | object | `{}` | A key-value map of flags to pass to the updater |
 | updater.replicaCount | int | `1` |  |
 | updater.revisionHistoryLimit | int | `10` | The number of old replicasets to retain, default is 10, 0 will garbage-collect old replicasets |
@@ -151,6 +153,7 @@ recommender:
 | updater.affinity | object | `{}` |  |
 | updater.podMonitor | object | `{"annotations":{},"enabled":false,"labels":{}}` | Enables a prometheus operator podMonitor for the updater |
 | admissionController.enabled | bool | `true` | If true, will install the admission-controller component of vpa |
+| admissionController.annotations | object | `{}` | Annotations to add to the admission controller deployment |
 | admissionController.extraArgs | object | `{}` | A key-value map of flags to pass to the admissionController |
 | admissionController.generateCertificate | bool | `true` | If true and admissionController is enabled, a pre-install hook will run to create the certificate for the webhook |
 | admissionController.secretName | string | `"{{ include \"vpa.fullname\" . }}-tls-secret"` | Name for the TLS secret created for the webhook. Default {{ .Release.Name }}-tls-secret |

--- a/stable/vpa/ci/test-values.yaml
+++ b/stable/vpa/ci/test-values.yaml
@@ -1,15 +1,21 @@
 recommender:
   enabled: true
+  annotations:
+    foo: bar
   podLabels:
     app: test
     foo: bar
 updater:
   enabled: true
+  annotations:
+    foo: bar
   podLabels:
     app: test
     foo: bar
 admissionController:
   enabled: true
+  annotations:
+    foo: bar
   extraArgs:
     v: "4"
   generateCertificate: true

--- a/stable/vpa/templates/admission-controller-deployment.yaml
+++ b/stable/vpa/templates/admission-controller-deployment.yaml
@@ -2,6 +2,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  {{- if .Values.admissionController.annotations }}
+  annotations:
+  {{ toYaml .Values.admissionController.annotations | indent 4 }}
+  {{- end }}
   name: {{ include "vpa.fullname" . }}-admission-controller
   labels:
     app.kubernetes.io/component: admission-controller

--- a/stable/vpa/templates/admission-controller-pdb.yaml
+++ b/stable/vpa/templates/admission-controller-pdb.yaml
@@ -9,5 +9,5 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: admission-controller
-      app.kubernetes.io/name: {{ template "vpa.fullname" . }}
+      app.kubernetes.io/name: {{ template "vpa.name" . }}
 {{- end }}

--- a/stable/vpa/templates/recommender-deployment.yaml
+++ b/stable/vpa/templates/recommender-deployment.yaml
@@ -2,6 +2,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  {{- if .Values.recommender.annotations }}
+  annotations:
+  {{ toYaml .Values.recommender.annotations | indent 4 }}
+  {{- end }}
   name: {{ include "vpa.fullname" . }}-recommender
   labels:
     app.kubernetes.io/component: recommender

--- a/stable/vpa/templates/recommender-pdb.yaml
+++ b/stable/vpa/templates/recommender-pdb.yaml
@@ -9,5 +9,5 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: recommender
-      app.kubernetes.io/name: {{ template "vpa.fullname" . }}
+      app.kubernetes.io/name: {{ template "vpa.name" . }}
 {{- end }}

--- a/stable/vpa/templates/updater-deployment.yaml
+++ b/stable/vpa/templates/updater-deployment.yaml
@@ -2,6 +2,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  {{- if .Values.updater.annotations }}
+  annotations:
+  {{ toYaml .Values.updater.annotations | indent 4 }}
+  {{- end }}
   name: {{ include "vpa.fullname" . }}-updater
   labels:
     app.kubernetes.io/component: updater

--- a/stable/vpa/templates/updater-pdb.yaml
+++ b/stable/vpa/templates/updater-pdb.yaml
@@ -9,5 +9,5 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: updater
-      app.kubernetes.io/name: {{ template "vpa.fullname" . }}
+      app.kubernetes.io/name: {{ template "vpa.name" . }}
 {{- end }}

--- a/stable/vpa/values.yaml
+++ b/stable/vpa/values.yaml
@@ -30,6 +30,8 @@ serviceAccount:
 recommender:
   # recommender.enabled -- If true, the vpa recommender component will be installed.
   enabled: true
+  # recommender.annotations -- Annotations to add to the recommender deployment
+  annotations: {}
   # recommender.extraArgs -- A set of key-value flags to be passed to the recommender
   extraArgs:
     v: "4"
@@ -98,6 +100,8 @@ recommender:
 updater:
   # updater.enabled -- If true, the updater component will be deployed
   enabled: true
+  # updater.annotations -- Annotations to add to the updater deployment
+  annotations: {}
   # updater.extraArgs -- A key-value map of flags to pass to the updater
   extraArgs: {}
   replicaCount: 1
@@ -163,6 +167,8 @@ updater:
 admissionController:
   # admissionController.enabled -- If true, will install the admission-controller component of vpa
   enabled: true
+  # admissionController.annotations -- Annotations to add to the admission controller deployment
+  annotations: {}
   # admissionController.extraArgs -- A key-value map of flags to pass to the admissionController
   extraArgs: {}
   # admissionController.generateCertificate -- If true and admissionController is enabled, a pre-install hook will run to create the certificate for the webhook


### PR DESCRIPTION

**Why This PR?**
Created capability to add annotations to vpa deployments and fixed pdb labels

Fixes #1293 #1294 

**Changes**
Changes proposed in this pull request:

* Created capability to add annotations to vpa deployments
* Set `app.kubernetes.io/name` pdb label to match the value in helper file

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
