### PR TITLE
[stable/vpa] Refactor recommender deployment to support insights agent token when in Insights mode

### DIFF
--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 4.4.3
+version: 4.4.4
 appVersion: 1.0.0
 maintainers:
   - name: sudermanjr

--- a/stable/vpa/templates/recommender-deployment.yaml
+++ b/stable/vpa/templates/recommender-deployment.yaml
@@ -64,10 +64,18 @@ spec:
             - name: metrics
               containerPort: 8942
               protocol: TCP
-          {{- if .Values.recommender.envFromSecret }}
+          {{- $extraArgs := .Values.recommender.extraArgs | default dict }}
+          {{- $insightsRecommenderArgs := index $extraArgs "use-insights-recommender" | default dict }}
+          {{- if or .Values.recommender.envFromSecret $insightsRecommenderArgs }}
           envFrom:
+          {{- if $insightsRecommenderArgs }}
           - secretRef:
-              name: {{ .Values.recommender.envFromSecret }}
+            name: {{ .Release.Name }}-token
+          {{- end }}
+          {{- if .Values.recommender.envFromSecret }}
+          - secretRef:
+            name: {{ .Values.recommender.envFromSecret }}
+          {{- end }}
           {{- end }}
           resources:
             {{- toYaml .Values.recommender.resources | nindent 12 }}


### PR DESCRIPTION
**Why This PR?**
The VPA recommender, when in insights mode, needs to be able to reference an insights agent token which exists in a separate chart. To make this possible, we can assume since this chart (VPA) is a dependency of the insights-agent, that the secret name containing the token will be `.Release.Name-token`. We don't template this unless the recommender is configured to run in Insights mode and needs authorization (`.Values.recommender.extraArgs.use-insights-recommender=true`)

Templating:

```sh
helm template vpa . --show-only templates/recommender-deployment.yaml --set recommender.extraArgs.use-insights-recommender=true | grep -C2 'envFrom'
              containerPort: 8942
              protocol: TCP
          envFrom:
          - secretRef:
            name: vpa-token # .Release.Name-token

helm template vpa . --show-only templates/recommender-deployment.yaml --set recommender.extraArgs.use-insights-recommender=false | grep -C2 'envFrom

helm template vpa . --show-only templates/recommender-deployment.yaml --set recommender.envFromSecret=foobar | grep -C2 'envFrom'

              containerPort: 8942
              protocol: TCP
          envFrom:
          - secretRef:
            name: foobar

 helm template vpa . --show-only templates/recommender-deployment.yaml --set recommender.extraArgs.use-insights-recommender=true --set recommender.envFromSecret=foobar | grep -C4 'envFrom'
          ports:
            - name: metrics
              containerPort: 8942
              protocol: TCP
          envFrom:
          - secretRef:
            name: vpa-token
          - secretRef:
            name: foobar

helm template vpa . --show-only templates/recommender-deployment.yaml | grep -C2 'envFrom'
```


**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
