### PR TITLE
[stable/fairwinds-insights] Update Fairwinds Insights version and add move-resource-health-scores

### DIFF
--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 1.0.10
-* Add `cronjobs.move-resource-health-scores-to-ts` support
+* Add `cronjobs.move-health-scores-to-ts` support
 
 ## 1.0.9
 * Update application version to 14.13. [See the release notes for more details](https://insights.docs.fairwinds.com/release-notes)

--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
 ## 1.1.0
-* Update application version to 14.12. [See the release notes for more details](https://insights.docs.fairwinds.com/release-notes)
+* Add `cronjobs.move-resource-health-scores-to-ts` support
 
 ## 1.0.8
-* Add `cronjobs.move-resource-health-scores-to-ts` support
+* Update application version to 14.12. [See the release notes for more details](https://insights.docs.fairwinds.com/release-notes)
 
 ## 1.0.7
 * Update `repoScanJob.insightsCIVersion` to `5.3` which provides a better best-effort on scanning 

--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog
 
-## 1.0.8
+## 1.1.0
 * Update application version to 14.12. [See the release notes for more details](https://insights.docs.fairwinds.com/release-notes)
+
+## 1.0.8
+* Add `cronjobs.move-resource-health-scores-to-ts` support
 
 ## 1.0.7
 * Update `repoScanJob.insightsCIVersion` to `5.3` which provides a better best-effort on scanning 

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: "14.12"
+appVersion: "14.13"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 1.0.8
+version: 1.0.9
 kubeVersion: ">= 1.22.0-0"
 maintainers:
   - name: rbren

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "14.13"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 1.0.9
+version: 1.1.0
 kubeVersion: ">= 1.22.0-0"
 maintainers:
   - name: rbren

--- a/stable/fairwinds-insights/README.md
+++ b/stable/fairwinds-insights/README.md
@@ -53,7 +53,7 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | cronjobs.saml | object | `{"command":"refresh_saml_metadata","schedule":"0 * * * *"}` | Options for the SAML sync job |
 | cronjobs.slack-channels | object | `{"command":"slack_channels_local_refresher","schedule":"0/15 * * * *"}` | Options for the slack channels job. |
 | cronjobs.trial-end | object | `{"command":"trial_end_downgrade","schedule":""}` | Options for the trial-end job. |
-| cronjobs.move-resource-health-scores-to-ts | object | `{"command":"move_resource_health_scores_to_ts","schedule":"*/30 * * * *"}` | Options for the move-resource-health-scores-to-ts job. |
+| cronjobs.move-health-scores-to-ts | object | `{"command":"move_resource_health_scores_to_ts","schedule":"*/30 * * * *"}` | Options for the move-health-scores-to-ts job. |
 | selfHostedSecret | string | `nil` |  |
 | additionalEnvironmentVariables | object | `{}` | Additional Environment Variables to set on the Fairwinds Insights pods. |
 | rbac.serviceAccount.annotations | object | `{}` | Annotations to add to the service account |

--- a/stable/fairwinds-insights/README.md
+++ b/stable/fairwinds-insights/README.md
@@ -53,6 +53,7 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | cronjobs.saml | object | `{"command":"refresh_saml_metadata","schedule":"0 * * * *"}` | Options for the SAML sync job |
 | cronjobs.slack-channels | object | `{"command":"slack_channels_local_refresher","schedule":"0/15 * * * *"}` | Options for the slack channels job. |
 | cronjobs.trial-end | object | `{"command":"trial_end_downgrade","schedule":""}` | Options for the trial-end job. |
+| cronjobs.move-resource-health-scores-to-ts | object | `{"command":"move_resource_health_scores_to_ts","schedule":"*/30 * * * *"}` | Options for the move-resource-health-scores-to-ts job. |
 | selfHostedSecret | string | `nil` |  |
 | additionalEnvironmentVariables | object | `{}` | Additional Environment Variables to set on the Fairwinds Insights pods. |
 | rbac.serviceAccount.annotations | object | `{}` | Annotations to add to the service account |

--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -189,8 +189,8 @@ cronjobs:
     command: trial_end_downgrade
     schedule: ""
 
-  # -- Options for the move-resource-health-scores-to-ts job.
-  move-resource-health-scores-to-ts:
+  # -- Options for the move-health-scores-to-ts job.
+  move-health-scores-to-ts:
     command: move_resource_health_scores_to_ts
     schedule: "*/30 * * * *"
 

--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -189,6 +189,11 @@ cronjobs:
     command: trial_end_downgrade
     schedule: ""
 
+  # -- Options for the move-resource-health-scores-to-ts job.
+  move-resource-health-scores-to-ts:
+    command: move_resource_health_scores_to_ts
+    schedule: "*/30 * * * *"
+
 selfHostedSecret:
 
 # -- Additional Environment Variables to set on the Fairwinds Insights pods.


### PR DESCRIPTION
…-to-ts cronjob

**Why This PR?**
- Adds the new resource health-score cronjob

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
