### PR TITLE
[stable/vpa] Remove `if` around revisionHistoryLimit

### DIFF
--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 4.0.1
+version: 4.0.2
 appVersion: 1.0.0
 maintainers:
   - name: sudermanjr

--- a/stable/vpa/templates/admission-controller-deployment.yaml
+++ b/stable/vpa/templates/admission-controller-deployment.yaml
@@ -12,9 +12,7 @@ metadata:
     {{- include "vpa.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.admissionController.replicaCount }}
-  {{- if .Values.admissionController.revisionHistoryLimit }}
   revisionHistoryLimit: {{ .Values.admissionController.revisionHistoryLimit }}
-  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/component: admission-controller

--- a/stable/vpa/templates/recommender-deployment.yaml
+++ b/stable/vpa/templates/recommender-deployment.yaml
@@ -12,9 +12,7 @@ metadata:
     {{- include "vpa.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.recommender.replicaCount }}
-  {{- if .Values.recommender.revisionHistoryLimit }}
   revisionHistoryLimit: {{ .Values.recommender.revisionHistoryLimit }}
-  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/component: recommender

--- a/stable/vpa/templates/updater-deployment.yaml
+++ b/stable/vpa/templates/updater-deployment.yaml
@@ -12,9 +12,7 @@ metadata:
     {{- include "vpa.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.updater.replicaCount }}
-  {{- if .Values.updater.revisionHistoryLimit }}
   revisionHistoryLimit: {{ .Values.updater.revisionHistoryLimit }}
-  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/component: updater


### PR DESCRIPTION
**Why This PR?**
Setting `revisionHistoryLimit` to 0 prevents anything being templated as 0 is considered false.

**Changes**
Changes proposed in this pull request:

* Remove the surrounding `if` condition

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
