### PR TITLE
[stable/fairwinds-insights] add option for hostname max length

### DIFF
--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.21.8
+* Allow up to 17 chars in the URL prefix
+
 ## 0.21.7
 * Update application version to 14.7. [See the release notes for more details](https://insights.docs.fairwinds.com/release-notes)
 

--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 0.21.8
-* Allow up to 17 chars in the URL prefix
+* Allow additional chars in the URL prefix
 
 ## 0.21.7
 * Update application version to 14.7. [See the release notes for more details](https://insights.docs.fairwinds.com/release-notes)

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "14.7"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 0.21.7
+version: 0.21.8
 kubeVersion: ">= 1.22.0-0"
 maintainers:
   - name: rbren

--- a/stable/fairwinds-insights/README.md
+++ b/stable/fairwinds-insights/README.md
@@ -127,6 +127,7 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | service.type | string | `"ClusterIP"` | Service type for the API and Dashboard services |
 | service.annotations | string | `nil` | Annotations for the services |
 | sanitizedBranch | string | `nil` | Prefix to use on hostname. Generally not needed. |
+| sanitizedPrefixMaxLength | int | `12` | Maximum length for hostname prefix. |
 | ingress.enabled | bool | `false` | Enable Ingress |
 | ingress.tls | bool | `true` | Enable TLS |
 | ingress.hostedZones | list | `[]` | Hostnames to use for Ingress |

--- a/stable/fairwinds-insights/templates/_helpers.tpl
+++ b/stable/fairwinds-insights/templates/_helpers.tpl
@@ -33,7 +33,7 @@ Create chart name and version as used by the chart label.
 
 {{- define "fairwinds-insights.sanitizedPrefix" -}}
 {{- if .Values.sanitizedBranch -}}
-{{- printf "%s." (.Values.sanitizedBranch | trunc .Values.sanitizedPrefixMaxLength | trimSuffix "-") -}}
+{{- printf "%s." (.Values.sanitizedBranch | trunc (int .Values.sanitizedPrefixMaxLength) | trimSuffix "-") -}}
 {{- end -}}
 {{- end -}}
 

--- a/stable/fairwinds-insights/templates/_helpers.tpl
+++ b/stable/fairwinds-insights/templates/_helpers.tpl
@@ -33,7 +33,7 @@ Create chart name and version as used by the chart label.
 
 {{- define "fairwinds-insights.sanitizedPrefix" -}}
 {{- if .Values.sanitizedBranch -}}
-{{- printf "%s." (.Values.sanitizedBranch | trunc 17 | trimSuffix "-") -}}
+{{- printf "%s." (.Values.sanitizedBranch | trunc .Values.sanitizedPrefixMaxLength | trimSuffix "-") -}}
 {{- end -}}
 {{- end -}}
 

--- a/stable/fairwinds-insights/templates/_helpers.tpl
+++ b/stable/fairwinds-insights/templates/_helpers.tpl
@@ -33,7 +33,7 @@ Create chart name and version as used by the chart label.
 
 {{- define "fairwinds-insights.sanitizedPrefix" -}}
 {{- if .Values.sanitizedBranch -}}
-{{- printf "%s." (.Values.sanitizedBranch | trunc 12 | trimSuffix "-") -}}
+{{- printf "%s." (.Values.sanitizedBranch | trunc 17 | trimSuffix "-") -}}
 {{- end -}}
 {{- end -}}
 

--- a/stable/fairwinds-insights/templates/_helpers.tpl
+++ b/stable/fairwinds-insights/templates/_helpers.tpl
@@ -33,7 +33,7 @@ Create chart name and version as used by the chart label.
 
 {{- define "fairwinds-insights.sanitizedPrefix" -}}
 {{- if .Values.sanitizedBranch -}}
-{{- printf "%s." (.Values.sanitizedBranch | trunc (int .Values.sanitizedPrefixMaxLength) | trimSuffix "-") -}}
+{{- printf "%s." (.Values.sanitizedBranch | trunc (int .Values.sanitizedPrefixMaxLength | default 12) | trimSuffix "-") -}}
 {{- end -}}
 {{- end -}}
 

--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -433,6 +433,9 @@ service:
 # -- Prefix to use on hostname. Generally not needed.
 sanitizedBranch:
 
+# -- Maximum length for hostname prefix.
+sanitizedPrefixMaxLength: 12
+
 ingress:
   # -- Enable Ingress
   enabled: false


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Some of our URLs are getting truncated too aggressively.

We dropped to [12 characters a couple years ago](https://github.com/FairwindsOps/charts/pull/616), but unclear what the reason was.

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
