### PR TITLE
[stable/insights-agent] Added nested ifs to workaround bug on some helm versions

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.25.3
+* Cloud costs - added nested ifs to workaround a bug on some helm versions
+
 ## 2.25.2
 * Cloud costs - google credentials bug fix
 

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.25.2
+version: 2.25.3
 appVersion: 9.2.1
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png

--- a/stable/insights-agent/templates/cloud-costs/secret.yaml
+++ b/stable/insights-agent/templates/cloud-costs/secret.yaml
@@ -1,5 +1,6 @@
 {{- if and .Values.cloudcosts .Values.cloudcosts.enabled -}}
-{{ if and .Values.cloudcosts.aws .Values.cloudcosts.aws.accessKeyId }}
+{{ if .Values.cloudcosts.aws }}
+{{ if .Values.cloudcosts.aws.accessKeyId }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,7 +10,9 @@ data:
   AWS_ACCESS_KEY_ID: {{ .Values.cloudcosts.aws.accessKeyId | b64enc}}
   AWS_SECRET_ACCESS_KEY: {{ .Values.cloudcosts.aws.secretAccessKey | b64enc }}
 {{ end }}
-{{ if and .Values.cloudcosts.gcp .Values.cloudcosts.gcp.applicationCredentials }}
+{{ end }}
+{{ if .Values.cloudcosts.gcp }}
+{{ if .Values.cloudcosts.gcp.applicationCredentials }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -18,5 +21,6 @@ type: Opaque
 data:
   gcp-key.json: | 
     {{ .Values.cloudcosts.gcp.applicationCredentials | b64enc}}
+{{ end }}
 {{ end }}
 {{- end -}}

--- a/stable/insights-agent/templates/cloud-costs/secret.yaml
+++ b/stable/insights-agent/templates/cloud-costs/secret.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ .Values.cloudcosts.secretName }}
 type: Opaque
 data:
-  AWS_ACCESS_KEY_ID: {{ .Values.cloudcosts.aws.accessKeyId | b64enc}}
+  AWS_ACCESS_KEY_ID: {{ .Values.cloudcosts.aws.accessKeyId | b64enc }}
   AWS_SECRET_ACCESS_KEY: {{ .Values.cloudcosts.aws.secretAccessKey | b64enc }}
 {{ end }}
 {{ end }}


### PR DESCRIPTION
**Why This PR?**
Added nested ifs to workaround bug on some helm

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
