### PR TITLE
[stable/polaris] Default to networking/v1 for ingress

### DIFF
--- a/stable/polaris/CHANGELOG.md
+++ b/stable/polaris/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this Helm chart will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this chart adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 5.17.0
+* Removed the switch for networking apiVersion and default to networking/v1
+
 ## 5.16.0
 * Added default PDBs for both the webhook and the dashboard
 

--- a/stable/polaris/Chart.yaml
+++ b/stable/polaris/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Validation of best practices in your Kubernetes clusters
 name: polaris
-version: 5.16.0
+version: 5.17.0
 appVersion: "8.5"
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/polaris/master/pkg/dashboard/assets/favicon-32x32.png

--- a/stable/polaris/templates/ingress.yaml
+++ b/stable/polaris/templates/ingress.yaml
@@ -1,10 +1,6 @@
 {{- if .Values.dashboard.ingress.enabled -}}
 {{ $serviceName := printf "%s-dashboard" (include "polaris.fullname" .) -}}
-{{- if not (.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress") }}
-apiVersion: networking.k8s.io/v1beta1
-{{- else }}
 apiVersion: networking.k8s.io/v1
-{{- end }}
 kind: Ingress
 metadata:
   annotations:

--- a/stable/polaris/templates/ingress.yaml
+++ b/stable/polaris/templates/ingress.yaml
@@ -13,9 +13,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
   name: polaris
 spec:
-{{- if and (.Values.dashboard.ingress.ingressClassName) (.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress") }}
   ingressClassName: {{ .Values.dashboard.ingress.ingressClassName }}
-{{- end }}
 {{- if .Values.dashboard.ingress.defaultBackendEnabled }}
   defaultBackend:
     service:
@@ -28,19 +26,9 @@ spec:
   - host: {{ . }}
     http:
       paths:
-      {{- if not ($.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress") }}
       - backend:
           serviceName: {{ $serviceName }}
           servicePort: 80
-      {{- else }}
-      - backend:
-          service:
-            name: {{ $serviceName }}
-            port:
-              number: 80
-        path: /
-        pathType: Prefix
-      {{- end }}
   {{- end -}}
 {{- if .Values.dashboard.ingress.tls }}
   tls:

--- a/stable/polaris/templates/ingress.yaml
+++ b/stable/polaris/templates/ingress.yaml
@@ -27,8 +27,12 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: {{ $serviceName }}
-          servicePort: 80
+          service:
+            name: {{ $serviceName }}
+            port:
+              number: 80
+        path: /
+        pathType: Prefix
   {{- end -}}
 {{- if .Values.dashboard.ingress.tls }}
   tls:


### PR DESCRIPTION
**Why This PR?**
networking/v1beta1 has been deprecated a while, and /v1 has been available for a long time. I think it's time to remove the check.

**Changes**
Changes proposed in this pull request:

* remove if statement checking for apiVersion
* default to networking/v1

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.