### PR TITLE
[stable/vpa] add a value to set the admission controller port

### DIFF
--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 4.1.0
+version: 5.0.0
 appVersion: 1.0.0
 maintainers:
   - name: sudermanjr

--- a/stable/vpa/README.md
+++ b/stable/vpa/README.md
@@ -223,6 +223,7 @@ recommender:
 | admissionController.livenessProbe | object | `{"failureThreshold":6,"httpGet":{"path":"/health-check","port":"metrics","scheme":"HTTP"},"periodSeconds":5,"successThreshold":1,"timeoutSeconds":3}` | The liveness probe definition inside the admission controller pod |
 | admissionController.readinessProbe | object | `{"failureThreshold":120,"httpGet":{"path":"/health-check","port":"metrics","scheme":"HTTP"},"periodSeconds":5,"successThreshold":1,"timeoutSeconds":3}` | The readiness probe definition inside the admission controller pod |
 | admissionController.resources | object | `{"limits":{},"requests":{"cpu":"50m","memory":"200Mi"}}` | The resources block for the admission controller pod |
+| admissionController.service.port | int | `8000` | The port to run the admission controller on. Primarily affects GKE where firewall rules need to be added for admission controlle requests. |
 | admissionController.tlsSecretKeys | list | `[]` | The keys in the vpa-tls-certs secret to map in to the admission controller |
 | admissionController.nodeSelector | object | `{}` |  |
 | admissionController.tolerations | list | `[]` |  |

--- a/stable/vpa/templates/admission-controller-deployment.yaml
+++ b/stable/vpa/templates/admission-controller-deployment.yaml
@@ -51,6 +51,7 @@ spec:
           args:
             - --register-webhook=false
             - --webhook-service={{ include "vpa.fullname" . }}-webhook
+            - --port={{ .Values.admissionController.service.port }}
           {{- if .Values.admissionController.generateCertificate }}
             - --client-ca-file=/etc/tls-certs/ca
             - --tls-cert-file=/etc/tls-certs/cert
@@ -75,7 +76,7 @@ spec:
           {{- end }}
           ports:
             - name: http
-              containerPort: 8000
+              containerPort: {{ .Values.admissionController.service.port }}
               protocol: TCP
             - name: metrics
               containerPort: 8944

--- a/stable/vpa/templates/admission-controller-service.yaml
+++ b/stable/vpa/templates/admission-controller-service.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   ports:
     - port: 443
-      targetPort: 8000
+      targetPort: {{ .Values.admissionController.service.port }}
   selector:
     app.kubernetes.io/component: admission-controller
     {{- include "vpa.selectorLabels" . | nindent 4 }}

--- a/stable/vpa/values.yaml
+++ b/stable/vpa/values.yaml
@@ -274,6 +274,9 @@ admissionController:
     requests:
       cpu: 50m
       memory: 200Mi
+  service:
+    # -- The port to run the admission controller on. Primarily affects GKE where firewall rules need to be added for admission controlle requests.
+    port: 8000
   # admissionController.tlsSecretKeys -- The keys in the vpa-tls-certs secret to map in to the admission controller
   tlsSecretKeys: []
     # - key: ca.crt


### PR DESCRIPTION
**Why This PR?**
Sometimes you want/need a different port so that you can not write a bajillion firewall rules for all the admission controllers in your GKE clusters.

**Changes**
Changes proposed in this pull request:

* Add a value `admissionController.service.port` which controls the port at the container level

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.