### PR TITLE
[stable/insights-agent] Update insights-agent to version 4.0.2 and nova to v3.8.0

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 4.0.2
+* update nova to v3.8.0
+
 ## 4.0.1
 * add documentation on custom VPA recommender, default min-replicas for vpa updater to 1 for right-sizer
 

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 4.0.1
+version: 4.0.2
 appVersion: 9.2.1
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -222,7 +222,7 @@ nova:
   logLevel: 3
   image:
     repository: quay.io/fairwinds/nova
-    tag: "v3.7"
+    tag: "v3.8"
   resources:
     requests:
       cpu: 100m


### PR DESCRIPTION
**Why This PR?**
Updates nova to `v3.8.0` on `insights-agent`

Fixes internal #FWI-5867

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
