### PR TITLE
FWI-4945 [stable/insights-agent] [stable/insights-admssion] Upgrade chart deps

### DIFF
--- a/stable/insights-admission/CHANGELOG.md
+++ b/stable/insights-admission/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.9.0
+* Bump insights-admission to version 1.13
+
 ## 1.8.4
 * Start testing on 1.26 and 1.27
 

--- a/stable/insights-admission/Chart.yaml
+++ b/stable/insights-admission/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: insights-admission
 description: A Validating Webhook Admission Controller that utilizes Fairwinds Insights.
 type: application
-version: 1.8.4
-appVersion: "1.11"
+version: 1.9.0
+appVersion: "1.13"
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-admission/icon.png
 maintainers:

--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.24.0
+* Bumped `opa` plugin version to `2.3`
+* Bumped `right-sizer` plugin version to `0.5`
+* Bumped `workloads` plugin version to `2.6`
+
 ## 2.23.8
 * Add mountTmp flag to Kyverno job and default to true
 

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.23.8
+version: 2.24.0
 appVersion: 9.2.1
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -157,7 +157,7 @@ opa:
   timeout: 300
   image:
     repository: quay.io/fairwinds/fw-opa
-    tag: "2.2"
+    tag: "2.3"
   additionalAccess:
   # opa.defaultTargetResources -- A default list of Kubernetes targets to which OPA
   # policies will be applied.
@@ -204,7 +204,7 @@ workloads:
   timeout: 300
   image:
     repository: quay.io/fairwinds/workloads
-    tag: "2.5"
+    tag: "2.6"
   resources:
     requests:
       cpu: 100m
@@ -432,7 +432,7 @@ right-sizer:
   # This image is for the controller, the agent only runs the Insights uploader.
   image:
     repository: quay.io/fairwinds/right-sizer
-    tag: 0.4
+    tag: 0.5
     pullPolicy: Always
   # rightsizer.imagePullSecrets -- imagePullSecrets containing private registry credentials.
   imagePullSecrets: []


### PR DESCRIPTION
**Why This PR?**

Includes go-funk -> samber/lo migration changes for FWI-4945 (tech debt)

Fixes #

**Changes**
Changes proposed in this pull request:

[stable/insights-agent] and [stable/insights-admssion]

* Bumped `insights-admission` to version `1.13`
* Bumped `opa` plugin version to `2.3`
* Bumped `right-sizer` plugin version to `0.5`
* Bumped `workloads` plugin version to `2.6`

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
