### PR TITLE
[incubator/timescale] Update TimescaleDB version to 0.33.5 and use pg14.10-ts2.13.0-all image

### DIFF
--- a/incubator/timescale/Chart.yaml
+++ b/incubator/timescale/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 name: timescaledb-single
 description: 'TimescaleDB HA Deployment.'
 appVersion: 0.33.2  # Added to make linter happy
-version: 0.33.4
+version: 0.33.5
 icon: https://cdn.iconscout.com/icon/free/png-256/timescaledb-1958407-1651618.png
 
 # appVersion specifies the version of the software, which can vary wildly,

--- a/incubator/timescale/README.md
+++ b/incubator/timescale/README.md
@@ -28,7 +28,7 @@ TimescaleDB HA Deployment.
 | clusterName | string | `""` |  |
 | version | string | `nil` |  |
 | image.repository | string | `"timescale/timescaledb-ha"` |  |
-| image.tag | string | `"pg14.8-ts2.11.0-all"` |  |
+| image.tag | string | `"pg14.10-ts2.13.0-all"` |  |
 | image.pullPolicy | string | `"Always"` |  |
 | curlImage.repository | string | `"curlimages/curl"` |  |
 | curlImage.tag | string | `"7.87.0"` |  |

--- a/incubator/timescale/values.yaml
+++ b/incubator/timescale/values.yaml
@@ -20,7 +20,7 @@ image:
   # Image was built from
   # https://github.com/timescale/timescaledb-docker-ha
   repository: timescale/timescaledb-ha
-  tag: pg14.8-ts2.11.0-all
+  tag: pg14.10-ts2.13.0-all
   pullPolicy: Always
 
 # There are job and cronjob resources that run during updates or backups that use curl image


### PR DESCRIPTION
**Why This PR?**
Update TimescaleDB version to 0.33.5 and use pg14.10-ts2.13.0-all image

Fixes #

**Changes**
Changes proposed in this pull request:

* bumping image version

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
