### PR TITLE
[stable/fairwinds-insights] update timescale subchart

### DIFF
--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 1.0.5
+* Trigger rebuild with new timescale subchart
 
 ## 1.0.4
 * Update timescale subchart. Timescale version is the same, but some changes were made to the chart.

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "14.10"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 1.0.4
+version: 1.0.5
 kubeVersion: ">= 1.22.0-0"
 maintainers:
   - name: rbren


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Just a quick rebuild to pull in the latest patch to the timescale subchart

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
