### PR TITLE
[stable/goldilocks] update to 4.10.0. Update vpa to latest

### DIFF
--- a/stable/goldilocks/Chart.lock
+++ b/stable/goldilocks/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: vpa
   repository: https://charts.fairwinds.com/stable
-  version: 2.2.0
+  version: 2.5.1
 - name: metrics-server
   repository: https://charts.bitnami.com/bitnami
   version: 6.4.1
-digest: sha256:65dfffdd82f5d6603ee038a3fa3a501efddd36ea79338c8b403e13916f53da51
-generated: "2023-07-20T15:27:42.2213269Z"
+digest: sha256:358718baff45656e3b4a9fa0cddb5c17717041839542aa223620002e55e5ce26
+generated: "2023-09-05T15:36:02.054719-06:00"

--- a/stable/goldilocks/Chart.yaml
+++ b/stable/goldilocks/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: "v4.9.0"
-version: 7.1.2
+appVersion: "v4.10.0"
+version: 7.2.0
 kubeVersion: ">= 1.22.0-0"
 description: |
   A Helm chart for running Fairwinds Goldilocks. See https://github.com/FairwindsOps/goldilocks
@@ -16,7 +16,7 @@ keywords:
   - kubernetes
 dependencies:
   - name: vpa
-    version: 2.2.0
+    version: 2.5.*
     repository: https://charts.fairwinds.com/stable
     condition: vpa.enabled
   - name: metrics-server

--- a/stable/goldilocks/README.md
+++ b/stable/goldilocks/README.md
@@ -65,7 +65,7 @@ This will completely remove the VPA and then re-install it using the new method.
 | metrics-server.enabled | bool | `false` | If true, the metrics-server will be installed as a sub-chart |
 | metrics-server.apiService.create | bool | `true` |  |
 | image.repository | string | `"us-docker.pkg.dev/fairwinds-ops/oss/goldilocks"` | Repository for the goldilocks image |
-| image.tag | string | `"v4.9.0"` | The goldilocks image tag to use |
+| image.tag | string | `"v4.10.0"` | The goldilocks image tag to use |
 | image.pullPolicy | string | `"Always"` | imagePullPolicy - Highly recommended to leave this as `Always` |
 | imagePullSecrets | list | `[]` | A list of image pull secret names to use |
 | nameOverride | string | `""` |  |

--- a/stable/goldilocks/values.yaml
+++ b/stable/goldilocks/values.yaml
@@ -17,7 +17,7 @@ image:
   # image.repository -- Repository for the goldilocks image
   repository: us-docker.pkg.dev/fairwinds-ops/oss/goldilocks
   # image.tag -- The goldilocks image tag to use
-  tag: v4.9.0
+  tag: v4.10.0
   # image.pullPolicy -- imagePullPolicy - Highly recommended to leave this as `Always`
   pullPolicy: Always
 


### PR DESCRIPTION
**Why This PR?**
Updates

**Changes**
Changes proposed in this pull request:

* Update goldilocks to 4.10.0
* Update VPA sub-chart to latest (2.5.1)

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.