### PR TITLE
[stable/polaris] Support string type of config value

### DIFF
--- a/stable/polaris/CHANGELOG.md
+++ b/stable/polaris/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this Helm chart will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this chart adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 5.15.0
+
+* Support `string` type of `config` value
+
 ## 5.13.0
 * Update Polaris to 8.5.0
 

--- a/stable/polaris/Chart.yaml
+++ b/stable/polaris/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Validation of best practices in your Kubernetes clusters
 name: polaris
-version: 5.14.0
+version: 5.15.0
 appVersion: "8.5"
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/polaris/master/pkg/dashboard/assets/favicon-32x32.png

--- a/stable/polaris/templates/configmap.yaml
+++ b/stable/polaris/templates/configmap.yaml
@@ -11,12 +11,17 @@ metadata:
     {{- include "polaris.labels" $ | nindent 4 }}
 data:
   config.yaml: |
+    {{- if kindIs "map" . }}
     {{- range $key, $value := . }}
     {{ $key }}:
     {{- toYaml $value | nindent 6 }}
     {{- if and (eq $key "exemptions") ($.Values.additionalExemptions) }}
     {{- toYaml $.Values.additionalExemptions | nindent 6 }}
     {{- end }}
+    {{- end }}
+    {{- end }}
+    {{- if kindIs "string" . }}
+    {{- . | nindent 4 }}
     {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Fixes #1303 

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [ ] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
