### PR TITLE
[stable/insights-agent] Cloud Cost plugin fixes

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.25.1
+* Cloud costs plugin bug fix
+
 ## 2.25.0
 * Added cloud costs plugin
 

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.25.0
+version: 2.25.1
 appVersion: 9.2.1
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png

--- a/stable/insights-agent/templates/cloud-costs/secret.yaml
+++ b/stable/insights-agent/templates/cloud-costs/secret.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.cloudcosts .Values.cloudcosts.enabled -}}
-{{ if .Values.cloudcosts.aws.accessKeyId }}
+{{ if and .Values.cloudcosts.aws .Values.cloudcosts.aws.accessKeyId }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,7 +9,7 @@ data:
   AWS_ACCESS_KEY_ID: {{ .Values.cloudcosts.aws.accessKeyId | b64enc}}
   AWS_SECRET_ACCESS_KEY: {{ .Values.cloudcosts.aws.secretAccessKey | b64enc }}
 {{ end }}
-{{ if .Values.cloudcosts.gcp.applicationCredentials }}
+{{ if and Values.cloudcosts.gcp .Values.cloudcosts.gcp.applicationCredentials }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/stable/insights-agent/templates/cloud-costs/secret.yaml
+++ b/stable/insights-agent/templates/cloud-costs/secret.yaml
@@ -9,7 +9,7 @@ data:
   AWS_ACCESS_KEY_ID: {{ .Values.cloudcosts.aws.accessKeyId | b64enc}}
   AWS_SECRET_ACCESS_KEY: {{ .Values.cloudcosts.aws.secretAccessKey | b64enc }}
 {{ end }}
-{{ if and Values.cloudcosts.gcp .Values.cloudcosts.gcp.applicationCredentials }}
+{{ if and .Values.cloudcosts.gcp .Values.cloudcosts.gcp.applicationCredentials }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/stable/insights-agent/templates/rbac.yaml
+++ b/stable/insights-agent/templates/rbac.yaml
@@ -103,4 +103,9 @@ subjects:
   name: {{ include "insights-agent.fullname" . }}-awscosts
   namespace: {{ .Release.Namespace }}
 {{- end }}
+{{- if (index .Values "cloudcosts" "enabled") }}
+- kind: ServiceAccount
+  name: {{ include "insights-agent.fullname" . }}-cloudcosts
+  namespace: {{ .Release.Namespace }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
**Why This PR?**
Fixes some Cloud Costs charts bugs

Fixes #
Fixes charts for cloud costs plugin

**Changes**
Changes proposed in this pull request:

* Add ServiceAccount
* Fixes "and" logic

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
