### PR TITLE
[stable/insights-agent] remove fixed patch version from insights-uploader

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.1.1
+* use `insights-uploader:0.5` as default (remove fixed patch version) 
+
 ## 3.1.0
 * upgraded aws costs and cloud costs to support tagprefix parameter
 

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 3.1.0
+version: 3.1.1
 appVersion: 9.2.1
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png

--- a/stable/insights-agent/README.md
+++ b/stable/insights-agent/README.md
@@ -71,7 +71,7 @@ Parameter | Description | Default
 `insights.apiToken` | Only needed if `fleetInstall=true` | ""
 `uploader.image.repository`  | The repository to pull the uploader script from | quay.io/fairwinds/insights-uploader
 `uploader.imagePullSecret` | A pull secret for a private uploader image
-`uploader.image.tag` | The tag to use for the uploader script | 0.2
+`uploader.image.tag` | The tag to use for the uploader script | 0.5
 `uploader.resources` | CPU/memory requests and limits for the uploader script |
 `uploader.sendFailures` | Send logs of failure to Insights when a job fails. | true
 `uploader.env` | Set extra environment variables for the uploader script | []

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -29,7 +29,7 @@ rbac:
 uploader:
   image:
     repository: quay.io/fairwinds/insights-uploader
-    tag: "0.5.1"
+    tag: "0.5"
   imagePullSecret: ""
   sendFailures: true
   resources:


### PR DESCRIPTION
**Why This PR?**
Agent was not pulling the latest `0.5.3` of `insights-uploader` due to its being fixed at patch level on `0.5.1`

Fixes #

**Changes**
Changes proposed in this pull request:

* use `0.5` instead of `0.5.1`

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
