### PR TITLE
[stable/install-reporter] unset aws secrets

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.26.1
+* unset awscosts aws keys in install-reporter configmap 
+
 ## 2.26.0
 * Add TTL option for install-reporter to better support Argo deployment
 

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.26.0
+version: 2.26.1
 appVersion: 9.2.1
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.26.1
+version: 2.26.2
 appVersion: 9.2.1
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png

--- a/stable/insights-agent/templates/install-reporter/configmap.yaml
+++ b/stable/insights-agent/templates/install-reporter/configmap.yaml
@@ -10,5 +10,7 @@ data:
   values.json: |
     {{ $values := .Values | deepCopy }}
     {{ $_ := unset $values "insights" }}
+    {{ $_ := unset $values "awscosts.awsAccessKeyId" }}
+    {{ $_ := unset $values "awscosts.awsSecretAccessKey" }}
     {{ $out := dict "values" $values "version" .Chart.Version }}
     {{- toPrettyJson $out | nindent 4 }}


### PR DESCRIPTION
**Why This PR?**
when setting `awscosts.awsAccessKeyId` or `awscosts.awsSecretAccessKey` the values are printed out to the install-reporter configmap. 

Fixes #

**Changes**
Changes proposed in this pull request:

* add unset lines to install-reporter configmap.yaml to not include those aws keys
*

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
