### PR TITLE
[stable/insights-agent] Increase trivy memory

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.1.3
+* Increase default memory for trivy
+
 ## 3.1.2
 * Added parameter mountTmp=true as default for aws and cloud costs
 

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 3.1.2
+version: 3.1.3
 appVersion: 9.2.1
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -294,7 +294,7 @@ trivy:
   resources:
     requests:
       cpu: 100m
-      memory: 128Mi
+      memory: 1Gi
 
 pluto:
   enabled: false


### PR DESCRIPTION
**Why This PR?**
We're noticing Trivy OOMing in some clusters. This should help prevent it.

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
