### PR TITLE
[stable/vpa] Specify VPA components' container names

### DIFF
--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 4.4.1
+version: 4.5.1
 appVersion: 1.0.0
 maintainers:
   - name: sudermanjr

--- a/stable/vpa/templates/admission-controller-deployment.yaml
+++ b/stable/vpa/templates/admission-controller-deployment.yaml
@@ -41,7 +41,7 @@ spec:
       securityContext:
         {{- toYaml .Values.admissionController.podSecurityContext | nindent 8 }}
       containers:
-        - name: {{ .Chart.Name }}
+        - name: {{ .Chart.Name }}-admission-controller
           securityContext:
             {{- toYaml .Values.admissionController.securityContext | nindent 12 }}
           image: {{ printf "%s:%s" .Values.admissionController.image.repository (.Values.admissionController.image.tag | default .Chart.AppVersion) }}

--- a/stable/vpa/templates/recommender-deployment.yaml
+++ b/stable/vpa/templates/recommender-deployment.yaml
@@ -41,7 +41,7 @@ spec:
       securityContext:
         {{- toYaml .Values.recommender.podSecurityContext | nindent 8 }}
       containers:
-        - name: {{ .Chart.Name }}
+        - name: {{ .Chart.Name }}-recommender
           securityContext:
             {{- toYaml .Values.recommender.securityContext | nindent 12 }}
           image: {{ printf "%s:%s" .Values.recommender.image.repository (.Values.recommender.image.tag | default .Chart.AppVersion) }}

--- a/stable/vpa/templates/updater-deployment.yaml
+++ b/stable/vpa/templates/updater-deployment.yaml
@@ -41,7 +41,7 @@ spec:
       securityContext:
         {{- toYaml .Values.updater.podSecurityContext | nindent 8 }}
       containers:
-        - name: {{ .Chart.Name }}
+        - name: {{ .Chart.Name }}-updater
           securityContext:
             {{- toYaml .Values.updater.securityContext | nindent 12 }}
           image: {{ printf "%s:%s" .Values.updater.image.repository (.Values.updater.image.tag | default .Chart.AppVersion) }}


### PR DESCRIPTION
**Why This PR?**
The container names of all VPA components are the same, `vpa`, which makes it difficult to monitor the individual components. 

Fixes #

**Changes**
Changes proposed in this pull request:

* Use full container names for VPA recommender, updater, and admission controller

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
