### PR TITLE
[stable/insights-agent] set a service account on the install-reporter job by default

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+
+## 2.23.7
+* Added install-reporter serviceAccount
 ## 2.23.6
 * Updated kyverno rbac
 ## 2.23.5

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.23.6
+version: 2.23.7
 appVersion: 9.2.1
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png

--- a/stable/insights-agent/templates/install-reporter/job.yaml
+++ b/stable/insights-agent/templates/install-reporter/job.yaml
@@ -21,6 +21,7 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
     spec:
+      serviceAccountName: {{ include "insights-agent.fullname" . }}-install-reporter
       restartPolicy: Never
       {{- with .Values.installReporter.imagePullSecrets }}
       imagePullSecrets:

--- a/stable/insights-agent/templates/install-reporter/serviceacount.yaml
+++ b/stable/insights-agent/templates/install-reporter/serviceacount.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "insights-agent.fullname" . }}-install-reporter
+  labels:
+    app: insights-agent
+  annotations:
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation


### PR DESCRIPTION
**Why This PR?**
some security tools require that the `serviceAccountName` field be populated for all jobs and pods. This creates a named service account with no additional permissions to satisfy this requirement. 

Fixes #

**Changes**
Changes proposed in this pull request:

* creates a service account and adds it to the install-reporter job
*

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
