### PR TITLE
[stable/insights-admission] bump agent to 1.14

### DIFF
--- a/stable/insights-admission/CHANGELOG.md
+++ b/stable/insights-admission/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.10.0
+* Bump insights-admission to version 1.14
+
 ## 1.9.0
 * Bump insights-admission to version 1.13
 

--- a/stable/insights-admission/CHANGELOG.md
+++ b/stable/insights-admission/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.10.0
+## 1.9.1
 * Bump insights-admission to version 1.14
 
 ## 1.9.0

--- a/stable/insights-admission/Chart.yaml
+++ b/stable/insights-admission/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: insights-admission
 description: A Validating Webhook Admission Controller that utilizes Fairwinds Insights.
 type: application
-version: 1.9.0
-appVersion: "1.13"
+version: 1.10.0
+appVersion: "1.14"
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-admission/icon.png
 maintainers:

--- a/stable/insights-admission/Chart.yaml
+++ b/stable/insights-admission/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: insights-admission
 description: A Validating Webhook Admission Controller that utilizes Fairwinds Insights.
 type: application
-version: 1.10.0
+version: 1.9.1
 appVersion: "1.14"
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-admission/icon.png


### PR DESCRIPTION
**Why This PR?**
Bump `appVersion` from agent to 1.14

Fixes #

**Changes**
Changes proposed in this pull request:

* Bump `appVersion` from agent to 1.14

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
