### PR TITLE
[stable/goldilocks] Remove `if` around revisionHistoryLimit

### DIFF
--- a/stable/goldilocks/Chart.yaml
+++ b/stable/goldilocks/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 appVersion: "v4.10.0"
-version: 8.0.0
+version: 8.0.1
 kubeVersion: ">= 1.22.0-0"
 description: |
   A Helm chart for running Fairwinds Goldilocks. See https://github.com/FairwindsOps/goldilocks

--- a/stable/goldilocks/templates/controller-deployment.yaml
+++ b/stable/goldilocks/templates/controller-deployment.yaml
@@ -19,9 +19,7 @@ metadata:
   {{- end }}
 spec:
   replicas: 1
-  {{- if .Values.controller.revisionHistoryLimit }}
   revisionHistoryLimit: {{ .Values.controller.revisionHistoryLimit }}
-  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "goldilocks.name" . }}

--- a/stable/goldilocks/templates/dashboard-deployment.yaml
+++ b/stable/goldilocks/templates/dashboard-deployment.yaml
@@ -19,9 +19,7 @@ metadata:
   {{- end }}
 spec:
   replicas: {{ .Values.dashboard.replicaCount }}
-  {{- if .Values.dashboard.revisionHistoryLimit }}
   revisionHistoryLimit: {{ .Values.dashboard.revisionHistoryLimit }}
-  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "goldilocks.name" . }}


### PR DESCRIPTION
**Why This PR?**
Setting `revisionHistoryLimit` to 0 prevents anything being templated as 0 is considered false.

**Changes**
Changes proposed in this pull request:

* Remove the surrounding `if` condition

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
