### PR TITLE
[stable/rbac-manager] Add option to add relabelings to serviceMonitor

### DIFF
--- a/stable/rbac-manager/Chart.yaml
+++ b/stable/rbac-manager/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rbac-manager
-version: 1.18.0
+version: 1.18.1
 appVersion: 1.7.0
 kubeVersion: ">= 1.22.0-0"
 description: A Kubernetes operator that simplifies the management of Role Bindings and Service Accounts.

--- a/stable/rbac-manager/Chart.yaml
+++ b/stable/rbac-manager/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rbac-manager
-version: 1.18.1
+version: 1.19.0
 appVersion: 1.7.0
 kubeVersion: ">= 1.22.0-0"
 description: A Kubernetes operator that simplifies the management of Role Bindings and Service Accounts.

--- a/stable/rbac-manager/README.md
+++ b/stable/rbac-manager/README.md
@@ -76,3 +76,4 @@ In the above workflow, an RBAC Definition installed between revision 1 and 2 sho
 | serviceMonitor.annotations | object | `{}` | Annotations to apply to the serviceMonitor and headless service |
 | serviceMonitor.namespace | string | `""` | The namespace to deploy the serviceMonitor into |
 | serviceMonitor.interval | string | `"60s"` | How often to scrape the metrics endpoint |
+| serviceMonitor.relabelings | list | `[]` | RelabelConfigs to apply to samples before scraping |

--- a/stable/rbac-manager/templates/servicemonitor.yaml
+++ b/stable/rbac-manager/templates/servicemonitor.yaml
@@ -24,6 +24,10 @@ spec:
   - interval: {{ .Values.serviceMonitor.interval }}
     port: metrics
     path: /metrics
+    {{- with .Values.serviceMonitor.relabelings }}
+    relabelings:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
   selector:
     matchLabels:
       app: {{ template "rbac-manager.name" . }}

--- a/stable/rbac-manager/values.yaml
+++ b/stable/rbac-manager/values.yaml
@@ -76,3 +76,5 @@ serviceMonitor:
   namespace: ""
   # serviceMonitor.interval -- How often to scrape the metrics endpoint
   interval: 60s
+  # serviceMonitor.relabelings -- RelabelConfigs to apply to samples before scraping
+  relabelings: []


### PR DESCRIPTION
**Why This PR?**
- Adding use-case for relabelings for serviceMonitor. [Reference](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config)

**Changes**
Changes proposed in this pull request:

- Add `relabelings` List to `rbac-manager` chart

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
