### PR TITLE
[stable/insights-agent] FWI-4838 Add `mountTmp` flag to Kyverno job and default to `true`

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.23.8
+* Add mountTmp flag to Kyverno job and default to true
+
 ## 2.23.7
 * Added install-reporter serviceAccount
 ## 2.23.6

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.23.7
+version: 2.23.8
 appVersion: 9.2.1
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png

--- a/stable/insights-agent/templates/_specs.yaml
+++ b/stable/insights-agent/templates/_specs.yaml
@@ -88,6 +88,10 @@ imagePullSecrets:
 volumes:
 - name: output
   emptyDir: {}
+{{ if .Config.mountTmp }}
+- name: tmp
+  emptyDir: {}
+{{- end }}
 {{-   if (and .Values.global.sslCertFileSecretName .Values.global.sslCertFileSecretKey) }}
 {{       include "ssl-cert-file-volume-spec" . | trim }}
 {{-   end }}
@@ -107,6 +111,10 @@ env:
 volumeMounts:
 - name: output
   mountPath: /output
+{{- if .Config.mountTmp }}
+- name: tmp
+  mountPath: /tmp
+{{- end }}
 {{ include "ssl-cert-file-volumemount-spec" . }}
 {{- end }}
 

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -587,3 +587,4 @@ kyverno:
       cpu: 100m
       memory: 128Mi
   timeout: 300
+  mountTmp: true


### PR DESCRIPTION
**Why This PR?**

The Kyverno bash script writes to `/tmp` through the use of here-docs and here-strings. When `readOnlyRootFilesystem=true`, this can result in the following error

```
/main.sh: line 58: cannot create temp file for here-document: Read-only file system
Error on Line: 58
```

**Changes**
Changes proposed in this pull request:

* add a `mountTmp` value to the `kyverno` config in `insights-agent`
* default to true
* this will mount `/tmp` as an emptyDir to accommodate read-only root filesystems

Note that we haven't officially put Kyverno in the helm chart docs yet. Happy to do a follow-up to address this when we are ready to.

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
