### PR TITLE
[stable/goldilocks] feat: add allow setting priority class

### DIFF
--- a/stable/goldilocks/Chart.yaml
+++ b/stable/goldilocks/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 appVersion: "v4.10.0"
-version: 8.0.1
+version: 8.1.0
 kubeVersion: ">= 1.22.0-0"
 description: |
   A Helm chart for running Fairwinds Goldilocks. See https://github.com/FairwindsOps/goldilocks

--- a/stable/goldilocks/README.md
+++ b/stable/goldilocks/README.md
@@ -72,6 +72,7 @@ This will completely remove the VPA and then re-install it using the new method.
 | fullnameOverride | string | `""` |  |
 | controller.enabled | bool | `true` | Whether or not to install the controller deployment |
 | controller.revisionHistoryLimit | int | `10` | Number of old replicasets to retain, default is 10, 0 will garbage-collect old replicasets |
+| controller.priorityClassName | string | `""` | Name of a priority class, which indicates the importance of a workload relative to others |
 | controller.rbac.create | bool | `true` | If set to true, rbac resources will be created for the controller |
 | controller.rbac.enableArgoproj | bool | `true` | If set to true, the clusterrole will give access to argoproj.io resources |
 | controller.rbac.extraRules | list | `[]` | Extra rbac rules for the controller clusterrole |
@@ -95,6 +96,7 @@ This will completely remove the VPA and then re-install it using the new method.
 | dashboard.basePath | string | `nil` | Path on which the dashboard is served. Defaults to `/` |
 | dashboard.enabled | bool | `true` | If true, the dashboard component will be installed |
 | dashboard.revisionHistoryLimit | int | `10` | Number of old replicasets to retain, default is 10, 0 will garbage-collect old replicasets |
+| dashboard.priorityClassName | string | `""` | Name of a priority class, which indicates the importance of a workload relative to others |
 | dashboard.replicaCount | int | `2` | Number of dashboard pods to run |
 | dashboard.service.type | string | `"ClusterIP"` | The type of the dashboard service |
 | dashboard.service.port | int | `80` | The port to run the dashboard service on |

--- a/stable/goldilocks/templates/controller-deployment.yaml
+++ b/stable/goldilocks/templates/controller-deployment.yaml
@@ -39,6 +39,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      {{- with .Values.controller.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/stable/goldilocks/templates/dashboard-deployment.yaml
+++ b/stable/goldilocks/templates/dashboard-deployment.yaml
@@ -39,6 +39,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      {{- with .Values.dashboard.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/stable/goldilocks/values.yaml
+++ b/stable/goldilocks/values.yaml
@@ -32,6 +32,8 @@ controller:
   enabled: true
   # controller.revisionHistoryLimit -- Number of old replicasets to retain, default is 10, 0 will garbage-collect old replicasets
   revisionHistoryLimit: 10
+  # controller.priorityClassName -- Name of a priority class, which indicates the importance of a workload relative to others
+  priorityClassName: ""
   rbac:
     # controller.rbac.create -- If set to true, rbac resources will be created for the controller
     create: true
@@ -99,6 +101,8 @@ dashboard:
   enabled: true
   # dashboard.revisionHistoryLimit -- Number of old replicasets to retain, default is 10, 0 will garbage-collect old replicasets
   revisionHistoryLimit: 10
+  # dashboard.priorityClassName -- Name of a priority class, which indicates the importance of a workload relative to others
+  priorityClassName: ""
   # dashboard.replicaCount -- Number of dashboard pods to run
   replicaCount: 2
   service:


### PR DESCRIPTION
**Why This PR?**
With platform engineering it's important for infrastructure workloads to take precedence over user workloads when it comes to scheduling deployments. Defining priority classes comes to the rescue here.

Fixes #

**Changes**
Changes proposed in this pull request:

* introducing 2 new values
* introducing PriorityClass to controller and dashboard deployments

**Checklist:**

* [ x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x ] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [ x] Any new values are backwards compatible and/or have sensible default.
* [x ] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
