### PR TITLE
[stable/astro] Allow cluster_variables to reference other variables via tpl

### DIFF
--- a/stable/astro/Chart.yaml
+++ b/stable/astro/Chart.yaml
@@ -1,5 +1,5 @@
 name: astro
-version: 1.0.13
+version: 1.0.14
 apiVersion: v1
 appVersion: "1.5.3"
 kubeVersion: ">= 1.22.0-0"

--- a/stable/astro/templates/configmap-data.yaml
+++ b/stable/astro/templates/configmap-data.yaml
@@ -9,5 +9,13 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 data:
-  config.yml: {{ toYaml .Values.custom_config.data | indent 4 }}
+  config.yml: |
+{{- range $key, $value := (fromYaml .Values.custom_config.data) }}
+    {{ $key }}:
+{{- if eq $key "cluster_variables" }}
+{{ tpl (toYaml $value) $ | indent 8 }}
+{{- else }}
+{{ toYaml $value | indent 8 }}
+{{- end }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
**Why This PR?**
Cluster variables provide an easy way to pass in extra data to filter on (ie, environment name), but currently there is no way to pass those in from the command line since we can't run `rulesets` through tpl. This means that at the moment you need a values file for each environment that contains only different `cluster_variables`.

**Changes**
Changes proposed in this pull request:

* Parse the `cluster_variables` and `rulesets` sections separately so that the former can be run through tpl.

**Other Options**

* One other way I could see doing this would be to parse `strings` and `maps` differently, so if the user set data as a string it would have the current functionality but a map would do the new functionality. My concern here is that someone could unintentionally do one or the other and it may be confusing.
* Have a flag to declare that you want this functionality.
* Use something completely different than the `data` section for this functionality.

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
