### PR TITLE
[stable/goldilocks] Update vpa chart

### DIFF
--- a/stable/goldilocks/Chart.lock
+++ b/stable/goldilocks/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: vpa
   repository: https://charts.fairwinds.com/stable
-  version: 2.5.1
+  version: 3.0.2
 - name: metrics-server
   repository: https://charts.bitnami.com/bitnami
   version: 6.4.1
-digest: sha256:358718baff45656e3b4a9fa0cddb5c17717041839542aa223620002e55e5ce26
-generated: "2023-09-05T15:36:02.054719-06:00"
+digest: sha256:7a923abb2a353b828b45e0ae502ac0bb21b009312490ff7f4b50aebc9a29bea0
+generated: "2023-10-27T11:14:25.826905956+09:00"

--- a/stable/goldilocks/Chart.yaml
+++ b/stable/goldilocks/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 appVersion: "v4.10.0"
-version: 7.3.2
+version: 8.0.0
 kubeVersion: ">= 1.22.0-0"
 description: |
   A Helm chart for running Fairwinds Goldilocks. See https://github.com/FairwindsOps/goldilocks

--- a/stable/goldilocks/Chart.yaml
+++ b/stable/goldilocks/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 appVersion: "v4.10.0"
-version: 7.3.1
+version: 7.3.2
 kubeVersion: ">= 1.22.0-0"
 description: |
   A Helm chart for running Fairwinds Goldilocks. See https://github.com/FairwindsOps/goldilocks
@@ -16,7 +16,7 @@ keywords:
   - kubernetes
 dependencies:
   - name: vpa
-    version: 2.5.*
+    version: 3.0.*
     repository: https://charts.fairwinds.com/stable
     condition: vpa.enabled
   - name: metrics-server


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

relates to:

- https://github.com/FairwindsOps/charts/pull/1325
- https://github.com/FairwindsOps/charts/pull/1327
- https://github.com/FairwindsOps/charts/pull/1354

**Changes**
Changes proposed in this pull request:

* Update vpa chart 2.5.1 -> 3.0.2

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
