### PR TITLE
[stable/vpa] decrease MutatingWebhookConfiguration timeoutSeconds from 30 to 5

### DIFF
--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 4.4.5
+version: 4.4.6
 appVersion: 1.0.0
 maintainers:
   - name: sudermanjr

--- a/stable/vpa/README.md
+++ b/stable/vpa/README.md
@@ -210,7 +210,7 @@ recommender:
 | admissionController.mutatingWebhookConfiguration.failurePolicy | string | `"Ignore"` | The failurePolicy for the mutating webhook. Allowed values are: Ignore, Fail |
 | admissionController.mutatingWebhookConfiguration.namespaceSelector | object | `{}` | The namespaceSelector controls, which namespaces are affected by the webhook |
 | admissionController.mutatingWebhookConfiguration.objectSelector | object | `{}` | The objectSelector can filter object on e.g. labels |
-| admissionController.mutatingWebhookConfiguration.timeoutSeconds | int | `30` |  |
+| admissionController.mutatingWebhookConfiguration.timeoutSeconds | int | `5` |  |
 | admissionController.replicaCount | int | `1` |  |
 | admissionController.revisionHistoryLimit | int | `10` | The number of old replicasets to retain, default is 10, 0 will garbage-collect old replicasets |
 | admissionController.podDisruptionBudget | object | `{}` | This is the setting for the pod disruption budget |

--- a/stable/vpa/values.yaml
+++ b/stable/vpa/values.yaml
@@ -237,7 +237,7 @@ admissionController:
     # admissionController.mutatingWebhookConfiguration.objectSelector -- The objectSelector can filter object on e.g. labels
     objectSelector: {}
     # admissionController.mutatingWebhookConfiguration.timeout -- Sets the amount of time the API server will wait on a response from the webhook service.
-    timeoutSeconds: 30
+    timeoutSeconds: 5
 
   replicaCount: 1
   # admissionController.revisionHistoryLimit -- The number of old replicasets to retain, default is 10, 0 will garbage-collect old replicasets


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

We've observed that a long `timeoutSeconds` in the VPA admission webhook, while the admission controller itself is unresponsive, can cause an associated `ReplicaSet` to enter a backoff period where pod scheduling is no longer attempted for an indeterminate amount of time

Fixes #6015

**Changes**
Changes proposed in this pull request:

Decrease the `timeoutSeconds` in the VPA admission controller from `30` to `5` to avoid failures in ReplicaSet scheduling

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
