### PR TITLE
[stable/vpa] fix: 🔧 Add hook-weight to vpa-admission-certgen

### DIFF
--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 3.0.0
+version: 3.0.1
 appVersion: 0.14.0
 maintainers:
   - name: sudermanjr

--- a/stable/vpa/templates/webhooks/jobs/certgen-clusterrole.yaml
+++ b/stable/vpa/templates/webhooks/jobs/certgen-clusterrole.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "-110"
   labels:
     app.kubernetes.io/component: admission-certgen
     {{- include "vpa.labels" . | nindent 4 }}

--- a/stable/vpa/templates/webhooks/jobs/certgen-clusterrolebinding.yaml
+++ b/stable/vpa/templates/webhooks/jobs/certgen-clusterrolebinding.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "-110"
   labels:
     app.kubernetes.io/component: admission-certgen
     {{- include "vpa.labels" . | nindent 4 }}

--- a/stable/vpa/templates/webhooks/jobs/certgen-create.yaml
+++ b/stable/vpa/templates/webhooks/jobs/certgen-create.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "-110"
   labels:
     app.kubernetes.io/component: certgen
     {{- include "vpa.labels" . | nindent 4 }}

--- a/stable/vpa/templates/webhooks/jobs/certgen-role.yaml
+++ b/stable/vpa/templates/webhooks/jobs/certgen-role.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "-110"
   labels:
     app.kubernetes.io/component: admission-certgen
     {{- include "vpa.labels" . | nindent 4 }}

--- a/stable/vpa/templates/webhooks/jobs/certgen-rolebinding.yaml
+++ b/stable/vpa/templates/webhooks/jobs/certgen-rolebinding.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "-110"
   labels:
     app.kubernetes.io/component: admission-certgen
     {{- include "vpa.labels" . | nindent 4 }}

--- a/stable/vpa/templates/webhooks/jobs/certgen-sa.yaml
+++ b/stable/vpa/templates/webhooks/jobs/certgen-sa.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "-110"
   labels:
     app.kubernetes.io/component: admission-certgen
     {{- include "vpa.labels" . | nindent 4 }}


### PR DESCRIPTION
**Why This PR?**

When using ArgoCD with this chart and the` admissionController.generateCertificate: true`, argocd cannot create the secret `vpa-tls-secret` needed by the job `vpa-admission-certgen-create`

This `vpa-tls-secret` is needed for second job` vpa-certgen` and argocd respects the hook-weight priorities

Fixes #

**Changes**
Changes proposed in this pull request:

* Add annotation` "helm.sh/hook-weight": "-110"` in order to create the secret before other jobs

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
