### PR TITLE
[stable/insights-agent] Add ingresses resource to defaultTargetResources in values.yaml

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.24.4
+* Added ingresses resource to `defaultTargetResources`
+
 ## 2.24.3
 * Fix for adding additional rules for OPA via insights-admission
 
@@ -7,7 +10,7 @@
 * bump `pluto` to version 5.18
 
 ## 2.24.1
-* bump `insights-admission` to version '1.9.*' in requirements.yaml 
+* bump `insights-admission` to version '1.9.*' in requirements.yaml
 
 ## 2.24.0
 * Bumped `opa` plugin version to `2.3`
@@ -223,7 +226,7 @@ only available as of 1.22.
 * Support arm64 architecture (CronJob executor and insights-plugins)
 
 ## 2.6.11
-* Update `nova` version to `v3.4` 
+* Update `nova` version to `v3.4`
 * Use `nova find --helm --containers` to run `nova` - This way, both outdated/deprecated charts and containers will be reported to the output file
 
 ## 2.6.10

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.24.3
+version: 2.24.4
 appVersion: 9.2.1
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -179,6 +179,10 @@ opa:
     resources:
     - pods
     - replicationcontrollers
+  - apiGroups:
+    - networking.k8s.io
+    resources:
+    - ingresses
   # opa.admissionRulesAsTargetResources -- If the admission controller is enabled,
   # the APIGroups and Resources found in insights-admission `webhookConfig.rules`
   # will be added as OPA Kubernetes target resources, plus


### PR DESCRIPTION
**Why This PR?**
Ingress resources should be part of the default standard objects that insights can observe for policy management. 

Fixes #

**Changes**
Changes proposed in this pull request:

* Add ingresses object and networking.k8s.io apigroup to `defaultTargetResources` in values.yaml

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
