### PR TITLE
[stable/vpa] Make an opportunity to extend rbac ClusterRoles

### DIFF
--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 2.6.0
+version: 3.0.0
 appVersion: 0.14.0
 maintainers:
   - name: sudermanjr

--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 2.5.1
+version: 2.6.0
 appVersion: 0.14.0
 maintainers:
   - name: sudermanjr

--- a/stable/vpa/README.md
+++ b/stable/vpa/README.md
@@ -35,7 +35,7 @@ You can define it as follows:
 
 ```yaml
 rbac:
-  clusterRoles:
+  extraRules:
     vpaActor:
       - apiGroups:
           - batch
@@ -134,13 +134,13 @@ recommender:
 | fullnameOverride | string | `""` | A template override for the fullname |
 | podLabels | object | `{}` | Labels to add to all pods |
 | rbac.create | bool | `true` | If true, then rbac resources (ClusterRoles and ClusterRoleBindings) will be created for the selected components. Temporary rbac resources will still be created, to ensure a functioning installation process |
-| rbac.clusterRoles | object | `{"vpaActor":[],"vpaCheckpointActor":[],"vpaEvictioner":[],"vpaMetricsReader":[],"vpaStatusReader":[],"vpaTargetReader":[]}` | Extra rbac rules for Clusterroles |
-| rbac.clusterRoles.vpaActor | list | `[]` | Extra rbac rules for the vpa-actor ClusterRole |
-| rbac.clusterRoles.vpaCheckpointActor | list | `[]` | Extra rbac rules for the vpa-checkpoint-actor ClusterRole |
-| rbac.clusterRoles.vpaEvictioner | list | `[]` | Extra rbac rules for the vpa-evictioner ClusterRole |
-| rbac.clusterRoles.vpaMetricsReader | list | `[]` | Extra rbac rules for the vpa-metrics-reader ClusterRole |
-| rbac.clusterRoles.vpaTargetReader | list | `[]` | Extra rbac rules for the vpa-target-reader ClusterRole |
-| rbac.clusterRoles.vpaStatusReader | list | `[]` | Extra rbac rules for the vpa-status-reader ClusterRole |
+| rbac.extraRules | object | `{"vpaActor":[],"vpaCheckpointActor":[],"vpaEvictioner":[],"vpaMetricsReader":[],"vpaStatusReader":[],"vpaTargetReader":[]}` | Extra rbac rules for ClusterRoles |
+| rbac.extraRules.vpaActor | list | `[]` | Extra rbac rules for the vpa-actor ClusterRole |
+| rbac.extraRules.vpaCheckpointActor | list | `[]` | Extra rbac rules for the vpa-checkpoint-actor ClusterRole |
+| rbac.extraRules.vpaEvictioner | list | `[]` | Extra rbac rules for the vpa-evictioner ClusterRole |
+| rbac.extraRules.vpaMetricsReader | list | `[]` | Extra rbac rules for the vpa-metrics-reader ClusterRole |
+| rbac.extraRules.vpaTargetReader | list | `[]` | Extra rbac rules for the vpa-target-reader ClusterRole |
+| rbac.extraRules.vpaStatusReader | list | `[]` | Extra rbac rules for the vpa-status-reader ClusterRole |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created for each component |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service accounts for each component |
 | serviceAccount.name | string | `""` | The base name of the service account to use (appended with the component). If not set and create is true, a name is generated using the fullname template and appended for each component |

--- a/stable/vpa/README.md
+++ b/stable/vpa/README.md
@@ -25,6 +25,32 @@ The admissionController is the only one that poses a stability consideration bec
 
 For more details, please see the values below, and the vertical pod autosclaer documentation.
 
+## *BREAKING* Upgrading from <= v2.5.1 to 3.0.0
+
+### ClusterRole rules
+
+Previously, ClusterRoles were created by default from templates and could not be extended with custom rules. Since `3.0.0` version it is possible.
+
+You can define it as follows:
+
+```yaml
+rbac:
+  clusterRoles:
+    vpaActor:
+      - apiGroups:
+          - batch
+        resources:
+          - '*'
+        verbs:
+          - get
+    vpaCheckpointActor: []
+    vpaEvictioner: []
+    vpaMetricsReader: []
+    vpaTargetReader: []
+    vpaStatusReader: []
+
+```
+
 ## *BREAKING* Upgrading from <= v1.7.x to 2.0.0
 
 ### Certificate generation

--- a/stable/vpa/README.md
+++ b/stable/vpa/README.md
@@ -107,7 +107,14 @@ recommender:
 | nameOverride | string | `""` | A template override for the name |
 | fullnameOverride | string | `""` | A template override for the fullname |
 | podLabels | object | `{}` | Labels to add to all pods |
-| rbac.create | bool | `true` | If true, then rbac resources (clusterroles and clusterrolebindings) will be created for the selected components. Temporary rbac resources will still be created, to ensure a functioning installation process |
+| rbac.create | bool | `true` | If true, then rbac resources (ClusterRoles and ClusterRoleBindings) will be created for the selected components. Temporary rbac resources will still be created, to ensure a functioning installation process |
+| rbac.clusterRoles | object | `{"vpaActor":[],"vpaCheckpointActor":[],"vpaEvictioner":[],"vpaMetricsReader":[],"vpaStatusReader":[],"vpaTargetReader":[]}` | Extra rbac rules for Clusterroles |
+| rbac.clusterRoles.vpaActor | list | `[]` | Extra rbac rules for the vpa-actor ClusterRole |
+| rbac.clusterRoles.vpaCheckpointActor | list | `[]` | Extra rbac rules for the vpa-checkpoint-actor ClusterRole |
+| rbac.clusterRoles.vpaEvictioner | list | `[]` | Extra rbac rules for the vpa-evictioner ClusterRole |
+| rbac.clusterRoles.vpaMetricsReader | list | `[]` | Extra rbac rules for the vpa-metrics-reader ClusterRole |
+| rbac.clusterRoles.vpaTargetReader | list | `[]` | Extra rbac rules for the vpa-target-reader ClusterRole |
+| rbac.clusterRoles.vpaStatusReader | list | `[]` | Extra rbac rules for the vpa-status-reader ClusterRole |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created for each component |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service accounts for each component |
 | serviceAccount.name | string | `""` | The base name of the service account to use (appended with the component). If not set and create is true, a name is generated using the fullname template and appended for each component |

--- a/stable/vpa/README.md.gotmpl
+++ b/stable/vpa/README.md.gotmpl
@@ -25,6 +25,32 @@ The admissionController is the only one that poses a stability consideration bec
 
 For more details, please see the values below, and the vertical pod autosclaer documentation.
 
+## *BREAKING* Upgrading from <= v2.5.1 to 3.0.0
+
+### ClusterRole rules
+
+Previously, ClusterRoles were created by default from templates and could not be extended with custom rules. Since `3.0.0` version it is possible.
+
+You can define it as follows:
+
+```yaml
+rbac:
+  clusterRoles:
+    vpaActor:
+      - apiGroups:
+          - batch
+        resources:
+          - '*'
+        verbs:
+          - get
+    vpaCheckpointActor: []
+    vpaEvictioner: []
+    vpaMetricsReader: []
+    vpaTargetReader: []
+    vpaStatusReader: []
+
+```
+
 ## *BREAKING* Upgrading from <= v1.7.x to 2.0.0
 
 ### Certificate generation

--- a/stable/vpa/README.md.gotmpl
+++ b/stable/vpa/README.md.gotmpl
@@ -35,7 +35,7 @@ You can define it as follows:
 
 ```yaml
 rbac:
-  clusterRoles:
+  extraRules:
     vpaActor:
       - apiGroups:
           - batch

--- a/stable/vpa/ci/test-values.yaml
+++ b/stable/vpa/ci/test-values.yaml
@@ -1,3 +1,59 @@
+rbac:
+  clusterRoles:
+    vpaActor:
+      - apiGroups:
+          - batch
+        resources:
+          - '*'
+        verbs:
+          - get
+          - list
+          - watch
+    vpaCheckpointActor:
+      - apiGroups:
+          - batch
+        resources:
+          - '*'
+        verbs:
+          - get
+          - list
+          - watch
+    vpaEvictioner:
+      - apiGroups:
+          - batch
+        resources:
+          - '*'
+        verbs:
+          - get
+          - list
+          - watch
+    vpaMetricsReader:
+      - apiGroups:
+          - batch
+        resources:
+          - '*'
+        verbs:
+          - get
+          - list
+          - watch
+    vpaTargetReader:
+      - apiGroups:
+          - batch
+        resources:
+          - '*'
+        verbs:
+          - get
+          - list
+          - watch
+    vpaStatusReader:
+      - apiGroups:
+          - batch
+        resources:
+          - '*'
+        verbs:
+          - get
+          - list
+          - watch
 recommender:
   enabled: true
   annotations:

--- a/stable/vpa/ci/test-values.yaml
+++ b/stable/vpa/ci/test-values.yaml
@@ -1,5 +1,5 @@
 rbac:
-  clusterRoles:
+  extraRules:
     vpaActor:
       - apiGroups:
           - batch

--- a/stable/vpa/templates/clusterroles.yaml
+++ b/stable/vpa/templates/clusterroles.yaml
@@ -12,6 +12,9 @@ rules:
     verbs:
       - get
       - list
+  {{- if .Values.rbac.clusterRoles.vpaMetricsReader -}}
+  {{ toYaml .Values.rbac.clusterRoles.vpaMetricsReader | nindent 2 }}
+  {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -55,6 +58,9 @@ rules:
       - list
       - watch
       - patch
+  {{- if .Values.rbac.clusterRoles.vpaActor -}}
+  {{ toYaml .Values.rbac.clusterRoles.vpaActor | nindent 2 }}
+  {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -90,6 +96,9 @@ rules:
     verbs:
       - get
       - list
+  {{- if .Values.rbac.clusterRoles.vpaCheckpointActor -}}
+  {{ toYaml .Values.rbac.clusterRoles.vpaCheckpointActor | nindent 2 }}
+  {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -109,6 +118,9 @@ rules:
       - pods/eviction
     verbs:
       - create
+  {{- if .Values.rbac.clusterRoles.vpaEvictioner -}}
+  {{ toYaml .Values.rbac.clusterRoles.vpaEvictioner | nindent 2 }}
+  {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -150,6 +162,9 @@ rules:
       - get
       - list
       - watch
+  {{- if .Values.rbac.clusterRoles.vpaTargetReader -}}
+  {{ toYaml .Values.rbac.clusterRoles.vpaTargetReader | nindent 2 }}
+  {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -164,4 +179,7 @@ rules:
       - get
       - list
       - watch
+  {{- if .Values.rbac.clusterRoles.vpaStatusReader -}}
+  {{ toYaml .Values.rbac.clusterRoles.vpaStatusReader | nindent 2 }}
+  {{- end }}
 {{- end }}

--- a/stable/vpa/templates/clusterroles.yaml
+++ b/stable/vpa/templates/clusterroles.yaml
@@ -12,8 +12,8 @@ rules:
     verbs:
       - get
       - list
-  {{- if .Values.rbac.clusterRoles.vpaMetricsReader -}}
-  {{ toYaml .Values.rbac.clusterRoles.vpaMetricsReader | nindent 2 }}
+  {{- if .Values.rbac.extraRules.vpaMetricsReader -}}
+  {{ toYaml .Values.rbac.extraRules.vpaMetricsReader | nindent 2 }}
   {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -58,8 +58,8 @@ rules:
       - list
       - watch
       - patch
-  {{- if .Values.rbac.clusterRoles.vpaActor -}}
-  {{ toYaml .Values.rbac.clusterRoles.vpaActor | nindent 2 }}
+  {{- if .Values.rbac.extraRules.vpaActor -}}
+  {{ toYaml .Values.rbac.extraRules.vpaActor | nindent 2 }}
   {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -96,8 +96,8 @@ rules:
     verbs:
       - get
       - list
-  {{- if .Values.rbac.clusterRoles.vpaCheckpointActor -}}
-  {{ toYaml .Values.rbac.clusterRoles.vpaCheckpointActor | nindent 2 }}
+  {{- if .Values.rbac.extraRules.vpaCheckpointActor -}}
+  {{ toYaml .Values.rbac.extraRules.vpaCheckpointActor | nindent 2 }}
   {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -118,8 +118,8 @@ rules:
       - pods/eviction
     verbs:
       - create
-  {{- if .Values.rbac.clusterRoles.vpaEvictioner -}}
-  {{ toYaml .Values.rbac.clusterRoles.vpaEvictioner | nindent 2 }}
+  {{- if .Values.rbac.extraRules.vpaEvictioner -}}
+  {{ toYaml .Values.rbac.extraRules.vpaEvictioner | nindent 2 }}
   {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -162,8 +162,8 @@ rules:
       - get
       - list
       - watch
-  {{- if .Values.rbac.clusterRoles.vpaTargetReader -}}
-  {{ toYaml .Values.rbac.clusterRoles.vpaTargetReader | nindent 2 }}
+  {{- if .Values.rbac.extraRules.vpaTargetReader -}}
+  {{ toYaml .Values.rbac.extraRules.vpaTargetReader | nindent 2 }}
   {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -179,7 +179,7 @@ rules:
       - get
       - list
       - watch
-  {{- if .Values.rbac.clusterRoles.vpaStatusReader -}}
-  {{ toYaml .Values.rbac.clusterRoles.vpaStatusReader | nindent 2 }}
+  {{- if .Values.rbac.extraRules.vpaStatusReader -}}
+  {{ toYaml .Values.rbac.extraRules.vpaStatusReader | nindent 2 }}
   {{- end }}
 {{- end }}

--- a/stable/vpa/values.yaml
+++ b/stable/vpa/values.yaml
@@ -16,19 +16,19 @@ rbac:
   # rbac.create -- If true, then rbac resources (ClusterRoles and ClusterRoleBindings) will be created for the selected components.
   # Temporary rbac resources will still be created, to ensure a functioning installation process
   create: true
-  # rbac.clusterRoles -- Extra rbac rules for Clusterroles
-  clusterRoles:
-    # rbac.clusterRoles.vpaActor -- Extra rbac rules for the vpa-actor ClusterRole
+  # rbac.extraRules -- Extra rbac rules for ClusterRoles
+  extraRules:
+    # rbac.extraRules.vpaActor -- Extra rbac rules for the vpa-actor ClusterRole
     vpaActor: []
-    # rbac.clusterRoles.vpaCheckpointActor -- Extra rbac rules for the vpa-checkpoint-actor ClusterRole
+    # rbac.extraRules.vpaCheckpointActor -- Extra rbac rules for the vpa-checkpoint-actor ClusterRole
     vpaCheckpointActor: []
-    # rbac.clusterRoles.vpaEvictioner -- Extra rbac rules for the vpa-evictioner ClusterRole
+    # rbac.extraRules.vpaEvictioner -- Extra rbac rules for the vpa-evictioner ClusterRole
     vpaEvictioner: []
-    # rbac.clusterRoles.vpaMetricsReader -- Extra rbac rules for the vpa-metrics-reader ClusterRole
+    # rbac.extraRules.vpaMetricsReader -- Extra rbac rules for the vpa-metrics-reader ClusterRole
     vpaMetricsReader: []
-    # rbac.clusterRoles.vpaTargetReader -- Extra rbac rules for the vpa-target-reader ClusterRole
+    # rbac.extraRules.vpaTargetReader -- Extra rbac rules for the vpa-target-reader ClusterRole
     vpaTargetReader: []
-    # rbac.clusterRoles.vpaStatusReader -- Extra rbac rules for the vpa-status-reader ClusterRole
+    # rbac.extraRules.vpaStatusReader -- Extra rbac rules for the vpa-status-reader ClusterRole
     vpaStatusReader: []
 
 serviceAccount:

--- a/stable/vpa/values.yaml
+++ b/stable/vpa/values.yaml
@@ -13,9 +13,23 @@ fullnameOverride: ""
 # podLabels -- Labels to add to all pods
 podLabels: {}
 rbac:
-  # rbac.create -- If true, then rbac resources (clusterroles and clusterrolebindings) will be created for the selected components.
+  # rbac.create -- If true, then rbac resources (ClusterRoles and ClusterRoleBindings) will be created for the selected components.
   # Temporary rbac resources will still be created, to ensure a functioning installation process
   create: true
+  # rbac.clusterRoles -- Extra rbac rules for Clusterroles
+  clusterRoles:
+    # rbac.clusterRoles.vpaActor -- Extra rbac rules for the vpa-actor ClusterRole
+    vpaActor: []
+    # rbac.clusterRoles.vpaCheckpointActor -- Extra rbac rules for the vpa-checkpoint-actor ClusterRole
+    vpaCheckpointActor: []
+    # rbac.clusterRoles.vpaEvictioner -- Extra rbac rules for the vpa-evictioner ClusterRole
+    vpaEvictioner: []
+    # rbac.clusterRoles.vpaMetricsReader -- Extra rbac rules for the vpa-metrics-reader ClusterRole
+    vpaMetricsReader: []
+    # rbac.clusterRoles.vpaTargetReader -- Extra rbac rules for the vpa-target-reader ClusterRole
+    vpaTargetReader: []
+    # rbac.clusterRoles.vpaStatusReader -- Extra rbac rules for the vpa-status-reader ClusterRole
+    vpaStatusReader: []
 
 serviceAccount:
   # serviceAccount.create -- Specifies whether a service account should be created for each component


### PR DESCRIPTION
**Why This PR?**
At the moment, there are no opportunity to add extra rules in `ClusterRole`, and for some use-cases it is a must.

Fixes #

**Changes**
Changes proposed in this pull request:

* This PR make an opportunity to extend rbac ClusterRoles

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
