### PR TITLE
[stable/goldilocks] Turn off resource limits by default

### DIFF
--- a/stable/goldilocks/Chart.yaml
+++ b/stable/goldilocks/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 appVersion: "v4.10.0"
-version: 7.2.0
+version: 7.2.1
 kubeVersion: ">= 1.22.0-0"
 description: |
   A Helm chart for running Fairwinds Goldilocks. See https://github.com/FairwindsOps/goldilocks

--- a/stable/goldilocks/Chart.yaml
+++ b/stable/goldilocks/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 appVersion: "v4.10.0"
-version: 7.2.1
+version: 7.3.0
 kubeVersion: ">= 1.22.0-0"
 description: |
   A Helm chart for running Fairwinds Goldilocks. See https://github.com/FairwindsOps/goldilocks

--- a/stable/goldilocks/README.md
+++ b/stable/goldilocks/README.md
@@ -84,7 +84,7 @@ This will completely remove the VPA and then re-install it using the new method.
 | controller.tolerations | list | `[]` | Tolerations for the controller pod |
 | controller.affinity | object | `{}` | Affinity for the controller pods |
 | controller.topologySpreadConstraints | list | `[]` | Topology spread constraints for the controller pods |
-| controller.resources | object | `{"limits":{"cpu":"25m","memory":"256Mi"},"requests":{"cpu":"25m","memory":"256Mi"}}` | The resources block for the controller pods |
+| controller.resources | object | `{}` | The resources block for the controller pods |
 | controller.podSecurityContext | object | `{}` | Defines the podSecurityContext for the controller pod |
 | controller.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":10324}` | The container securityContext for the controller container |
 | controller.deployment.extraVolumeMounts | list | `[]` | Extra volume mounts for the controller container |
@@ -118,7 +118,7 @@ This will completely remove the VPA and then re-install it using the new method.
 | dashboard.ingress.hosts[0].paths[0].path | string | `"/"` |  |
 | dashboard.ingress.hosts[0].paths[0].type | string | `"ImplementationSpecific"` |  |
 | dashboard.ingress.tls | list | `[]` |  |
-| dashboard.resources | object | `{"limits":{"cpu":"25m","memory":"256Mi"},"requests":{"cpu":"25m","memory":"256Mi"}}` | A resources block for the dashboard. |
+| dashboard.resources | object | `{}` | A resources block for the dashboard. |
 | dashboard.podSecurityContext | object | `{}` | Defines the podSecurityContext for the dashboard pod |
 | dashboard.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":10324}` | The container securityContext for the dashboard container |
 | dashboard.nodeSelector | object | `{}` |  |

--- a/stable/goldilocks/README.md
+++ b/stable/goldilocks/README.md
@@ -84,7 +84,7 @@ This will completely remove the VPA and then re-install it using the new method.
 | controller.tolerations | list | `[]` | Tolerations for the controller pod |
 | controller.affinity | object | `{}` | Affinity for the controller pods |
 | controller.topologySpreadConstraints | list | `[]` | Topology spread constraints for the controller pods |
-| controller.resources | object | `{}` | The resources block for the controller pods |
+| controller.resources | object | `{"limits":{},"requests":{"cpu":"25m","memory":"256Mi"}}` | The resources block for the controller pods |
 | controller.podSecurityContext | object | `{}` | Defines the podSecurityContext for the controller pod |
 | controller.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":10324}` | The container securityContext for the controller container |
 | controller.deployment.extraVolumeMounts | list | `[]` | Extra volume mounts for the controller container |
@@ -118,7 +118,7 @@ This will completely remove the VPA and then re-install it using the new method.
 | dashboard.ingress.hosts[0].paths[0].path | string | `"/"` |  |
 | dashboard.ingress.hosts[0].paths[0].type | string | `"ImplementationSpecific"` |  |
 | dashboard.ingress.tls | list | `[]` |  |
-| dashboard.resources | object | `{}` | A resources block for the dashboard. |
+| dashboard.resources | object | `{"limits":{},"requests":{"cpu":"25m","memory":"256Mi"}}` | A resources block for the dashboard. |
 | dashboard.podSecurityContext | object | `{}` | Defines the podSecurityContext for the dashboard pod |
 | dashboard.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":10324}` | The container securityContext for the dashboard container |
 | dashboard.nodeSelector | object | `{}` |  |

--- a/stable/goldilocks/values.yaml
+++ b/stable/goldilocks/values.yaml
@@ -60,13 +60,11 @@ controller:
   # controller.topologySpreadConstraints -- Topology spread constraints for the controller pods
   topologySpreadConstraints: []
   # controller.resources -- The resources block for the controller pods
-  resources: {}
-    # limits:
-    #   cpu: 25m
-    #   memory: 256Mi
-    # requests:
-    #   cpu: 25m
-    #   memory: 256Mi
+  resources:
+    limits: {}
+    requests:
+      cpu: 25m
+      memory: 256Mi
   # controller.podSecurityContext -- Defines the podSecurityContext for the controller pod
   podSecurityContext: {}
   # controller.securityContext -- The container securityContext for the controller container
@@ -159,13 +157,11 @@ dashboard:
     #      - chart-example.local
 
   # dashboard.resources -- A resources block for the dashboard.
-  resources: {}
-    # limits:
-    #   cpu: 25m
-    #   memory: 256Mi
-    # requests:
-    #   cpu: 25m
-    #   memory: 256Mi
+  resources:
+    limits: {}
+    requests:
+      cpu: 25m
+      memory: 256Mi
   # dashboard.podSecurityContext -- Defines the podSecurityContext for the dashboard pod
   podSecurityContext: {}
   # dashboard.securityContext -- The container securityContext for the dashboard container

--- a/stable/goldilocks/values.yaml
+++ b/stable/goldilocks/values.yaml
@@ -60,13 +60,13 @@ controller:
   # controller.topologySpreadConstraints -- Topology spread constraints for the controller pods
   topologySpreadConstraints: []
   # controller.resources -- The resources block for the controller pods
-  resources:
-    limits:
-      cpu: 25m
-      memory: 256Mi
-    requests:
-      cpu: 25m
-      memory: 256Mi
+  resources: {}
+    # limits:
+    #   cpu: 25m
+    #   memory: 256Mi
+    # requests:
+    #   cpu: 25m
+    #   memory: 256Mi
   # controller.podSecurityContext -- Defines the podSecurityContext for the controller pod
   podSecurityContext: {}
   # controller.securityContext -- The container securityContext for the controller container
@@ -159,13 +159,13 @@ dashboard:
     #      - chart-example.local
 
   # dashboard.resources -- A resources block for the dashboard.
-  resources:
-    limits:
-      cpu: 25m
-      memory: 256Mi
-    requests:
-      cpu: 25m
-      memory: 256Mi
+  resources: {}
+    # limits:
+    #   cpu: 25m
+    #   memory: 256Mi
+    # requests:
+    #   cpu: 25m
+    #   memory: 256Mi
   # dashboard.podSecurityContext -- Defines the podSecurityContext for the dashboard pod
   podSecurityContext: {}
   # dashboard.securityContext -- The container securityContext for the dashboard container


### PR DESCRIPTION
**Why This PR?**
At the moment, you cannot turn off resources, because it is in values. From time to time you need to define only `requests` and keep the `limits` flexible.

Fixes #

**Changes**
Changes proposed in this pull request:

* This PR turns off resources for dashboard and controller by default, and make an opportunity to define `requests` only. 

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
