### PR TITLE
[stable/vpa] trim name for certgen job

### DIFF
--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 4.4.2
+version: 4.4.3
 appVersion: 1.0.0
 maintainers:
   - name: sudermanjr

--- a/stable/vpa/templates/webhooks/jobs/certgen-create.yaml
+++ b/stable/vpa/templates/webhooks/jobs/certgen-create.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name:  {{ include "vpa.fullname" . }}-admission-certgen-create
+  name:  {{ include "vpa.fullname" . }}-admission-certgen
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_
We're hitting issues with the 63 character limit when using VPA as a subchart

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
