### PR TITLE
[stable/vpa] Fix `admission-certgen` label typo

### DIFF
--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 4.0.1
+version: 4.1.0
 appVersion: 1.0.0
 maintainers:
   - name: sudermanjr

--- a/stable/vpa/templates/webhooks/jobs/certgen-create.yaml
+++ b/stable/vpa/templates/webhooks/jobs/certgen-create.yaml
@@ -16,7 +16,7 @@ spec:
     metadata:
       name: {{ include "vpa.fullname" . }}-admission-certgen
       labels:
-        app.kubernetes.io/component: cadmission-ertgen
+        app.kubernetes.io/component: admission-certgen
         {{- include "vpa.labels" . | nindent 8 }}
     spec:
       restartPolicy: OnFailure


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Hi! 👋 

There is a typo in the VPA chart for the label `app.kubernetes.io/component: cadmission-ertgen` which should be `admission-certgen`. 👍 

**Changes**
Changes proposed in this pull request:

* Fixes typo  `cadmission-ertgen` -> `admission-certgen`

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
