### PR TITLE
[stable/rbac-manager] updates image.tag to 1.7 bumps chart version to 1.18

### DIFF
--- a/stable/rbac-manager/Chart.yaml
+++ b/stable/rbac-manager/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: rbac-manager
-version: 1.17.6
-appVersion: 1.6.5
+version: 1.18.0
+appVersion: 1.7.0
 kubeVersion: ">= 1.22.0-0"
 description: A Kubernetes operator that simplifies the management of Role Bindings and Service Accounts.
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/rbac-manager/icon.png

--- a/stable/rbac-manager/README.md
+++ b/stable/rbac-manager/README.md
@@ -53,7 +53,7 @@ In the above workflow, an RBAC Definition installed between revision 1 and 2 sho
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | image.repository | string | `"quay.io/reactiveops/rbac-manager"` | The image to run for rbac manager |
-| image.tag | string | `"v1.6.5"` | The tag of the image to run |
+| image.tag | string | `"v1.7.0"` | The tag of the image to run |
 | image.digest | string | `""` | The digest of the image to run |
 | image.pullPolicy | string | `"Always"` | The image pullPolicy. Recommend not changing this |
 | image.imagePullSecrets | list | `[]` |  |

--- a/stable/rbac-manager/values.yaml
+++ b/stable/rbac-manager/values.yaml
@@ -2,7 +2,7 @@ image:
   # image.repository -- The image to run for rbac manager
   repository: quay.io/reactiveops/rbac-manager
   # image.tag -- The tag of the image to run
-  tag: v1.6.5
+  tag: v1.7.0
   # image.digest -- The digest of the image to run
   digest: ""
   # image.pullPolicy -- The image pullPolicy. Recommend not changing this


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_


Fixes #
Updates the default image version to the latest release

**Changes**
Changes proposed in this pull request:

* update image tag to v1.7.0
* update chart version to 1.18.0

**Checklist:**

* [ x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [ x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [ x] Any new values are backwards compatible and/or have sensible default.
* [ x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
