### PR TITLE
[incubator/timescale] add support for pull secret

### DIFF
--- a/incubator/timescale/Chart.yaml
+++ b/incubator/timescale/Chart.yaml
@@ -4,8 +4,8 @@
 apiVersion: v1
 name: timescaledb-single
 description: 'TimescaleDB HA Deployment.'
-appVersion: 0.30.3  # added to make linter happy - version of downstream chart
-version: 0.30.3
+appVersion: 0.30.4  # added to make linter happy - version of downstream chart
+version: 0.30.4
 # appVersion specifies the version of the software, which can vary wildly,
 # e.g. TimescaleDB 1.4.1 on PostgreSQL 11 or TimescaleDB 1.5.0 on PostgreSQL 12.
 # https://github.com/helm/helm/blob/master/docs/charts.md#the-appversion-field

--- a/incubator/timescale/templates/statefulset-timescaledb.yaml
+++ b/incubator/timescale/templates/statefulset-timescaledb.yaml
@@ -107,6 +107,10 @@ spec:
           allowPrivilegeEscalation: false
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- with .Values.image.pullSecret }}
+        imagePullSecrets:
+        - name: {{ . }}
+        {{- end }}
         lifecycle:
           preStop:
             exec:


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_
We need to add a pull secret for rate limiting

I have a corresponding PR in the downstream chart here: https://github.com/timescale/helm-charts/pull/635/files


**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
