### PR TITLE
[stable/polaris] set log-level for webhook

### DIFF
--- a/stable/polaris/Chart.yaml
+++ b/stable/polaris/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Validation of best practices in your Kubernetes clusters
 name: polaris
-version: 5.13.0
+version: 5.14.0
 appVersion: "8.5"
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/polaris/master/pkg/dashboard/assets/favicon-32x32.png

--- a/stable/polaris/README.md
+++ b/stable/polaris/README.md
@@ -79,6 +79,7 @@ the 0.10.0 version of this chart will only work on kubernetes 1.14.0+
 | webhook.validate | bool | `true` | Enables the Validating Webhook, to reject resources with issues |
 | webhook.mutate | bool | `false` | Enables the Mutating Webhook, to modify resources with issues |
 | webhook.replicas | int | `2` | Number of replicas |
+| webhook.logLevel | string | `"info"` | Set the logging level for the Webhook command |
 | webhook.nodeSelector | object | `{}` | Webhook pod nodeSelector |
 | webhook.tolerations | list | `[]` | Webhook pod tolerations |
 | webhook.affinity | object | `{}` | Webhook pods affinity |

--- a/stable/polaris/templates/webhook.deployment.yaml
+++ b/stable/polaris/templates/webhook.deployment.yaml
@@ -52,6 +52,9 @@ spec:
             {{- end }}
             - --validate={{ .Values.webhook.validate }}
             - --mutate={{ .Values.webhook.mutate }}
+            {{- if .Values.webhook.logLevel }}
+            - --log-level={{ .Values.webhook.logLevel }}
+            {{- end }}
           image: '{{.Values.image.repository}}:{{.Values.image.tag | default .Chart.AppVersion }}'
           imagePullPolicy: '{{.Values.image.pullPolicy}}'
           ports:

--- a/stable/polaris/values.yaml
+++ b/stable/polaris/values.yaml
@@ -139,6 +139,8 @@ webhook:
   mutate: false
   # webhook.replicas -- Number of replicas
   replicas: 2
+  # webhook.logLevel -- Set the logging level for the Webhook command
+  logLevel: info
   # webhook.nodeSelector -- Webhook pod nodeSelector
   nodeSelector: {}
   # webhook.tolerations -- Webhook pod tolerations


### PR DESCRIPTION
**Why This PR?**
I would like to set loglevel for webhook container.

**Changes**
Changes proposed in this pull request:

* Add a new variable `webhook.logLevel` to set loglevel of webhook container.

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
