### PR TITLE
Revert "[incubator/timescale] Bump TimescaleDB to pg14.9-ts2.11.2 (#1…

### DIFF
--- a/incubator/timescale/Chart.yaml
+++ b/incubator/timescale/Chart.yaml
@@ -4,8 +4,8 @@
 apiVersion: v1
 name: timescaledb-single
 description: 'TimescaleDB HA Deployment.'
-appVersion: 0.30.2  # added to make linter happy - version of downstream chart
-version: 0.30.2
+appVersion: 0.30.1  # added to make linter happy - version of downstream chart
+version: 0.30.1
 # appVersion specifies the version of the software, which can vary wildly,
 # e.g. TimescaleDB 1.4.1 on PostgreSQL 11 or TimescaleDB 1.5.0 on PostgreSQL 12.
 # https://github.com/helm/helm/blob/master/docs/charts.md#the-appversion-field

--- a/incubator/timescale/Chart.yaml
+++ b/incubator/timescale/Chart.yaml
@@ -4,8 +4,8 @@
 apiVersion: v1
 name: timescaledb-single
 description: 'TimescaleDB HA Deployment.'
-appVersion: 0.30.1  # added to make linter happy - version of downstream chart
-version: 0.30.1
+appVersion: 0.30.3  # added to make linter happy - version of downstream chart
+version: 0.30.3
 # appVersion specifies the version of the software, which can vary wildly,
 # e.g. TimescaleDB 1.4.1 on PostgreSQL 11 or TimescaleDB 1.5.0 on PostgreSQL 12.
 # https://github.com/helm/helm/blob/master/docs/charts.md#the-appversion-field

--- a/incubator/timescale/README.md
+++ b/incubator/timescale/README.md
@@ -28,7 +28,7 @@ TimescaleDB HA Deployment.
 | clusterName | string | `""` |  |
 | version | string | `nil` |  |
 | image.repository | string | `"timescale/timescaledb-ha"` |  |
-| image.tag | string | `"pg14.9-ts2.11.2"` |  |
+| image.tag | string | `"pg14.8-ts2.11.0-all"` |  |
 | image.pullPolicy | string | `"Always"` |  |
 | secrets.credentials.PATRONI_SUPERUSER_PASSWORD | string | `""` |  |
 | secrets.credentials.PATRONI_REPLICATION_PASSWORD | string | `""` |  |

--- a/incubator/timescale/values.yaml
+++ b/incubator/timescale/values.yaml
@@ -20,7 +20,7 @@ image:
   # Image was built from
   # https://github.com/timescale/timescaledb-docker-ha
   repository: timescale/timescaledb-ha
-  tag: pg14.9-ts2.11.2
+  tag: pg14.8-ts2.11.0-all
   pullPolicy: Always
 
 # By default those secrets are randomly generated.


### PR DESCRIPTION
…319)"

This reverts commit 53bbb3edeffe53bbf037996cae99d02235ea3119.

**Why This PR?**
_a short description of why this PR is needed_

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
