### PR TITLE
[stable/goldilocks] Use TopologySpreadConstraint from dashboard object in dashboard deployment

### DIFF
--- a/stable/goldilocks/Chart.yaml
+++ b/stable/goldilocks/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 appVersion: "v4.9.0"
-version: 7.1.1
+version: 7.1.2
 kubeVersion: ">= 1.22.0-0"
 description: |
   A Helm chart for running Fairwinds Goldilocks. See https://github.com/FairwindsOps/goldilocks

--- a/stable/goldilocks/Chart.yaml
+++ b/stable/goldilocks/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 appVersion: "v4.10.0"
-version: 7.3.0
+version: 7.3.1
 kubeVersion: ">= 1.22.0-0"
 description: |
   A Helm chart for running Fairwinds Goldilocks. See https://github.com/FairwindsOps/goldilocks

--- a/stable/goldilocks/Chart.yaml
+++ b/stable/goldilocks/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 appVersion: "v4.9.0"
-version: 7.0.2
+version: 7.0.3
 kubeVersion: ">= 1.22.0-0"
 description: |
   A Helm chart for running Fairwinds Goldilocks. See https://github.com/FairwindsOps/goldilocks

--- a/stable/goldilocks/Chart.yaml
+++ b/stable/goldilocks/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 appVersion: "v4.9.0"
-version: 7.0.3
+version: 7.1.1
 kubeVersion: ">= 1.22.0-0"
 description: |
   A Helm chart for running Fairwinds Goldilocks. See https://github.com/FairwindsOps/goldilocks

--- a/stable/goldilocks/ci/test-values.yaml
+++ b/stable/goldilocks/ci/test-values.yaml
@@ -29,6 +29,13 @@ controller:
           - "watch"
     extraClusterRoleBindings:
       - view
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: DoNotSchedule
+      labelSelector:
+        matchLabels:
+          app: controller
 
 dashboard:
   basePath: goldilocks
@@ -46,7 +53,7 @@ dashboard:
       whenUnsatisfiable: DoNotSchedule
       labelSelector:
         matchLabels:
-          app: alertmanager
+          app: dashboard
   deployment:
     additionalLabels:
       test: value

--- a/stable/goldilocks/ci/test-values.yaml
+++ b/stable/goldilocks/ci/test-values.yaml
@@ -32,7 +32,7 @@ controller:
   topologySpreadConstraints:
     - maxSkew: 1
       topologyKey: topology.kubernetes.io/zone
-      whenUnsatisfiable: DoNotSchedule
+      whenUnsatisfiable: ScheduleAnyway
       labelSelector:
         matchLabels:
           app: controller
@@ -50,7 +50,7 @@ dashboard:
   topologySpreadConstraints:
     - maxSkew: 1
       topologyKey: topology.kubernetes.io/zone
-      whenUnsatisfiable: DoNotSchedule
+      whenUnsatisfiable: ScheduleAnyway
       labelSelector:
         matchLabels:
           app: dashboard

--- a/stable/goldilocks/ci/test-values.yaml
+++ b/stable/goldilocks/ci/test-values.yaml
@@ -31,7 +31,7 @@ controller:
       - view
   topologySpreadConstraints:
     - maxSkew: 1
-      topologyKey: topology.kubernetes.io/zone
+      topologyKey: kubernetes.io/hostname
       whenUnsatisfiable: ScheduleAnyway
       labelSelector:
         matchLabels:
@@ -49,7 +49,7 @@ dashboard:
   replicaCount: 2
   topologySpreadConstraints:
     - maxSkew: 1
-      topologyKey: topology.kubernetes.io/zone
+      topologyKey: kubernetes.io/hostname
       whenUnsatisfiable: ScheduleAnyway
       labelSelector:
         matchLabels:

--- a/stable/goldilocks/ci/test-values.yaml
+++ b/stable/goldilocks/ci/test-values.yaml
@@ -35,7 +35,7 @@ controller:
       whenUnsatisfiable: ScheduleAnyway
       labelSelector:
         matchLabels:
-          app: controller
+          app.kubernetes.io/component: controller
 
 dashboard:
   basePath: goldilocks
@@ -53,7 +53,7 @@ dashboard:
       whenUnsatisfiable: ScheduleAnyway
       labelSelector:
         matchLabels:
-          app: dashboard
+          app.kubernetes.io/component: dashboard
   deployment:
     additionalLabels:
       test: value

--- a/stable/goldilocks/ci/test-values.yaml
+++ b/stable/goldilocks/ci/test-values.yaml
@@ -29,13 +29,6 @@ controller:
           - "watch"
     extraClusterRoleBindings:
       - view
-  topologySpreadConstraints:
-    - maxSkew: 1
-      topologyKey: kubernetes.io/hostname
-      whenUnsatisfiable: ScheduleAnyway
-      labelSelector:
-        matchLabels:
-          app.kubernetes.io/component: controller
 
 dashboard:
   basePath: goldilocks
@@ -47,13 +40,6 @@ dashboard:
           - path: /
             type: ImplementationSpecific
   replicaCount: 2
-  topologySpreadConstraints:
-    - maxSkew: 2
-      topologyKey: kubernetes.io/hostname
-      whenUnsatisfiable: ScheduleAnyway
-      labelSelector:
-        matchLabels:
-          app.kubernetes.io/component: dashboard
   deployment:
     additionalLabels:
       test: value

--- a/stable/goldilocks/ci/test-values.yaml
+++ b/stable/goldilocks/ci/test-values.yaml
@@ -48,7 +48,7 @@ dashboard:
             type: ImplementationSpecific
   replicaCount: 2
   topologySpreadConstraints:
-    - maxSkew: 1
+    - maxSkew: 2
       topologyKey: kubernetes.io/hostname
       whenUnsatisfiable: ScheduleAnyway
       labelSelector:

--- a/stable/goldilocks/templates/dashboard-deployment.yaml
+++ b/stable/goldilocks/templates/dashboard-deployment.yaml
@@ -99,7 +99,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- with .Values.controller.topologySpreadConstraints }}
+    {{- with .Values.dashboard.topologySpreadConstraints }}
       topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
     {{- end }}


### PR DESCRIPTION
**Why This PR?**
_The Goldilocks chart currently uses the `controller` TopologySpreadConstraints for the `dashboard` Deployment. It does not allow for unique component values in the TSC labelSelector._

Fixes #

**Changes**
Changes proposed in this pull request:

* Use the `dashboard` TopologySpreadConstraint in the `dashboard` Deployment template.

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
