### PR TITLE
[stable/vpa] Add the ability to specify an envFrom secret

### DIFF
--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 3.0.2
+version: 3.1.0
 appVersion: 0.14.0
 maintainers:
   - name: sudermanjr

--- a/stable/vpa/README.md
+++ b/stable/vpa/README.md
@@ -146,6 +146,7 @@ recommender:
 | serviceAccount.name | string | `""` | The base name of the service account to use (appended with the component). If not set and create is true, a name is generated using the fullname template and appended for each component |
 | serviceAccount.automountServiceAccountToken | bool | `true` | Automount API credentials for the Service Account |
 | recommender.enabled | bool | `true` | If true, the vpa recommender component will be installed. |
+| recommender.envFromSecret | string | `""` | Specify a secret to get environment variables from |
 | recommender.annotations | object | `{}` | Annotations to add to the recommender deployment |
 | recommender.extraArgs | object | `{"pod-recommendation-min-cpu-millicores":15,"pod-recommendation-min-memory-mb":100,"v":"4"}` | A set of key-value flags to be passed to the recommender |
 | recommender.replicaCount | int | `1` |  |

--- a/stable/vpa/templates/recommender-deployment.yaml
+++ b/stable/vpa/templates/recommender-deployment.yaml
@@ -66,6 +66,11 @@ spec:
             - name: metrics
               containerPort: 8942
               protocol: TCP
+          {{- if .Values.recommender.envFromSecret }}
+          envFrom:
+          - secretRef:
+              name: {{ .Values.recommender.envFromSecret }}
+          {{- end }}
           resources:
             {{- toYaml .Values.recommender.resources | nindent 12 }}
       {{- with .Values.recommender.nodeSelector }}

--- a/stable/vpa/values.yaml
+++ b/stable/vpa/values.yaml
@@ -44,6 +44,8 @@ serviceAccount:
 recommender:
   # recommender.enabled -- If true, the vpa recommender component will be installed.
   enabled: true
+  # -- Specify a secret to get environment variables from
+  envFromSecret: ""
   # recommender.annotations -- Annotations to add to the recommender deployment
   annotations: {}
   # recommender.extraArgs -- A set of key-value flags to be passed to the recommender


### PR DESCRIPTION
**Why This PR?**
Sometimes you want to add a secret environment variable to the pod

**Changes**
Changes proposed in this pull request:

* add recommender.envFromSecret value

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.