### PR TITLE
[stable/vpa] support for k8s minor version with + suffix

### DIFF
--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 4.4.5
+version: 4.4.6
 appVersion: 1.0.0
 maintainers:
   - name: sudermanjr

--- a/stable/vpa/templates/tests/_test_helpers.tpl
+++ b/stable/vpa/templates/tests/_test_helpers.tpl
@@ -3,9 +3,9 @@ Get kubectl image tag
 */}}
 {{- define "vpa.test.tag" -}}
 {{- if .Values.tests.image }}
-{{- default (printf "%s.%s" .Capabilities.KubeVersion.Major .Capabilities.KubeVersion.Minor) .Values.tests.image.tag }}
+{{- default (printf "%s.%s" .Capabilities.KubeVersion.Major (trimSuffix "+" .Capabilities.KubeVersion.Minor)) .Values.tests.image.tag }}
 {{- else }}
-{{- printf "%s.%s" .Capabilities.KubeVersion.Major .Capabilities.KubeVersion.Minor }}
+{{- printf "%s.%s" .Capabilities.KubeVersion.Major (trimSuffix "+" .Capabilities.KubeVersion.Minor) }}
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Minor versions of Kubernetes may have a + at the end. (e.g. Amazon EKS)
Running `helm test` fails to pull the image due to the + in the `kubectl` image tag.

Fixes #

**Changes**
Changes proposed in this pull request:

* Trim the + at the end of the image tag

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
