### PR TITLE
[stable/insights-agent] fix rbac for opa

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.24.3
+* Fix for adding additional rules for OPA via insights-admission
+
 ## 2.24.2
 * bump `pluto` to version 5.18
 

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.24.2
+version: 2.24.3
 appVersion: 9.2.1
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png

--- a/stable/insights-agent/ci/test-values.yaml
+++ b/stable/insights-agent/ci/test-values.yaml
@@ -110,6 +110,32 @@ prometheus:
 admission:
   enabled: true
 
+insights-admission:
+  webhookConfig:
+    failurePolicy: Ignore
+    rules:
+    - apiGroups:
+      - ""
+      apiVersions:
+      - "v1"
+      operations:
+      - CREATE
+      - UPDATE
+      - DELETE
+      resources:
+      - namespaces
+      scope: Cluster
+    - apiGroups:
+      - apps
+      apiVersions:
+      - "v1"
+      operations:
+      - DELETE
+      resources:
+      - deployments
+      - statefulsets
+      scope: Cluster
+
 awscosts:
   enabled: false
   secretName: awscosts-secret

--- a/stable/insights-agent/templates/opa/rbac.yaml
+++ b/stable/insights-agent/templates/opa/rbac.yaml
@@ -87,8 +87,8 @@ metadata:
   name: {{ include "insights-agent.fullname" $ }}-opa-admission-targetresources
   labels:
     app: insights-agent
-{{- range $AdmissionValues.webhookConfig.rules }}
 rules:
+{{- range $AdmissionValues.webhookConfig.rules }}
 - apiGroups:
 {{ toYaml .apiGroups | indent 2 }}
   resources:


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_
OPA is creating a duplicate `rules` block

Fixes https://github.com/FairwindsOps/charts/issues/1348

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
