### PR TITLE
[stable/insights-agent] FWI-5449 Upgrade prometheus helm chart to 25.8.2

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.26.3
+* upgrade prometheus helm chart to 25.8.2 and remove pinned kube-state-metrics image
+
 ## 2.26.2
 * unset awscosts aws keys in install-reporter configmap 
 

--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
-## 2.26.3
-* upgrade prometheus helm chart to 25.8.2 and remove pinned kube-state-metrics image
+## 3.0.0
+* upgrade prometheus helm chart to 25.8.2 and remove pinned kube-state-metrics image. Important note for migration: the following values have been changed in the upstream prometheus chart: `prometheus.nodeExporter` -> `prometheus.prometheus-node-exporter`, `prometheus.pushgateway` -> `prometheus.prometheus-pushgateway`
 
 ## 2.26.2
 * unset awscosts aws keys in install-reporter configmap 

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.26.3
+version: 3.0.0
 appVersion: 9.2.1
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.26.2
+version: 2.26.3
 appVersion: 9.2.1
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png

--- a/stable/insights-agent/requirements.yaml
+++ b/stable/insights-agent/requirements.yaml
@@ -5,7 +5,7 @@ dependencies:
   condition: goldilocks.enabled
 - name: prometheus
   repository: https://prometheus-community.github.io/helm-charts
-  version: '15.9.1'  # TODO: when updating this, remove the pinned version for kube-state-metrics in values.yaml
+  version: '25.8.2'
   condition: prometheus-metrics.installPrometheusServer
 - name: insights-admission
   repository: https://charts.fairwinds.com/stable

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -328,9 +328,9 @@ prometheus:
     enabled: true
   alertmanager:
     enabled: false
-  nodeExporter:
+  prometheus-node-exporter:
     enabled: false
-  pushgateway:
+  prometheus-pushgateway:
     enabled: false
   configmapReload:
     prometheus:

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -358,9 +358,6 @@ prometheus:
   kube-state-metrics:
     image:
       pullPolicy: Always
-      registry: ""
-      repository: registry.k8s.io/kube-state-metrics/kube-state-metrics
-      tag: "v2.4.1"  # TODO: remove this once we update to the latest p8s chart
     resources:
       requests:
         cpu: 10m


### PR DESCRIPTION
Fixes internal ticket FWI-5449

Summary: there have been some substantial recent changes made to Prometheus in order to cut memory consumption in v2.47.2: https://thenewstack.io/30-pull-requests-later-prometheus-memory-use-is-cut-in-half/ 

**Changes**
Changes proposed in this pull request:

* upgrade prometheus helm chart to 25.8.2
* remove pinned kube-state-metrics image

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
