### PR TITLE
[stable/insights-agent] Add enableClosedBeta flag, also make it the condition for the VPA subchart

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 4.0.3
+* add `enableClosedBeta` flag to the `right-sizer` chart, also make it the condition for the VPA subchart
+
 ## 4.0.2
 * update nova to v3.8.0
 

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 4.0.2
+version: 4.0.3
 appVersion: 9.2.1
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png

--- a/stable/insights-agent/requirements.yaml
+++ b/stable/insights-agent/requirements.yaml
@@ -19,5 +19,5 @@ dependencies:
 - name: vpa
   version: '4.4.5'
   repository: https://charts.fairwinds.com/stable
-  condition: right-sizer.enabled
+  condition: right-sizer.enableClosedBeta
   alias: right-sizer-vpa

--- a/stable/insights-agent/templates/right-sizer/configmap.yaml
+++ b/stable/insights-agent/templates/right-sizer/configmap.yaml
@@ -1,4 +1,4 @@
-{{- if (index .Values "right-sizer" "enabled") }}
+{{- if and (index .Values "right-sizer" "enabled") (index .Values "right-sizer" "enableClosedBeta") }}
 {{- with (index .Values "right-sizer" "config") }}
 apiVersion: v1
 kind: ConfigMap

--- a/stable/insights-agent/templates/right-sizer/controller-deployment.yaml
+++ b/stable/insights-agent/templates/right-sizer/controller-deployment.yaml
@@ -1,4 +1,4 @@
-{{- if (index .Values "right-sizer" "enabled") }}
+{{- if and (index .Values "right-sizer" "enabled") (index .Values "right-sizer" "enableClosedBeta") }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/stable/insights-agent/templates/vpa-conflict-check.yaml
+++ b/stable/insights-agent/templates/vpa-conflict-check.yaml
@@ -1,0 +1,3 @@
+{{- if and (index .Values "right-sizer" "enableClosedBeta") (.Values.goldilocks.installVPA) }}
+{{- fail "Cannot install VPA for both right-sizer and goldilocks in insights-agent" }}
+{{- end }}

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -454,6 +454,7 @@ cloudcosts:
 # requires a custom VPA configuration to work properly, see `right-sizer-vpa` section below in this values file
 right-sizer:
   enabled: false
+  enableClosedBeta: false
   image:
     repository: quay.io/fairwinds/insights-right-sizer
     tag: v0.0.2-dev


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Also add a check to make sure `right-sizer.enableClosedBeta` and `goldilocks.installVPA` are not both set, as it will obviously cause issues having two VPA deployments.

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
