### PR TITLE
[stable/insights-agent] fix right-sizer oom-detection flag

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 4.0.4
+* Fix guard against installing oom-detector unless right-sizer is enabled
 
 ## 4.0.3
 * add `enableClosedBeta` flag to the `right-sizer` chart, also make it the condition for the VPA subchart

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 4.0.3
+version: 4.0.4
 appVersion: 9.2.1
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png

--- a/stable/insights-agent/templates/right-sizer/oom-detection-agent-cronjob.yaml
+++ b/stable/insights-agent/templates/right-sizer/oom-detection-agent-cronjob.yaml
@@ -1,4 +1,4 @@
-{{- if (index .Values "right-sizer" "oom-detection" "enabled") -}}
+{{- if (and (index .Values "right-sizer" "enabled") (index .Values "right-sizer" "oom-detection" "enabled")) -}}
 {{- $_ := set . "Label" "right-sizer" }}
 {{- $_ := set . "Config" (index .Values "right-sizer" "oom-detection") }}
 {{- include "cronjob" . }}

--- a/stable/insights-agent/templates/right-sizer/oom-detection-controller-deployment.yaml
+++ b/stable/insights-agent/templates/right-sizer/oom-detection-controller-deployment.yaml
@@ -1,4 +1,4 @@
-{{- if (index .Values "right-sizer" "oom-detection" "enabled") -}}
+{{- if (and (index .Values "right-sizer" "enabled") (index .Values "right-sizer" "oom-detection" "enabled")) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/stable/insights-agent/templates/right-sizer/oom-detection-controller-rbac.yaml
+++ b/stable/insights-agent/templates/right-sizer/oom-detection-controller-rbac.yaml
@@ -1,4 +1,4 @@
-{{- if and (index .Values "right-sizer" "oom-detection" "enabled") (not .Values.rbac.disabled) -}}
+{{- if and (and (index .Values "right-sizer" "enabled") (index .Values "right-sizer" "oom-detection" "enabled")) (not .Values.rbac.disabled) -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_
The default install installs the oom-detector, even if you haven't enabled right-sizer


**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
