### PR TITLE
[stable/insights-agent] Fix bug in cloudcosts Helm chart

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## 3.1.5
+* Fix bug in cloud-costs chart
+
+## 3.1.4
+* Fix support for IRSA in cloud-costs
 
 ## 3.1.3
 * Increase default memory for trivy

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 3.1.3
+version: 3.1.5
 appVersion: 9.2.1
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png

--- a/stable/insights-agent/templates/cloud-costs/cronjob.yaml
+++ b/stable/insights-agent/templates/cloud-costs/cronjob.yaml
@@ -22,7 +22,6 @@ spec:
             emptyDir: {}
           {{- end }}  
           containers:
-          {{- if .Values.cloudcosts.secretName }}
           - {{ include "container-spec" . | indent 12 | trim }}
             {{- if eq .Values.cloudcosts.provider "aws" }}
             - name: creds

--- a/stable/insights-agent/templates/cloud-costs/cronjob.yaml
+++ b/stable/insights-agent/templates/cloud-costs/cronjob.yaml
@@ -24,7 +24,6 @@ spec:
           containers:
           - {{ include "container-spec" . | indent 12 | trim }}
             {{- if eq .Values.cloudcosts.provider "aws" }}
-            {{- if .Values.cloudcosts.secretName }}
             - name: creds
               mountPath: /.aws
             env:

--- a/stable/insights-agent/templates/cloud-costs/cronjob.yaml
+++ b/stable/insights-agent/templates/cloud-costs/cronjob.yaml
@@ -28,6 +28,7 @@ spec:
             - name: creds
               mountPath: /.aws
             env:
+            {{- if .Values.cloudcosts.secretName }}
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
**Why This PR?**
I made a mistake in the last update where the `env` key would be missing if you weren't passing in an AWS Key
Fixes #

**Changes**
Changes proposed in this pull request:


**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
