### PR TITLE
[stable/insights-agent] Fixes for right-sizer VPA settings

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 4.0.1
+* add documentation on custom VPA recommender, default min-replicas for vpa updater to 1 for right-sizer
+
 ## 4.0.0
 * `right-sizer` has been renamed to `oom-detection`, which is a component of the new Insights right-sizer. The `right-sizer` prior to this release will be referred to as `oom-detection` going forward. These binaries may be further consolidated in a future release to avoid confusion. Configuration for `right-sizer` in your `values.yaml` will now be under `right-sizer.oom-detection`. e.g.:
 

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 4.0.0
+version: 4.0.1
 appVersion: 9.2.1
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -612,11 +612,17 @@ right-sizer-vpa:
     extraArgs:
       use-insights-recommender: 'true'
       recommender-interval: '1h'
+      # these need to be set separately if using right-sizer, as 'vpa' is a subchart
+      # insights-organization: ''
+      # insights-cluster: ''
   metrics-server:
     # metrics-server.enabled -- If true, the metrics-server will be installed as a sub-chart
     enabled: false
     apiService:
       create: true
+  updater:
+    extraArgs:
+      min-replicas: 1
 
 falco:
   enabled: false


### PR DESCRIPTION
**Why This PR?**
add documentation on custom recommender, default min-replicas for vpa updater to 1 for right-sizer

Fixes #

**Changes**
Because `vpa` is a subchart of `insights-agent`, we have to additionally populate the insights org/cluster in `right-sizer-vpa` like this:

```
right-sizer-vpa:
  recommender:   
    extraArgs:
      insights-organization: 'ORG'
      insights-cluster: 'CLUSTER'
```

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
