### PR TITLE
[incubator/skopeo-sync] fix cronjob apiVersion

### DIFF
--- a/incubator/skopeo-sync/Chart.yaml
+++ b/incubator/skopeo-sync/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: skopeo-sync
 description: A Helm chart for Kubernetes
 type: application
-version: 0.3.0
+version: 0.3.1
 appVersion: "v1.13"
 maintainers:
   - name: sudermanjr

--- a/incubator/skopeo-sync/templates/cronjob.yaml
+++ b/incubator/skopeo-sync/templates/cronjob.yaml
@@ -3,7 +3,7 @@
 ---
 {{- end }}
 {{- if not ($.Capabilities.APIVersions.Has "batch/v1/CronJob") }}
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 {{- else }}
 apiVersion: batch/v1
 {{- end }}


### PR DESCRIPTION
**Why This PR?**
v1beta1 is deprecated

**Changes**
Changes proposed in this pull request:

* s/v1beta1/v1

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.