### PR TITLE
[stable/insights-agent] set ttl for install reporter

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.25.0
+* Add TTL option for install-reporter to better support Argo deployment
+
 ## 2.24.5
 * Bumped `polaris` plugin version to `8.5`
 

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.24.5
+version: 2.25.0
 appVersion: 9.2.1
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png

--- a/stable/insights-agent/README.md
+++ b/stable/insights-agent/README.md
@@ -75,6 +75,7 @@ Parameter | Description | Default
 `uploader.resources` | CPU/memory requests and limits for the uploader script |
 `uploader.sendFailures` | Send logs of failure to Insights when a job fails. | true
 `uploader.env` | Set extra environment variables for the uploader script | []
+`installReporter.ttl` | Set to -1 to prevent install reporter job from cleaning up after itself | 300
 `cronjobs.disableServiceMesh` | Adds annotations to all CronJobs to not inject Linkerd or Istio | true
 `cronjobs.backoffLimit` | Backoff limit to use for each report CronJob | 1
 `cronjobs.imagePullSecret` | A pull secret for cronjob images

--- a/stable/insights-agent/templates/install-reporter/job.yaml
+++ b/stable/insights-agent/templates/install-reporter/job.yaml
@@ -8,11 +8,17 @@ metadata:
     polaris.fairwinds.com/memoryLimitsMissing-exempt: "true"
     polaris.fairwinds.com/cpuLimitsMissing-exempt: "true"
     "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+    {{- $values := .Values | deepCopy }}
+    {{- $_ := unset $values "insights" }}
+    {{- $out := dict "values" $values "version" .Chart.Version }}
+    insights.fairwinds.com/values-hash: "{{- toPrettyJson $out | sha256sum }}"
   {{- with .Values.installReporter.additionalAnnotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if gt (int .Values.installReporter.ttl) 0 }}
   ttlSecondsAfterFinished: 300
+  {{- end }}
   backoffLimit: {{ .Values.cronjobs.backoffLimit }}
   template:
     {{- with .Values.global.customWorkloadAnnotations }}

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -63,6 +63,7 @@ cronjobExecutor:
       memory: 128Mi
 
 installReporter:
+  ttl: 300
   image:
     repository: quay.io/fairwinds/insights-uploader
     tag: "0.4"


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

install-reporter repeatedly runs when deployed with Argo, because the job cleans up after itself

**Changes**
Changes proposed in this pull request:
* Add a `ttl` option, which can be set to -1 to avoid cleanup
* Add a hash to the job which changes when any values or chart version changes, causing the job to re-create

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
