### PR TITLE
[stable/insights-agent] Remove the need for AWS access key secret if using IRSA

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 3.1.4
+* Fix support for IRSA in cloud-costs
 
 ## 3.1.3
 * Increase default memory for trivy

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 3.1.3
+version: 3.1.4
 appVersion: 9.2.1
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png

--- a/stable/insights-agent/templates/cloud-costs/cronjob.yaml
+++ b/stable/insights-agent/templates/cloud-costs/cronjob.yaml
@@ -22,9 +22,9 @@ spec:
             emptyDir: {}
           {{- end }}  
           containers:
-          {{- if .Values.cloudcosts.secretName }}
           - {{ include "container-spec" . | indent 12 | trim }}
             {{- if eq .Values.cloudcosts.provider "aws" }}
+            {{- if .Values.cloudcosts.secretName }}
             - name: creds
               mountPath: /.aws
             env:
@@ -38,6 +38,7 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.cloudcosts.secretName }}
                   key: AWS_SECRET_ACCESS_KEY
+            {{- end }}
             - name: AWS_DEFAULT_REGION
               value: {{ required "You must set cloudcosts.aws.region, please see https://insights.docs.fairwinds.com/technical-details/reports/aws-costs/#agent-configuration" .Values.cloudcosts.aws.region }}
             {{ include "proxy-env-spec" . | indent 12 | trim }}
@@ -87,5 +88,4 @@ spec:
             {{ include "security-context" . | indent 12 | trim }}
           {{ include "uploaderContainer" . | indent 10 | trim }}
             {{- end }}
-          {{- end }}  
   {{- end -}}


### PR DESCRIPTION
**Why This PR?**
If you want to use IRSA auth instead of access keys, the chart fails to deploy as the secret does not exist (because it's only created if you pass in access keys)

Fixes #

**Changes**

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
