### PR TITLE
[stable/fairwinds-insights] FWI-5916 - Add support for cronjobs.image-vulnerabilities-refresh

### DIFF
--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 2.2.0
-* Add `cronjobs.image-vulnerabilities-refresh` support
+* Add `cronjobs.image-vulns-refresh` support
 
 ## 2.1.4
 * Update application version to 15.6. [See the release notes for more details](https://insights.docs.fairwinds.com/release-notes)

--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.2.0
+* Add `cronjobs.image-vulnerabilities-refresh` support 
+
 ## 2.1.3
 * Update agent version to 4.x
 

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: "15.5"
+appVersion: "15.6"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 2.1.3
+version: 2.2.0
 kubeVersion: ">= 1.22.0-0"
 maintainers:
   - name: rbren

--- a/stable/fairwinds-insights/README.md
+++ b/stable/fairwinds-insights/README.md
@@ -54,7 +54,7 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | cronjobs.slack-channels | object | `{"command":"slack_channels_local_refresher","schedule":"0/15 * * * *"}` | Options for the slack channels job. |
 | cronjobs.trial-end | object | `{"command":"trial_end_downgrade","schedule":""}` | Options for the trial-end job. |
 | cronjobs.move-health-scores-to-ts | object | `{"command":"move_resource_health_scores_to_ts","schedule":"*/30 * * * *"}` | Options for the move-health-scores-to-ts job. |
-| cronjobs.image-vulnerabilities-refresh | object | `{"command":"image_vulnerabilities_refresher","schedule":"*/30 * * * *"}` | Options for the image-vulnerabilities-refresh job. |
+| cronjobs.image-vulns-refresh | object | `{"command":"image_vulnerabilities_refresher","schedule":"*/30 * * * *"}` | Options for the image-vulns-refresh job. |
 | selfHostedSecret | string | `nil` |  |
 | additionalEnvironmentVariables | object | `{}` | Additional Environment Variables to set on the Fairwinds Insights pods. |
 | rbac.serviceAccount.annotations | object | `{}` | Annotations to add to the service account |

--- a/stable/fairwinds-insights/README.md
+++ b/stable/fairwinds-insights/README.md
@@ -54,7 +54,7 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | cronjobs.slack-channels | object | `{"command":"slack_channels_local_refresher","schedule":"0/15 * * * *"}` | Options for the slack channels job. |
 | cronjobs.trial-end | object | `{"command":"trial_end_downgrade","schedule":""}` | Options for the trial-end job. |
 | cronjobs.move-health-scores-to-ts | object | `{"command":"move_resource_health_scores_to_ts","schedule":"*/30 * * * *"}` | Options for the move-health-scores-to-ts job. |
-| cronjobs.image-vulnerabilities-refresh | object | `{"command":"image_vulnerabilities_refresher","schedule":"*/30 * * * *"}` | Options for the image vulnerabilities refresher job. |
+| cronjobs.image-vulnerabilities-refresh | object | `{"command":"image_vulnerabilities_refresher","schedule":"*/30 * * * *"}` | Options for the image-vulnerabilities-refresh job. |
 | selfHostedSecret | string | `nil` |  |
 | additionalEnvironmentVariables | object | `{}` | Additional Environment Variables to set on the Fairwinds Insights pods. |
 | rbac.serviceAccount.annotations | object | `{}` | Annotations to add to the service account |

--- a/stable/fairwinds-insights/README.md
+++ b/stable/fairwinds-insights/README.md
@@ -54,6 +54,7 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | cronjobs.slack-channels | object | `{"command":"slack_channels_local_refresher","schedule":"0/15 * * * *"}` | Options for the slack channels job. |
 | cronjobs.trial-end | object | `{"command":"trial_end_downgrade","schedule":""}` | Options for the trial-end job. |
 | cronjobs.move-health-scores-to-ts | object | `{"command":"move_resource_health_scores_to_ts","schedule":"*/30 * * * *"}` | Options for the move-health-scores-to-ts job. |
+| cronjobs.image-vulnerabilities-refresh | object | `{"command":"image_vulnerabilities_refresher","schedule":"*/30 * * * *"}` | Options for the image vulnerabilities refresher job. |
 | selfHostedSecret | string | `nil` |  |
 | additionalEnvironmentVariables | object | `{}` | Additional Environment Variables to set on the Fairwinds Insights pods. |
 | rbac.serviceAccount.annotations | object | `{}` | Annotations to add to the service account |

--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -194,7 +194,7 @@ cronjobs:
     command: move_resource_health_scores_to_ts
     schedule: "*/30 * * * *"
 
-  # -- Options for the image vulnerabilities refresher job.
+  # -- Options for the image-vulnerabilities-refresh job.
   image-vulnerabilities-refresh:
     command: image_vulnerabilities_refresher
     schedule: "*/30 * * * *"

--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -194,6 +194,11 @@ cronjobs:
     command: move_resource_health_scores_to_ts
     schedule: "*/30 * * * *"
 
+  # -- Options for the image vulnerabilities refresher job.
+  image-vulnerabilities-refresh:
+    command: 'image_vulnerabilities_refresher'
+    schedule: "*/30 * * * *"
+
 selfHostedSecret:
 
 # -- Additional Environment Variables to set on the Fairwinds Insights pods.

--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -196,7 +196,7 @@ cronjobs:
 
   # -- Options for the image vulnerabilities refresher job.
   image-vulnerabilities-refresh:
-    command: 'image_vulnerabilities_refresher'
+    command: image_vulnerabilities_refresher
     schedule: "*/30 * * * *"
 
 selfHostedSecret:

--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -194,8 +194,8 @@ cronjobs:
     command: move_resource_health_scores_to_ts
     schedule: "*/30 * * * *"
 
-  # -- Options for the image-vulnerabilities-refresh job.
-  image-vulnerabilities-refresh:
+  # -- Options for the image-vulns-refresh job.
+  image-vulns-refresh:
     command: image_vulnerabilities_refresher
     schedule: "*/30 * * * *"
 


### PR DESCRIPTION
…vulnerabilities refresh

**Why This PR?**
Add new cronjob to refresh image vulnerabilities mat. views

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
