### PR TITLE
[stable/insights-agent] Add note about 3.x upgrades

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.1.3
+* Updated changelog
+
 ## 3.1.2
 * Added parameter mountTmp=true as default for aws and cloud costs
 
@@ -10,6 +13,8 @@
 * upgraded aws costs and cloud costs to support tagprefix parameter
 
 ## 3.0.0
+> If you're using the prometheus packaged with the Insights Agent, you'll need to run `helm delete insights-agent -n insights-agent` before installing 3.x
+
 * upgrade prometheus helm chart to 25.8.2 and remove pinned kube-state-metrics image. Important note for migration: the following values have been changed in the upstream prometheus chart: `prometheus.nodeExporter` -> `prometheus.prometheus-node-exporter`, `prometheus.pushgateway` -> `prometheus.prometheus-pushgateway`
 
 ## 2.26.2

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 3.1.2
+version: 3.1.3
 appVersion: 9.2.1
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,11 +1,10 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 3.1.6
+version: 3.1.7
 appVersion: 9.2.1
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:
   - name: rbren
-  - name: makoscafee
   - name: jdesouza


### PR DESCRIPTION
A user discovered that upgrading from 2.x to 3.x triggers an error unless the chart is deleted first.

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
