### PR TITLE
[stable/insights-agent] Add tip on selecting apiVersion with gitops tooling

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 2.24.2
+* Add gitops tip to readme
 ## 2.24.1
 * bump `insights-admission` to version '1.9.*' in requirements.yaml 
 

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.24.1
+version: 2.24.2
 appVersion: 9.2.1
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.24.2
+version: 2.24.3
 appVersion: 9.2.1
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png

--- a/stable/insights-agent/README.md
+++ b/stable/insights-agent/README.md
@@ -24,6 +24,9 @@ In order to avoid every report consuming resources at once, you can stagger the 
 by setting the minute of the cron schedule to a random number. For example,
 to run at a random minute every hour, your cron expression can be `rand * * * *`.
 
+### Gitops Tooling and Cronjobs
+If using continuous delivery tooling to deploy insights, you should explicitly set `.Values.cronjobs.apiVersion` to ensure compatible apiVersions are used for your cluster. This is handled automatically when deploying with helm. 
+
 ## Reports
 There are several different report types which can be enabled and configured:
 * `polaris`


### PR DESCRIPTION
**Why This PR?**
Adds tip in chart readme on selecting appropriate values when using gitops tooling.


**Changes**

* readme

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
