### PR TITLE
[stable/polaris] Add default PDBs to the dashboard and webhook

### DIFF
--- a/stable/polaris/CHANGELOG.md
+++ b/stable/polaris/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this Helm chart will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this chart adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 5.16.0
+* Added default PDBs for both the webhook and the dashboard
+
 ## 5.15.0
 
 * Support `string` type of `config` value

--- a/stable/polaris/Chart.yaml
+++ b/stable/polaris/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Validation of best practices in your Kubernetes clusters
 name: polaris
-version: 5.15.0
+version: 5.16.0
 appVersion: "8.5"
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/polaris/master/pkg/dashboard/assets/favicon-32x32.png

--- a/stable/polaris/README.md
+++ b/stable/polaris/README.md
@@ -75,6 +75,7 @@ the 0.10.0 version of this chart will only work on kubernetes 1.14.0+
 | dashboard.disallowConfigExemptions | bool | `false` | Disallow exemptions that are configured in the config file |
 | dashboard.disallowAnnotationExemptions | bool | `false` | Disallow exemptions that are configured via annotations |
 | dashboard.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true,"runAsNonRoot":true}` | securityContext to apply to the dashboard container |
+| dashboard.pdb.enable | bool | `true` | If true, enables a PDB for the dashboard |
 | webhook.enable | bool | `false` | Whether to run the webhook |
 | webhook.validate | bool | `true` | Enables the Validating Webhook, to reject resources with issues |
 | webhook.mutate | bool | `false` | Enables the Mutating Webhook, to modify resources with issues |
@@ -103,6 +104,7 @@ the 0.10.0 version of this chart will only work on kubernetes 1.14.0+
 | webhook.disallowAnnotationExemptions | bool | `false` | Disallow exemptions that are configured via annotations |
 | webhook.mutatingConfigurationAnnotations | object | `{}` |  |
 | webhook.validatingConfigurationAnnotations | object | `{}` |  |
+| webhook.pdb.enable | bool | `true` | If true, enables a PDB for the webhook |
 | audit.enable | bool | `false` | Runs a one-time audit. This is used internally at Fairwinds, and may not be useful for others. |
 | audit.cleanup | bool | `false` | Whether to delete the namespace once the audit is finished. |
 | audit.outputURL | string | `""` | A URL which will receive a POST request with audit results. |

--- a/stable/polaris/templates/dashboard.pdb.yaml
+++ b/stable/polaris/templates/dashboard.pdb.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.dashboard.enable -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "polaris.fullname" . }}-dashboard
+  {{- if .Values.templateOnly }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
+  labels:
+    {{- include "polaris.labels" . | nindent 4 }}
+    component: dashboard
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      {{- include "polaris.selectors" . | nindent 6 }}
+      component: dashboard
+{{- end }}

--- a/stable/polaris/templates/dashboard.pdb.yaml
+++ b/stable/polaris/templates/dashboard.pdb.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.dashboard.enable -}}
+{{- if and .Values.dashboard.enable .Values.dashboard.pdb.enable -}}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:

--- a/stable/polaris/templates/dashboard.pdb.yaml
+++ b/stable/polaris/templates/dashboard.pdb.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.dashboard.pdb }}
 {{- if and .Values.dashboard.enable .Values.dashboard.pdb.enable -}}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
@@ -15,4 +16,5 @@ spec:
     matchLabels:
       {{- include "polaris.selectors" . | nindent 6 }}
       component: dashboard
+{{- end }}
 {{- end }}

--- a/stable/polaris/templates/webhook.pdb.yaml
+++ b/stable/polaris/templates/webhook.pdb.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.webhook.pdb }}
 {{- if and .Values.webhook.enable .Values.webhook.pdb.enable -}}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
@@ -15,4 +16,5 @@ spec:
     matchLabels:
       {{- include "polaris.selectors" . | nindent 6 }}
       component: webhook
+{{- end }}
 {{- end }}

--- a/stable/polaris/templates/webhook.pdb.yaml
+++ b/stable/polaris/templates/webhook.pdb.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.webhook.enable -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "polaris.fullname" . }}-webhook
+  {{- if .Values.templateOnly }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
+  labels:
+    {{- include "polaris.labels" . | nindent 4 }}
+    component: webhook
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      {{- include "polaris.selectors" . | nindent 6 }}
+      component: webhook
+{{- end }}

--- a/stable/polaris/templates/webhook.pdb.yaml
+++ b/stable/polaris/templates/webhook.pdb.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.webhook.enable -}}
+{{- if and .Values.webhook.enable .Values.webhook.pdb.enable -}}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:

--- a/stable/polaris/values.yaml
+++ b/stable/polaris/values.yaml
@@ -129,6 +129,9 @@ dashboard:
     capabilities:
       drop:
         - ALL
+  pdb:
+    # -- If true, enables a PDB for the dashboard
+    enable: true
 
 webhook:
   # webhook.enable -- Whether to run the webhook
@@ -244,6 +247,9 @@ webhook:
   disallowAnnotationExemptions: false
   mutatingConfigurationAnnotations: {}
   validatingConfigurationAnnotations: {}
+  pdb:
+    # -- If true, enables a PDB for the webhook
+    enable: true
 
 audit:
   # audit.enable -- Runs a one-time audit. This is used internally at Fairwinds, and may not be useful for others.


### PR DESCRIPTION
**Why This PR?**
We were failing our own recommendations to have a PDB

**Changes**
Changes proposed in this pull request:

* Add default PDBs to the webhook and dashboard

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.