### PR TITLE
[stable/goldilocks] Update securityContext defaults

### DIFF
--- a/stable/goldilocks/Chart.yaml
+++ b/stable/goldilocks/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 appVersion: "v4.10.0"
-version: 7.3.0
+version: 7.3.1
 kubeVersion: ">= 1.22.0-0"
 description: |
   A Helm chart for running Fairwinds Goldilocks. See https://github.com/FairwindsOps/goldilocks

--- a/stable/goldilocks/README.md
+++ b/stable/goldilocks/README.md
@@ -85,7 +85,7 @@ This will completely remove the VPA and then re-install it using the new method.
 | controller.affinity | object | `{}` | Affinity for the controller pods |
 | controller.topologySpreadConstraints | list | `[]` | Topology spread constraints for the controller pods |
 | controller.resources | object | `{"limits":{},"requests":{"cpu":"25m","memory":"256Mi"}}` | The resources block for the controller pods |
-| controller.podSecurityContext | object | `{}` | Defines the podSecurityContext for the controller pod |
+| controller.podSecurityContext | object | `{"seccompProfile":{"type":"RuntimeDefault"}}` | Defines the podSecurityContext for the controller pod |
 | controller.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":10324}` | The container securityContext for the controller container |
 | controller.deployment.extraVolumeMounts | list | `[]` | Extra volume mounts for the controller container |
 | controller.deployment.extraVolumes | list | `[]` | Extra volumes for the controller pod |
@@ -119,7 +119,7 @@ This will completely remove the VPA and then re-install it using the new method.
 | dashboard.ingress.hosts[0].paths[0].type | string | `"ImplementationSpecific"` |  |
 | dashboard.ingress.tls | list | `[]` |  |
 | dashboard.resources | object | `{"limits":{},"requests":{"cpu":"25m","memory":"256Mi"}}` | A resources block for the dashboard. |
-| dashboard.podSecurityContext | object | `{}` | Defines the podSecurityContext for the dashboard pod |
+| dashboard.podSecurityContext | object | `{"seccompProfile":{"type":"RuntimeDefault"}}` | Defines the podSecurityContext for the dashboard pod |
 | dashboard.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":10324}` | The container securityContext for the dashboard container |
 | dashboard.nodeSelector | object | `{}` |  |
 | dashboard.tolerations | list | `[]` |  |

--- a/stable/goldilocks/values.yaml
+++ b/stable/goldilocks/values.yaml
@@ -66,7 +66,9 @@ controller:
       cpu: 25m
       memory: 256Mi
   # controller.podSecurityContext -- Defines the podSecurityContext for the controller pod
-  podSecurityContext: {}
+  podSecurityContext:
+    seccompProfile:
+      type: RuntimeDefault
   # controller.securityContext -- The container securityContext for the controller container
   securityContext:
     readOnlyRootFilesystem: true
@@ -163,7 +165,9 @@ dashboard:
       cpu: 25m
       memory: 256Mi
   # dashboard.podSecurityContext -- Defines the podSecurityContext for the dashboard pod
-  podSecurityContext: {}
+  podSecurityContext:
+    seccompProfile:
+      type: RuntimeDefault
   # dashboard.securityContext -- The container securityContext for the dashboard container
   securityContext:
     readOnlyRootFilesystem: true


### PR DESCRIPTION
**Why This PR?**
We run Kyverno on our clusters which alerts if the various securityContext settings aren't explicitly configured. Your Helm chart allows me to set/override these, but before I push this out to more clusters I figured it would be easier if the chart defaults were just updated.

**Changes**
Changes proposed in this pull request:

* Update `controller.podSecurityContext` defaults to include `seccompProfile`.
* Update `dashboard.podSecurityContext` defaults to include `seccompProfile`.

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
