### PR TITLE
[stable/vpa] add namespace in deployments

### DIFF
--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 3.0.2
+version: 3.0.3
 appVersion: 0.14.0
 maintainers:
   - name: sudermanjr

--- a/stable/vpa/templates/admission-controller-deployment.yaml
+++ b/stable/vpa/templates/admission-controller-deployment.yaml
@@ -7,6 +7,7 @@ metadata:
   {{- .Values.admissionController.annotations | toYaml | nindent 4 }}
   {{- end }}
   name: {{ include "vpa.fullname" . }}-admission-controller
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: admission-controller
     {{- include "vpa.labels" . | nindent 4 }}

--- a/stable/vpa/templates/admission-controller-service-account.yaml
+++ b/stable/vpa/templates/admission-controller-service-account.yaml
@@ -4,6 +4,7 @@ kind: ServiceAccount
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 metadata:
   name: {{ include "vpa.serviceAccountName" . }}-admission-controller
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "vpa.labels" . | nindent 4 }}
     app.kubernetes.io/component: admission-controller

--- a/stable/vpa/templates/recommender-deployment.yaml
+++ b/stable/vpa/templates/recommender-deployment.yaml
@@ -7,6 +7,7 @@ metadata:
   {{- .Values.recommender.annotations | toYaml | nindent 4 }}
   {{- end }}
   name: {{ include "vpa.fullname" . }}-recommender
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: recommender
     {{- include "vpa.labels" . | nindent 4 }}

--- a/stable/vpa/templates/recommender-service-account.yaml
+++ b/stable/vpa/templates/recommender-service-account.yaml
@@ -4,6 +4,7 @@ kind: ServiceAccount
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 metadata:
   name: {{ include "vpa.serviceAccountName" . }}-recommender
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "vpa.labels" . | nindent 4 }}
     app.kubernetes.io/component: recommender

--- a/stable/vpa/templates/updater-deployment.yaml
+++ b/stable/vpa/templates/updater-deployment.yaml
@@ -7,6 +7,7 @@ metadata:
   {{- .Values.updater.annotations | toYaml | nindent 4 }}
   {{- end }}
   name: {{ include "vpa.fullname" . }}-updater
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: updater
     {{- include "vpa.labels" . | nindent 4 }}

--- a/stable/vpa/templates/updater-service-account.yaml
+++ b/stable/vpa/templates/updater-service-account.yaml
@@ -4,6 +4,7 @@ kind: ServiceAccount
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 metadata:
   name: {{ include "vpa.serviceAccountName" . }}-updater
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "vpa.labels" . | nindent 4 }}
     app.kubernetes.io/component: updater

--- a/stable/vpa/templates/webhooks/jobs/certgen-sa.yaml
+++ b/stable/vpa/templates/webhooks/jobs/certgen-sa.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "vpa.fullname" . }}-admission-certgen
+  namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded


### PR DESCRIPTION
**Why This PR?**
For usage VPA as subchart (e.g. goldilocks) when helm is used just as renderer (we use qbec for that) we need to render namespace in metadata. Currently (NO "namespace:" in deployment's metadata) namespaced objects may be created in some random ("default" in case of qbec) namespace, so RBAC is broken.

Fixes #

**Changes**
Changes proposed in this pull request:

* Render release's namespace in all deployment objects
* Bump up VPA chart version (patchversion)

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [ ] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
