### PR TITLE
FWI-2508 Add terminationGracePeriodSeconds to insights report job deployment spec

### DIFF
--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.21.0
+* Add `terminationGracePeriodSeconds` to insights report job deployment spec
+
 ## 0.20.0
 * Add `slackChannelsLocalRefresherCronjob` to `stable/fairwinds-insights`.
 

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "14.1"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 0.20.0
+version: 0.21.0
 kubeVersion: ">= 1.22.0-0"
 maintainers:
   - name: rbren

--- a/stable/fairwinds-insights/README.md
+++ b/stable/fairwinds-insights/README.md
@@ -217,6 +217,7 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | reportjob.resources.requests.memory | string | `"128Mi"` |  |
 | reportjob.nodeSelector | object | `{}` |  |
 | reportjob.tolerations | list | `[]` |  |
+| reportjob.terminationGracePeriodSeconds | int | `600` |  |
 | automatedPullRequestJob.enabled | bool | `true` |  |
 | automatedPullRequestJob.hpa.enabled | bool | `true` |  |
 | automatedPullRequestJob.hpa.min | int | `2` |  |

--- a/stable/fairwinds-insights/templates/deployment-report-job.yaml
+++ b/stable/fairwinds-insights/templates/deployment-report-job.yaml
@@ -32,6 +32,7 @@ spec:
         - name: {{ . }}
       {{- end }}
       serviceAccountName: {{ include "fairwinds-insights.fullname" . }}-insights
+      terminationGracePeriodSeconds: {{ .Values.reportjob.terminationGracePeriodSeconds }}
       containers:
         - name: fairwinds-insights
           image: "{{ .Values.apiImage.repository }}:{{ include "fairwinds-insights.apiImageTag" . }}"

--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -647,6 +647,7 @@ reportjob:
       memory: 128Mi
   nodeSelector: {}
   tolerations: []
+  terminationGracePeriodSeconds: 600
 
 automatedPullRequestJob:
   enabled: true


### PR DESCRIPTION
Fixes #FWI-1124

**Changes**

This introduces [`terminationGracePeriodSeconds`](https://cloud.google.com/blog/products/containers-kubernetes/kubernetes-best-practices-terminating-with-grace) per internal ticket FWI-2508, an enhancement which allows the insights report job to terminated gracefully after receipt of SIGINT. The scheduler should wait 10 minutes (this is our internal max processing time) before sending SIGKILL.

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
