### PR TITLE
[stable/insights-agent] exclude kube-system from right-sizer VPA admission controller webhook

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 4.1.2
+* Exclude kube-system from VPA admission controller webhook in right-sizer
+
 ## 4.1.1
 * Fixed cloud costs data conversion
 

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 4.1.1
+version: 4.1.2
 appVersion: 9.2.1
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -624,6 +624,13 @@ right-sizer-vpa:
   updater:
     extraArgs:
       min-replicas: 1
+  mutatingWebhookConfiguration:
+    namespaceSelector:
+      matchExpressions:
+      - key: kubernetes.io/metadata.name
+        operator: NotIn
+        values:
+        - kube-system
 
 falco:
   enabled: false


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Fixes FWI-6016

**Changes**
Changes proposed in this pull request:

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
