### PR TITLE
[stable/polaris]: allow to define additional podAnnotations

### DIFF
--- a/stable/polaris/README.md
+++ b/stable/polaris/README.md
@@ -53,6 +53,7 @@ the 0.10.0 version of this chart will only work on kubernetes 1.14.0+
 | dashboard.replicas | int | `2` | Number of replicas to run. |
 | dashboard.logLevel | string | `"Info"` | Set the logging level for the Dashboard command |
 | dashboard.podAdditionalLabels | object | `{}` | Custom additional labels on dashboard pods. |
+| dashboard.podAdditionalAnnotations | object | `{}` | Custom additional annotations on dashboard pods. |
 | dashboard.deploymentAnnotations | object | `{}` | Custom additional annotations on dashboard Deployment. |
 | dashboard.resources | object | `{"limits":{"cpu":"150m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | Requests and limits for the dashboard |
 | dashboard.extraContainers | list | `[]` | allows injecting additional containers. |

--- a/stable/polaris/templates/dashboard.deployment.yaml
+++ b/stable/polaris/templates/dashboard.deployment.yaml
@@ -21,9 +21,14 @@ spec:
       component: dashboard
   template:
     metadata:
-      {{- with .Values.config }}
+      {{- if or .Values.config .Values.dashboard.podAdditionalAnnotations }}
       annotations:
+        {{- with .Values.config }}
         checksum/config: '{{ include (print $.Template.BasePath "/configmap.yaml") $ | sha256sum }}'
+        {{- end }}
+        {{- with .Values.dashboard.podAdditionalAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
       labels:
         {{- include "polaris.selectors" . | nindent 8 }}

--- a/stable/polaris/values.yaml
+++ b/stable/polaris/values.yaml
@@ -47,6 +47,8 @@ dashboard:
   logLevel: Info
   # dashboard.podAdditionalLabels -- Custom additional labels on dashboard pods.
   podAdditionalLabels: {}
+  # dashboard.podAdditionalAnnotations -- Custom additional annotations on dashboard pods.
+  podAdditionalAnnotations: {}
   # dashboard.deploymentAnnotations -- Custom additional annotations on dashboard Deployment.
   deploymentAnnotations: {}
   # dashboard.resources -- Requests and limits for the dashboard


### PR DESCRIPTION
**Why This PR?**
Allow to define custom annotations on the pod level.

Using the pod level annotations, I can for example specify istio sidecar memory and CPU limits.

**Changes**
Changes proposed in this pull request:

* Allow to define pod level annotations

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [ ] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
