### PR TITLE
[stable/insights-agent] Added parameter  mountTmp=true as default for aws and cloud costs

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 3.1.2
-* Added parameter mountTmp= true as default for aws and cloud costs
+* Added parameter mountTmp=true as default for aws and cloud costs
 
 ## 3.1.1
 * use `insights-uploader:0.5` as default (remove fixed patch version) 

--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.1.2
+* Added parameter mounTmp= true as default for aws and cloud costs
+
 ## 3.1.1
 * use `insights-uploader:0.5` as default (remove fixed patch version) 
 

--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 3.1.2
-* Added parameter mounTmp= true as default for aws and cloud costs
+* Added parameter mountTmp= true as default for aws and cloud costs
 
 ## 3.1.1
 * use `insights-uploader:0.5` as default (remove fixed patch version) 

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 3.1.1
+version: 3.1.2
 appVersion: 9.2.1
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -450,7 +450,7 @@ cloudcosts:
   securityContext: {}
   containerSecurityContext: {}
   mountTmp: true
-  
+
 right-sizer:
   enabled: false
   schedule: "rand * * * *"

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -427,6 +427,7 @@ awscosts:
   securityContext: {}
   # awscosts.containerSecurityContext -- Additional container securityContext items for the cronJob.
   containerSecurityContext: {}
+  mountTmp: true
 
 cloudcosts:
   enabled: false
@@ -448,7 +449,8 @@ cloudcosts:
       memory: 2Gi
   securityContext: {}
   containerSecurityContext: {}
-
+  mountTmp: true
+  
 right-sizer:
   enabled: false
   schedule: "rand * * * *"


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
