### PR TITLE
feat(insights): add keda scaledobjects to chart

### DIFF
--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.1.0
+* Added the ability to configure keda scaledObjects for certain deployments.
+
 ## 1.0.11
 * Update application version to 15.0. [See the release notes for more details](https://insights.docs.fairwinds.com/release-notes)
 

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "15.0"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 1.0.11
+version: 1.1.0
 kubeVersion: ">= 1.22.0-0"
 maintainers:
   - name: rbren

--- a/stable/fairwinds-insights/README.md
+++ b/stable/fairwinds-insights/README.md
@@ -74,6 +74,20 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | api.hpa.min | int | `2` | Minimum number of replicas for the API server. |
 | api.hpa.max | int | `4` | Maximum number of replicas for the API server. |
 | api.hpa.metrics | list | `[{"resource":{"name":"cpu","target":{"averageUtilization":75,"type":"Utilization"}},"type":"Resource"},{"resource":{"name":"memory","target":{"averageUtilization":75,"type":"Utilization"}},"type":"Resource"}]` | Scaling metrics |
+| api.scaledObject.enabled | bool | `false` |  |
+| api.scaledObject.min | int | `0` |  |
+| api.scaledObject.max | int | `1` |  |
+| api.scaledObject.triggers[0].type | string | `"prometheus"` |  |
+| api.scaledObject.triggers[0].metadata.serverAddress | string | `"http://prometheus-operated.prometheus:9090"` |  |
+| api.scaledObject.triggers[0].metadata.metricName | string | `"nginx_ingress_controller_requests"` |  |
+| api.scaledObject.triggers[0].metadata.threshold | string | `"5"` |  |
+| api.scaledObject.triggers[0].metadata.activationThreshold | string | `".001"` |  |
+| api.scaledObject.triggers[0].metadata.query | string | `"sum(rate(nginx_ingress_controller_requests{host=\"INGRESS_HOST\"}[1m]))"` |  |
+| api.scaledObject.triggers[1].type | string | `"cron"` |  |
+| api.scaledObject.triggers[1].metadata.timezone | string | `"America/Denver"` |  |
+| api.scaledObject.triggers[1].metadata.start | string | `"9 * * * 1-5"` |  |
+| api.scaledObject.triggers[1].metadata.end | string | `"14 * * * 1-5"` |  |
+| api.scaledObject.triggers[1].metadata.desiredReplicas | string | `"1"` |  |
 | api.resources | object | `{"limits":{"cpu":"1000m","memory":"1024Mi"},"requests":{"cpu":"250m","memory":"256Mi"}}` | Resources for the API server. |
 | api.nodeSelector | object | `{}` | Node Selector for the API server. |
 | api.tolerations | list | `[]` | Tolerations for the API server. |

--- a/stable/fairwinds-insights/templates/scaledobject-api.yaml
+++ b/stable/fairwinds-insights/templates/scaledobject-api.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.api.scaledObject.enabled }}
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: {{ include "fairwinds-insights.fullname" . }}-api
+  labels:
+    {{- include "fairwinds-insights.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: api
+spec:
+  scaleTargetRef:
+    name: {{ include "fairwinds-insights.fullname" . }}-api
+  minReplicaCount: {{ .Values.api.scaledObject.min }}
+  maxReplicaCount: {{ .Values.api.scaledObject.max }}
+  triggers:
+  {{- toYaml  .Values.api.scaledObject.triggers | nindent 2 }}
+{{- end }}

--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -276,6 +276,28 @@ api:
         target:
           type: Utilization
           averageUtilization: 75
+  scaledObject:
+    ## -- If true, enables a keda scaledObject for scaling the api pods.
+    enabled: false
+    ## -- Minimum replicas of the api deployment.
+    min: 0
+    ## -- Maximum replicas of the api deployment.
+    max: 1
+    ## -- A set of triggers for the api keda scaledObject.
+    triggers:
+    - type: prometheus
+      metadata:
+        serverAddress: http://prometheus-operated.prometheus:9090
+        metricName: nginx_ingress_controller_requests
+        threshold: '5'
+        activationThreshold: '.001'
+        query: sum(rate(nginx_ingress_controller_requests{host="INGRESS_HOST"}[1m]))
+    - type: cron
+      metadata:
+        timezone: America/Denver
+        start: 9 * * * 1-5
+        end: 14 * * * 1-5
+        desiredReplicas: "1"
   # -- Resources for the API server.
   resources:
     limits:


### PR DESCRIPTION
**Why This PR?**
To enable smarter scaling, we're going to add scaledObjects - this will allow us to do that

**Changes**
Changes proposed in this pull request:

* Add a keda scaled object

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.