### PR TITLE
[stable/vpa] Allow the admission controller to register itself as a webhook

### DIFF
--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 4.4.1
+version: 4.4.2
 appVersion: 1.0.0
 maintainers:
   - name: sudermanjr

--- a/stable/vpa/README.md
+++ b/stable/vpa/README.md
@@ -196,6 +196,7 @@ recommender:
 | admissionController.extraArgs | object | `{}` | A key-value map of flags to pass to the admissionController |
 | admissionController.generateCertificate | bool | `true` | If true and admissionController is enabled, a pre-install hook will run to create the certificate for the webhook |
 | admissionController.secretName | string | `"{{ include \"vpa.fullname\" . }}-tls-secret"` | Name for the TLS secret created for the webhook. Default {{ .Release.Name }}-tls-secret |
+| admissionController.registerWebhook | bool | `false` | If true, will allow the vpa admission controller to register itself as a mutating webhook |
 | admissionController.certGen.image.repository | string | `"registry.k8s.io/ingress-nginx/kube-webhook-certgen"` | An image that contains certgen for creating certificates. Only used if admissionController.generateCertificate is true |
 | admissionController.certGen.image.tag | string | `"v20230312-helm-chart-4.5.2-28-g66a760794"` | An image tag for the admissionController.certGen.image.repository image. Only used if admissionController.generateCertificate is true |
 | admissionController.certGen.image.pullPolicy | string | `"Always"` | The pull policy for the certgen image. Recommend not changing this |

--- a/stable/vpa/templates/admission-controller-deployment.yaml
+++ b/stable/vpa/templates/admission-controller-deployment.yaml
@@ -47,7 +47,7 @@ spec:
           image: {{ printf "%s:%s" .Values.admissionController.image.repository (.Values.admissionController.image.tag | default .Chart.AppVersion) }}
           imagePullPolicy: {{ .Values.admissionController.image.pullPolicy }}
           args:
-            - --register-webhook={{ .Values.admissionController.registerWebhook }}
+            - --register-webhook={{ .Values.admissionController.registerWebhook | quote }}
             - --webhook-service={{ include "vpa.fullname" . }}-webhook
           {{- if .Values.admissionController.generateCertificate }}
             - --client-ca-file=/etc/tls-certs/ca

--- a/stable/vpa/templates/admission-controller-deployment.yaml
+++ b/stable/vpa/templates/admission-controller-deployment.yaml
@@ -47,11 +47,7 @@ spec:
           image: {{ printf "%s:%s" .Values.admissionController.image.repository (.Values.admissionController.image.tag | default .Chart.AppVersion) }}
           imagePullPolicy: {{ .Values.admissionController.image.pullPolicy }}
           args:
-          {{- if .Values.admissionController.registerWebhook }}
-            - --register-webhook=true
-          {{- else }}
-            - --register-webhook=false
-          {{- end }}
+            - --register-webhook={{ .Values.admissionController.registerWebhook }}
             - --webhook-service={{ include "vpa.fullname" . }}-webhook
           {{- if .Values.admissionController.generateCertificate }}
             - --client-ca-file=/etc/tls-certs/ca

--- a/stable/vpa/templates/admission-controller-deployment.yaml
+++ b/stable/vpa/templates/admission-controller-deployment.yaml
@@ -47,7 +47,7 @@ spec:
           image: {{ printf "%s:%s" .Values.admissionController.image.repository (.Values.admissionController.image.tag | default .Chart.AppVersion) }}
           imagePullPolicy: {{ .Values.admissionController.image.pullPolicy }}
           args:
-            - --register-webhook={{ .Values.admissionController.registerWebhook | quote }}
+            - --register-webhook={{ .Values.admissionController.registerWebhook }}
             - --webhook-service={{ include "vpa.fullname" . }}-webhook
           {{- if .Values.admissionController.generateCertificate }}
             - --client-ca-file=/etc/tls-certs/ca

--- a/stable/vpa/templates/admission-controller-deployment.yaml
+++ b/stable/vpa/templates/admission-controller-deployment.yaml
@@ -47,7 +47,11 @@ spec:
           image: {{ printf "%s:%s" .Values.admissionController.image.repository (.Values.admissionController.image.tag | default .Chart.AppVersion) }}
           imagePullPolicy: {{ .Values.admissionController.image.pullPolicy }}
           args:
+          {{- if .Values.admissionController.registerWebhook }}
+            - --register-webhook=true
+          {{- else }}
             - --register-webhook=false
+          {{- end }}
             - --webhook-service={{ include "vpa.fullname" . }}-webhook
           {{- if .Values.admissionController.generateCertificate }}
             - --client-ca-file=/etc/tls-certs/ca

--- a/stable/vpa/templates/admission-controller-deployment.yaml
+++ b/stable/vpa/templates/admission-controller-deployment.yaml
@@ -47,7 +47,11 @@ spec:
           image: {{ printf "%s:%s" .Values.admissionController.image.repository (.Values.admissionController.image.tag | default .Chart.AppVersion) }}
           imagePullPolicy: {{ .Values.admissionController.image.pullPolicy }}
           args:
-            - --register-webhook={{ .Values.admissionController.registerWebhook }}
+          {{- if .Values.admissionController.registerWebhook }}
+            - --register-webhook=true
+          {{- else }}
+            - --register-webhook=false
+          {{- end }}
             - --webhook-service={{ include "vpa.fullname" . }}-webhook
           {{- if .Values.admissionController.generateCertificate }}
             - --client-ca-file=/etc/tls-certs/ca

--- a/stable/vpa/values.yaml
+++ b/stable/vpa/values.yaml
@@ -207,6 +207,8 @@ admissionController:
   generateCertificate: true
   # admissionController.secretName -- Name for the TLS secret created for the webhook. Default {{ .Release.Name }}-tls-secret
   secretName: "{{ include \"vpa.fullname\" . }}-tls-secret"
+  # admissionController.registerWebhook -- If true, will allow the vpa admission controller to register itself as a mutating webhook
+  registerWebhook: false
   certGen:
     image:
       # admissionController.certGen.image.repository -- An image that contains certgen for creating certificates. Only used if admissionController.generateCertificate is true


### PR DESCRIPTION
**Why This PR?**

Previously, we advocated for running the VPA controller in recommendation mode only. Recently, we are exploring additional options for right-sizing. One of which includes automatic setting of resource requests. In order for VPA recommendations to be applied, the VPA admission controller must register itself as a mutating webhook to intercept evicted pods and set resource requests. I am proposing we make `--register-webhook=true` configurable via `admissionController.registerWebhook` and default to `false`.

Related PR #1191

**Changes**
Changes proposed in this pull request:

* Add `admissionController.registerWebhook` to values for [stable/vpa] and default to false

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
