### PR TITLE
[stable/vpa] Fixing bug in vpa deployment annotation definition

### DIFF
--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 2.5.0
+version: 2.5.1
 appVersion: 0.14.0
 maintainers:
   - name: sudermanjr

--- a/stable/vpa/ci/test-values.yaml
+++ b/stable/vpa/ci/test-values.yaml
@@ -2,6 +2,7 @@ recommender:
   enabled: true
   annotations:
     foo: bar
+    "foo.io/deploy-repo": "https://gitlab.com/foo/myrepo"
   podLabels:
     app: test
     foo: bar
@@ -9,6 +10,7 @@ updater:
   enabled: true
   annotations:
     foo: bar
+    "foo.io/deploy-repo": "https://gitlab.com/foo/myrepo"
   podLabels:
     app: test
     foo: bar
@@ -16,6 +18,7 @@ admissionController:
   enabled: true
   annotations:
     foo: bar
+    "foo.io/deploy-repo": "https://gitlab.com/foo/myrepo"
   extraArgs:
     v: "4"
   generateCertificate: true

--- a/stable/vpa/templates/admission-controller-deployment.yaml
+++ b/stable/vpa/templates/admission-controller-deployment.yaml
@@ -4,7 +4,7 @@ kind: Deployment
 metadata:
   {{- if .Values.admissionController.annotations }}
   annotations:
-  {{ toYaml .Values.admissionController.annotations | indent 4 }}
+  {{- .Values.admissionController.annotations | toYaml | nindent 4 }}
   {{- end }}
   name: {{ include "vpa.fullname" . }}-admission-controller
   labels:

--- a/stable/vpa/templates/recommender-deployment.yaml
+++ b/stable/vpa/templates/recommender-deployment.yaml
@@ -4,7 +4,7 @@ kind: Deployment
 metadata:
   {{- if .Values.recommender.annotations }}
   annotations:
-  {{ toYaml .Values.recommender.annotations | indent 4 }}
+  {{- .Values.recommender.annotations | toYaml | nindent 4 }}
   {{- end }}
   name: {{ include "vpa.fullname" . }}-recommender
   labels:

--- a/stable/vpa/templates/updater-deployment.yaml
+++ b/stable/vpa/templates/updater-deployment.yaml
@@ -4,7 +4,7 @@ kind: Deployment
 metadata:
   {{- if .Values.updater.annotations }}
   annotations:
-  {{ toYaml .Values.updater.annotations | indent 4 }}
+  {{- .Values.updater.annotations | toYaml | nindent 4 }}
   {{- end }}
   name: {{ include "vpa.fullname" . }}-updater
   labels:


### PR DESCRIPTION
**Why This PR?**
Defining the following annotations in VPA deployments are resulting in yaml parse errors
 
```
Annotations:
  "foo.io/deploy-repo": "https://gitlab.com/foo/myrepo"
  "foo.io/slack-channel": "myteam"
```

Error observed:
```
Helm install failed: YAML parse error on
        vpa/templates/recommender-deployment.yaml: error converting YAML to
        JSON: yaml: line 5: did not find expected key
```

Fixes https://github.com/FairwindsOps/charts/pull/1299#issuecomment-1693276815

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
