### PR TITLE
[stable/goldilocks]: updated the dashboard service to include extra labels

### DIFF
--- a/stable/goldilocks/Chart.yaml
+++ b/stable/goldilocks/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 appVersion: "v4.10.0"
-version: 8.0.1
+version: 8.0.2
 kubeVersion: ">= 1.22.0-0"
 description: |
   A Helm chart for running Fairwinds Goldilocks. See https://github.com/FairwindsOps/goldilocks

--- a/stable/goldilocks/README.md
+++ b/stable/goldilocks/README.md
@@ -99,6 +99,7 @@ This will completely remove the VPA and then re-install it using the new method.
 | dashboard.service.type | string | `"ClusterIP"` | The type of the dashboard service |
 | dashboard.service.port | int | `80` | The port to run the dashboard service on |
 | dashboard.service.annotations | object | `{}` | Extra annotations for the dashboard service |
+| dashboard.service.additionalLabels | object | `{}` | Extra labels for the dashboard service  |
 | dashboard.flags | object | `{}` | A map of additional flags to pass to the dashboard |
 | dashboard.logVerbosity | string | `"2"` | Dashboard log verbosity. Can be set from 1-10 with 10 being extremely verbose |
 | dashboard.excludeContainers | string | `"linkerd-proxy,istio-proxy"` | Container names to exclude from displaying in the Goldilocks dashboard |

--- a/stable/goldilocks/README.md
+++ b/stable/goldilocks/README.md
@@ -99,7 +99,7 @@ This will completely remove the VPA and then re-install it using the new method.
 | dashboard.service.type | string | `"ClusterIP"` | The type of the dashboard service |
 | dashboard.service.port | int | `80` | The port to run the dashboard service on |
 | dashboard.service.annotations | object | `{}` | Extra annotations for the dashboard service |
-| dashboard.service.additionalLabels | object | `{}` | Extra labels for the dashboard service  |
+| dashboard.service.additionalLabels | object | `{}` | Extra labels for the dashboard service |
 | dashboard.flags | object | `{}` | A map of additional flags to pass to the dashboard |
 | dashboard.logVerbosity | string | `"2"` | Dashboard log verbosity. Can be set from 1-10 with 10 being extremely verbose |
 | dashboard.excludeContainers | string | `"linkerd-proxy,istio-proxy"` | Container names to exclude from displaying in the Goldilocks dashboard |

--- a/stable/goldilocks/templates/dashboard-service.yaml
+++ b/stable/goldilocks/templates/dashboard-service.yaml
@@ -10,6 +10,9 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/component: dashboard
+    {{- with .Values.dashboard.service.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.dashboard.service.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/stable/goldilocks/values.yaml
+++ b/stable/goldilocks/values.yaml
@@ -108,6 +108,8 @@ dashboard:
     port: 80
     # dashboard.service.annotations -- Extra annotations for the dashboard service
     annotations: {}
+    # dashboard.service.additionalLabels -- Extra labels for the dashboard service
+    additionalLabels: {}
   # dashboard.flags -- A map of additional flags to pass to the dashboard
   flags: {}
   # dashboard.logVerbosity -- Dashboard log verbosity. Can be set from 1-10 with 10 being extremely verbose


### PR DESCRIPTION
This renders the goldilocks dashboard service to be more flexible when adding labels to it.

**Why This PR?**
Update template of goldilocks dashboard service

Fixes #

**Changes**
Changes proposed in this pull request:

this change provides the ability to add extra labels to dashboard service of goldilocks.

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
