### PR TITLE
[incubator/datadog-apm] Bump datadog agent image tag to latest

### DIFF
--- a/incubator/datadog-apm/Chart.yaml
+++ b/incubator/datadog-apm/Chart.yaml
@@ -4,7 +4,7 @@ name: datadog-apm
 description: A modified chart that only installs the datadog-apm agent
 type: application
 version: 0.0.13
-appVersion: 7.52.1
+appVersion: 7.55.3
 maintainers:
   - name: sudermanjr
   - name: Azahorscak

--- a/incubator/datadog-apm/Chart.yaml
+++ b/incubator/datadog-apm/Chart.yaml
@@ -4,7 +4,7 @@ name: datadog-apm
 description: A modified chart that only installs the datadog-apm agent
 type: application
 version: 0.0.13
-appVersion: 7.55.3
+appVersion: 7.55.2
 maintainers:
   - name: sudermanjr
   - name: Azahorscak

--- a/incubator/datadog-apm/Chart.yaml
+++ b/incubator/datadog-apm/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: datadog-apm
 description: A modified chart that only installs the datadog-apm agent
 type: application
-version: 0.0.13
+version: 1.0.0
 appVersion: 7.55.2
 maintainers:
   - name: sudermanjr

--- a/incubator/datadog-apm/Chart.yaml
+++ b/incubator/datadog-apm/Chart.yaml
@@ -3,8 +3,8 @@ apiVersion: v2
 name: datadog-apm
 description: A modified chart that only installs the datadog-apm agent
 type: application
-version: 0.0.12
-appVersion: 7.40.0
+version: 0.0.13
+appVersion: 7.52.1
 maintainers:
   - name: sudermanjr
   - name: Azahorscak

--- a/incubator/datadog-apm/README.md
+++ b/incubator/datadog-apm/README.md
@@ -37,7 +37,7 @@ A modified chart that only installs the datadog-apm agent
 | clusterAgent.image.pullPolicy | string | `"Always"` |  |
 | clusterAgent.image.tag | string | `""` | Overrides the image tag whose default is {{ .Chart.AppVersion }} |
 | clusterAgent.command[0] | string | `"trace-agent"` |  |
-| clusterAgent.command[1] | string | `"-config=/etc/datadog-agent/datadog.yaml"` |  |
+| clusterAgent.command[1] | string | `"--config=/etc/datadog-agent/datadog-cluster.yaml"` |  |
 | clusterAgent.enabled | bool | `true` |  |
 | clusterAgent.token | string | `nil` |  |
 | clusterAgent.apm.enabled | bool | `true` |  |

--- a/incubator/datadog-apm/README.md
+++ b/incubator/datadog-apm/README.md
@@ -27,7 +27,7 @@ A modified chart that only installs the datadog-apm agent
 | nameOverride | string | `""` |  |
 | fullnameOverride | string | `""` |  |
 | targetSystem | string | `"linux"` |  |
-| remoteConfiguration | bool | `false` |  |
+| remoteConfiguration.enabled | bool | `false` |  |
 | datadog.apiKey | string | `nil` |  |
 | datadog.apiKeyExistingSecret | string | `nil` |  |
 | datadog.appKey | string | `nil` |  |

--- a/incubator/datadog-apm/README.md
+++ b/incubator/datadog-apm/README.md
@@ -5,7 +5,7 @@
 
 # datadog-apm
 
-![Version: 0.0.13](https://img.shields.io/badge/Version-0.0.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.40.0](https://img.shields.io/badge/AppVersion-7.52.1-informational?style=flat-square)
+![Version: 0.0.13](https://img.shields.io/badge/Version-0.0.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.52.1](https://img.shields.io/badge/AppVersion-7.52.1-informational?style=flat-square)
 
 A modified chart that only installs the datadog-apm agent
 

--- a/incubator/datadog-apm/README.md
+++ b/incubator/datadog-apm/README.md
@@ -5,7 +5,7 @@
 
 # datadog-apm
 
-![Version: 0.0.10](https://img.shields.io/badge/Version-0.0.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.40.0](https://img.shields.io/badge/AppVersion-7.40.0-informational?style=flat-square)
+![Version: 0.0.13](https://img.shields.io/badge/Version-0.0.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.40.0](https://img.shields.io/badge/AppVersion-7.52.1-informational?style=flat-square)
 
 A modified chart that only installs the datadog-apm agent
 

--- a/incubator/datadog-apm/README.md
+++ b/incubator/datadog-apm/README.md
@@ -5,7 +5,7 @@
 
 # datadog-apm
 
-![Version: 0.0.13](https://img.shields.io/badge/Version-0.0.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.55.2](https://img.shields.io/badge/AppVersion-7.55.2-informational?style=flat-square)
+![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.55.2](https://img.shields.io/badge/AppVersion-7.55.2-informational?style=flat-square)
 
 A modified chart that only installs the datadog-apm agent
 
@@ -27,13 +27,13 @@ A modified chart that only installs the datadog-apm agent
 | nameOverride | string | `""` |  |
 | fullnameOverride | string | `""` |  |
 | targetSystem | string | `"linux"` |  |
+| remoteConfiguration.enabled | bool | `false` |  |
 | datadog.apiKey | string | `nil` |  |
 | datadog.apiKeyExistingSecret | string | `nil` |  |
 | datadog.appKey | string | `nil` |  |
 | datadog.appKeySecretName | string | `nil` |  |
 | datadog.logLevel | string | `"INFO"` |  |
 | datadog.site | string | `"datadoghq.com"` |  |
-| datadog.remoteConfiguration.enabled | bool | `false` |  |
 | clusterAgent.image.repository | string | `"datadog/agent"` |  |
 | clusterAgent.image.pullPolicy | string | `"Always"` |  |
 | clusterAgent.image.tag | string | `""` | Overrides the image tag whose default is {{ .Chart.AppVersion }} |

--- a/incubator/datadog-apm/README.md
+++ b/incubator/datadog-apm/README.md
@@ -78,6 +78,7 @@ A modified chart that only installs the datadog-apm agent
 | clusterAgent.createPodDisruptionBudget | bool | `true` |  |
 | podAnnotations | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |
+| remoteConfiguration.enabled | bool | `false` |  |
 | securityContext | object | `{}` |  |
 | nodeSelector | object | `{}` |  |
 | tolerations | list | `[]` |  |

--- a/incubator/datadog-apm/README.md
+++ b/incubator/datadog-apm/README.md
@@ -5,7 +5,7 @@
 
 # datadog-apm
 
-![Version: 0.0.13](https://img.shields.io/badge/Version-0.0.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.52.1](https://img.shields.io/badge/AppVersion-7.52.1-informational?style=flat-square)
+![Version: 0.0.13](https://img.shields.io/badge/Version-0.0.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.55.3](https://img.shields.io/badge/AppVersion-7.55.3-informational?style=flat-square)
 
 A modified chart that only installs the datadog-apm agent
 

--- a/incubator/datadog-apm/README.md
+++ b/incubator/datadog-apm/README.md
@@ -5,7 +5,7 @@
 
 # datadog-apm
 
-![Version: 0.0.13](https://img.shields.io/badge/Version-0.0.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.55.3](https://img.shields.io/badge/AppVersion-7.55.3-informational?style=flat-square)
+![Version: 0.0.13](https://img.shields.io/badge/Version-0.0.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.55.2](https://img.shields.io/badge/AppVersion-7.55.2-informational?style=flat-square)
 
 A modified chart that only installs the datadog-apm agent
 

--- a/incubator/datadog-apm/README.md
+++ b/incubator/datadog-apm/README.md
@@ -27,7 +27,7 @@ A modified chart that only installs the datadog-apm agent
 | nameOverride | string | `""` |  |
 | fullnameOverride | string | `""` |  |
 | targetSystem | string | `"linux"` |  |
-| remoteConfiguration.enabled | bool | `false` |  |
+| remoteConfiguration | bool | `false` |  |
 | datadog.apiKey | string | `nil` |  |
 | datadog.apiKeyExistingSecret | string | `nil` |  |
 | datadog.appKey | string | `nil` |  |

--- a/incubator/datadog-apm/README.md
+++ b/incubator/datadog-apm/README.md
@@ -27,6 +27,7 @@ A modified chart that only installs the datadog-apm agent
 | nameOverride | string | `""` |  |
 | fullnameOverride | string | `""` |  |
 | targetSystem | string | `"linux"` |  |
+| remoteConfiguration.enabled | bool | `false` |  |
 | datadog.apiKey | string | `nil` |  |
 | datadog.apiKeyExistingSecret | string | `nil` |  |
 | datadog.appKey | string | `nil` |  |
@@ -78,7 +79,6 @@ A modified chart that only installs the datadog-apm agent
 | clusterAgent.createPodDisruptionBudget | bool | `true` |  |
 | podAnnotations | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |
-| remoteConfiguration.enabled | bool | `false` |  |
 | securityContext | object | `{}` |  |
 | nodeSelector | object | `{}` |  |
 | tolerations | list | `[]` |  |

--- a/incubator/datadog-apm/README.md
+++ b/incubator/datadog-apm/README.md
@@ -27,13 +27,13 @@ A modified chart that only installs the datadog-apm agent
 | nameOverride | string | `""` |  |
 | fullnameOverride | string | `""` |  |
 | targetSystem | string | `"linux"` |  |
-| remoteConfiguration.enabled | bool | `false` |  |
 | datadog.apiKey | string | `nil` |  |
 | datadog.apiKeyExistingSecret | string | `nil` |  |
 | datadog.appKey | string | `nil` |  |
 | datadog.appKeySecretName | string | `nil` |  |
 | datadog.logLevel | string | `"INFO"` |  |
 | datadog.site | string | `"datadoghq.com"` |  |
+| datadog.remoteConfiguration.enabled | bool | `false` |  |
 | clusterAgent.image.repository | string | `"datadog/agent"` |  |
 | clusterAgent.image.pullPolicy | string | `"Always"` |  |
 | clusterAgent.image.tag | string | `""` | Overrides the image tag whose default is {{ .Chart.AppVersion }} |

--- a/incubator/datadog-apm/README.md.gotmpl
+++ b/incubator/datadog-apm/README.md.gotmpl
@@ -5,7 +5,7 @@
 
 # datadog-apm
 
-![Version: 0.0.13](https://img.shields.io/badge/Version-0.0.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.55.2](https://img.shields.io/badge/AppVersion-7.55.2-informational?style=flat-square)
+![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.55.2](https://img.shields.io/badge/AppVersion-7.55.2-informational?style=flat-square)
 
 A modified chart that only installs the datadog-apm agent
 

--- a/incubator/datadog-apm/README.md.gotmpl
+++ b/incubator/datadog-apm/README.md.gotmpl
@@ -5,7 +5,7 @@
 
 # datadog-apm
 
-![Version: 0.0.13](https://img.shields.io/badge/Version-0.0.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.52.1](https://img.shields.io/badge/AppVersion-7.52.1-informational?style=flat-square)
+![Version: 0.0.13](https://img.shields.io/badge/Version-0.0.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.55.3](https://img.shields.io/badge/AppVersion-7.55.3-informational?style=flat-square)
 
 A modified chart that only installs the datadog-apm agent
 

--- a/incubator/datadog-apm/README.md.gotmpl
+++ b/incubator/datadog-apm/README.md.gotmpl
@@ -5,7 +5,7 @@
 
 # datadog-apm
 
-![Version: 0.0.13](https://img.shields.io/badge/Version-0.0.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.55.3](https://img.shields.io/badge/AppVersion-7.55.3-informational?style=flat-square)
+![Version: 0.0.13](https://img.shields.io/badge/Version-0.0.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.55.2](https://img.shields.io/badge/AppVersion-7.55.2-informational?style=flat-square)
 
 A modified chart that only installs the datadog-apm agent
 

--- a/incubator/datadog-apm/README.md.gotmpl
+++ b/incubator/datadog-apm/README.md.gotmpl
@@ -5,7 +5,7 @@
 
 # datadog-apm
 
-![Version: 0.0.10](https://img.shields.io/badge/Version-0.0.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.40.0](https://img.shields.io/badge/AppVersion-7.40.0-informational?style=flat-square)
+![Version: 0.0.13](https://img.shields.io/badge/Version-0.0.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.52.1](https://img.shields.io/badge/AppVersion-7.52.1-informational?style=flat-square)
 
 A modified chart that only installs the datadog-apm agent
 

--- a/incubator/datadog-apm/ci/test-values.yaml
+++ b/incubator/datadog-apm/ci/test-values.yaml
@@ -21,7 +21,7 @@ clusterAgent:
     tag: ""
   command:
     - trace-agent
-    - -config=/etc/datadog-agent/datadog.yaml
+    - --config=/etc/datadog-agent/datadog-cluster.yaml
   enabled: true
   # -- DATADOG_CLUSTER_AGENT_TOKEN
   token: XXXYYYXXXYYYXXXYYYXXXYYYXXX=

--- a/incubator/datadog-apm/ci/test-values.yaml
+++ b/incubator/datadog-apm/ci/test-values.yaml
@@ -3,7 +3,8 @@
 nameOverride: ""
 fullnameOverride: ""
 targetSystem: linux
-
+remoteConfiguration:
+  enabled: false
 datadog:
   apiKey: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX  # <DATADOG_API_KEY>
   apiKeyExistingSecret:   # <DATADOG_API_KEY_SECRET>

--- a/incubator/datadog-apm/templates/cluster-agent-deployment.yaml
+++ b/incubator/datadog-apm/templates/cluster-agent-deployment.yaml
@@ -108,8 +108,10 @@ spec:
                 name: {{ template "datadog-apm.apiSecretName" . }}
                 key: api-key
                 optional: true
+{{- if and .Values.remoteConfigration .Values.remoteConfigration.enabled -}}
           - name: DD_REMOTE_CONFIGURATION_ENABLED
-            value: {{ .Values.clusterAgent.metricsProvider.useDatadogMetrics | quote }}
+            value: {{ .Values.remoteConfigration.enabled | quote }}
+{{- end }}
           {{- if .Values.clusterAgent.metricsProvider.enabled }}
           - name: DD_APP_KEY
             valueFrom:

--- a/incubator/datadog-apm/templates/cluster-agent-deployment.yaml
+++ b/incubator/datadog-apm/templates/cluster-agent-deployment.yaml
@@ -24,14 +24,14 @@ spec:
     matchLabels:
       app: {{ template "datadog-apm.fullname" . }}-cluster-agent
         {{- if .Values.clusterAgent.podLabels }}
-{{ toYaml .Values.clusterAgent.podLabels | indent 6 }}
+          {{ toYaml .Values.clusterAgent.podLabels | indent 6 }}
         {{- end }}
   template:
     metadata:
       labels:
         app: {{ template "datadog-apm.fullname" . }}-cluster-agent
         {{- if .Values.clusterAgent.podLabels }}
-{{ toYaml .Values.clusterAgent.podLabels | indent 8 }}
+        {{ toYaml .Values.clusterAgent.podLabels | indent 8 }}
         {{- end }}
       name: {{ template "datadog-apm.fullname" . }}-cluster-agent
       annotations:
@@ -55,7 +55,7 @@ spec:
             ]
           }]
       {{- if .Values.clusterAgent.podAnnotations }}
-{{ toYaml .Values.clusterAgent.podAnnotations | indent 8 }}
+      {{ toYaml .Values.clusterAgent.podAnnotations | indent 8 }}
       {{- end }}
 
     spec:
@@ -64,7 +64,7 @@ spec:
       {{- end }}
       {{- if .Values.clusterAgent.image.pullSecrets }}
       imagePullSecrets:
-{{ toYaml .Values.clusterAgent.image.pullSecrets | indent 8 }}
+      {{ toYaml .Values.clusterAgent.image.pullSecrets | indent 8 }}
       {{- end }}
       serviceAccountName: {{ template "datadog-apm.serviceAccountName" . }}
       {{- if .Values.clusterAgent.useHostNetwork }}
@@ -73,7 +73,7 @@ spec:
       {{- end }}
       {{- if .Values.clusterAgent.dnsConfig }}
       dnsConfig:
-{{ toYaml .Values.clusterAgent.dnsConfig | indent 8 }}
+      {{ toYaml .Values.clusterAgent.dnsConfig | indent 8 }}
       {{- end }}
       containers:
       - name: cluster-agent
@@ -85,7 +85,7 @@ spec:
         {{- end }}
         imagePullPolicy: {{ .Values.clusterAgent.image.pullPolicy }}
         resources:
-{{ toYaml .Values.clusterAgent.resources | indent 10 }}
+        {{ toYaml .Values.clusterAgent.resources | indent 10 }}
         ports:
         - containerPort: 5005
           name: agentport
@@ -95,10 +95,10 @@ spec:
           name: metricsapi
           protocol: TCP
         {{- end }}
-{{- if .Values.datadog.envFrom }}
+        {{- if .Values.datadog.envFrom }}
         envFrom:
-{{ toYaml .Values.datadog.envFrom | indent 10 }}
-{{- end }}
+        {{ toYaml .Values.datadog.envFrom | indent 10 }}
+        {{- end }}
         env:
           - name: DD_HEALTH_PORT
             value: {{ .Values.clusterAgent.healthPort | quote }}
@@ -109,7 +109,7 @@ spec:
                 key: api-key
                 optional: true
           - name: DD_REMOTE_CONFIGURATION_ENABLED
-            value: {{ .Values.remoteConfiguration.enabled | quote }}
+            value: {{ .Values.datadog.remoteConfiguration.enabled | quote }}
           {{- if .Values.clusterAgent.metricsProvider.enabled }}
           - name: DD_APP_KEY
             valueFrom:

--- a/incubator/datadog-apm/templates/cluster-agent-deployment.yaml
+++ b/incubator/datadog-apm/templates/cluster-agent-deployment.yaml
@@ -108,10 +108,8 @@ spec:
                 name: {{ template "datadog-apm.apiSecretName" . }}
                 key: api-key
                 optional: true
-          {{- if .Values.datadog.remoteConfiguration.enabled }}
           - name: DD_REMOTE_CONFIGURATION_ENABLED
-            value: {{ .Values.datadog.remoteConfiguration.enabled | quote }}
-          {{- end }}
+            value: {{ .Values.clusterAgent.metricsProvider.useDatadogMetrics | quote }}
           {{- if .Values.clusterAgent.metricsProvider.enabled }}
           - name: DD_APP_KEY
             valueFrom:

--- a/incubator/datadog-apm/templates/cluster-agent-deployment.yaml
+++ b/incubator/datadog-apm/templates/cluster-agent-deployment.yaml
@@ -116,6 +116,8 @@ spec:
                 key: app-key
           - name: DD_EXTERNAL_METRICS_PROVIDER_ENABLED
             value: {{ .Values.clusterAgent.metricsProvider.enabled | quote }}
+          - name: DD_REMOTE_CONFIGURATION_ENABLED
+            value: {{ .Values.remoteConfiguration.enabled | quote }}
           - name: DD_EXTERNAL_METRICS_PROVIDER_PORT
             value: {{ include "clusterAgent.metricsProvider.port" . | quote }}
           - name: DD_EXTERNAL_METRICS_PROVIDER_WPA_CONTROLLER

--- a/incubator/datadog-apm/templates/cluster-agent-deployment.yaml
+++ b/incubator/datadog-apm/templates/cluster-agent-deployment.yaml
@@ -108,8 +108,10 @@ spec:
                 name: {{ template "datadog-apm.apiSecretName" . }}
                 key: api-key
                 optional: true
+          {{- if .Values.datadog.remoteConfiguration.enabled }}
           - name: DD_REMOTE_CONFIGURATION_ENABLED
             value: {{ .Values.datadog.remoteConfiguration.enabled | quote }}
+          {{- end }}
           {{- if .Values.clusterAgent.metricsProvider.enabled }}
           - name: DD_APP_KEY
             valueFrom:

--- a/incubator/datadog-apm/templates/cluster-agent-deployment.yaml
+++ b/incubator/datadog-apm/templates/cluster-agent-deployment.yaml
@@ -108,10 +108,10 @@ spec:
                 name: {{ template "datadog-apm.apiSecretName" . }}
                 key: api-key
                 optional: true
-{{- if and .Values.remoteConfigration .Values.remoteConfigration.enabled -}}
+          {{- if .Values.remoteConfigration -}}
           - name: DD_REMOTE_CONFIGURATION_ENABLED
-            value: {{ .Values.remoteConfigration.enabled | quote }}
-{{- end }}
+            value: {{ .Values.remoteConfigration | quote }}
+          {{- end }}
           {{- if .Values.clusterAgent.metricsProvider.enabled }}
           - name: DD_APP_KEY
             valueFrom:

--- a/incubator/datadog-apm/templates/cluster-agent-deployment.yaml
+++ b/incubator/datadog-apm/templates/cluster-agent-deployment.yaml
@@ -109,7 +109,7 @@ spec:
                 key: api-key
                 optional: true
           - name: DD_REMOTE_CONFIGURATION_ENABLED
-            value: "false"
+            value: {{ .Values.remoteConfiguration.enabled | quote }}
           {{- if .Values.clusterAgent.metricsProvider.enabled }}
           - name: DD_APP_KEY
             valueFrom:

--- a/incubator/datadog-apm/templates/cluster-agent-deployment.yaml
+++ b/incubator/datadog-apm/templates/cluster-agent-deployment.yaml
@@ -108,10 +108,8 @@ spec:
                 name: {{ template "datadog-apm.apiSecretName" . }}
                 key: api-key
                 optional: true
-          {{- if .Values.remoteConfigration -}}
           - name: DD_REMOTE_CONFIGURATION_ENABLED
-            value: {{ .Values.remoteConfigration | quote }}
-          {{- end }}
+            value: "false"
           {{- if .Values.clusterAgent.metricsProvider.enabled }}
           - name: DD_APP_KEY
             valueFrom:

--- a/incubator/datadog-apm/templates/cluster-agent-deployment.yaml
+++ b/incubator/datadog-apm/templates/cluster-agent-deployment.yaml
@@ -108,6 +108,8 @@ spec:
                 name: {{ template "datadog-apm.apiSecretName" . }}
                 key: api-key
                 optional: true
+          - name: DD_REMOTE_CONFIGURATION_ENABLED
+            value: {{ .Values.remoteConfiguration.enabled | quote }}
           {{- if .Values.clusterAgent.metricsProvider.enabled }}
           - name: DD_APP_KEY
             valueFrom:
@@ -116,8 +118,6 @@ spec:
                 key: app-key
           - name: DD_EXTERNAL_METRICS_PROVIDER_ENABLED
             value: {{ .Values.clusterAgent.metricsProvider.enabled | quote }}
-          - name: DD_REMOTE_CONFIGURATION_ENABLED
-            value: {{ .Values.remoteConfiguration.enabled | quote }}
           - name: DD_EXTERNAL_METRICS_PROVIDER_PORT
             value: {{ include "clusterAgent.metricsProvider.port" . | quote }}
           - name: DD_EXTERNAL_METRICS_PROVIDER_WPA_CONTROLLER

--- a/incubator/datadog-apm/templates/cluster-agent-deployment.yaml
+++ b/incubator/datadog-apm/templates/cluster-agent-deployment.yaml
@@ -24,14 +24,14 @@ spec:
     matchLabels:
       app: {{ template "datadog-apm.fullname" . }}-cluster-agent
         {{- if .Values.clusterAgent.podLabels }}
-          {{ toYaml .Values.clusterAgent.podLabels | indent 6 }}
+{{ toYaml .Values.clusterAgent.podLabels | indent 6 }}
         {{- end }}
   template:
     metadata:
       labels:
         app: {{ template "datadog-apm.fullname" . }}-cluster-agent
         {{- if .Values.clusterAgent.podLabels }}
-        {{ toYaml .Values.clusterAgent.podLabels | indent 8 }}
+{{ toYaml .Values.clusterAgent.podLabels | indent 8 }}
         {{- end }}
       name: {{ template "datadog-apm.fullname" . }}-cluster-agent
       annotations:
@@ -55,7 +55,7 @@ spec:
             ]
           }]
       {{- if .Values.clusterAgent.podAnnotations }}
-      {{ toYaml .Values.clusterAgent.podAnnotations | indent 8 }}
+{{ toYaml .Values.clusterAgent.podAnnotations | indent 8 }}
       {{- end }}
 
     spec:
@@ -64,7 +64,7 @@ spec:
       {{- end }}
       {{- if .Values.clusterAgent.image.pullSecrets }}
       imagePullSecrets:
-      {{ toYaml .Values.clusterAgent.image.pullSecrets | indent 8 }}
+{{ toYaml .Values.clusterAgent.image.pullSecrets | indent 8 }}
       {{- end }}
       serviceAccountName: {{ template "datadog-apm.serviceAccountName" . }}
       {{- if .Values.clusterAgent.useHostNetwork }}
@@ -73,7 +73,7 @@ spec:
       {{- end }}
       {{- if .Values.clusterAgent.dnsConfig }}
       dnsConfig:
-      {{ toYaml .Values.clusterAgent.dnsConfig | indent 8 }}
+{{ toYaml .Values.clusterAgent.dnsConfig | indent 8 }}
       {{- end }}
       containers:
       - name: cluster-agent
@@ -85,7 +85,7 @@ spec:
         {{- end }}
         imagePullPolicy: {{ .Values.clusterAgent.image.pullPolicy }}
         resources:
-        {{ toYaml .Values.clusterAgent.resources | indent 10 }}
+{{ toYaml .Values.clusterAgent.resources | indent 10 }}
         ports:
         - containerPort: 5005
           name: agentport
@@ -95,10 +95,10 @@ spec:
           name: metricsapi
           protocol: TCP
         {{- end }}
-        {{- if .Values.datadog.envFrom }}
+{{- if .Values.datadog.envFrom }}
         envFrom:
-        {{ toYaml .Values.datadog.envFrom | indent 10 }}
-        {{- end }}
+{{ toYaml .Values.datadog.envFrom | indent 10 }}
+{{- end }}
         env:
           - name: DD_HEALTH_PORT
             value: {{ .Values.clusterAgent.healthPort | quote }}

--- a/incubator/datadog-apm/values.yaml
+++ b/incubator/datadog-apm/values.yaml
@@ -4,6 +4,9 @@ nameOverride: ""
 fullnameOverride: ""
 targetSystem: linux
 
+remoteConfiguration:
+  enabled: false
+
 datadog:
   apiKey:  # <DATADOG_API_KEY>
   apiKeyExistingSecret:   # <DATADOG_API_KEY_SECRET>
@@ -20,7 +23,7 @@ clusterAgent:
     tag: ""
   command:
     - trace-agent
-    - -config=/etc/datadog-agent/datadog.yaml
+    - --config=/etc/datadog-agent/datadog-cluster.yaml
   enabled: true
   token:   # <DATADOG_CLUSTER_AGENT_TOKEN>
   apm:

--- a/incubator/datadog-apm/values.yaml
+++ b/incubator/datadog-apm/values.yaml
@@ -4,7 +4,8 @@ nameOverride: ""
 fullnameOverride: ""
 targetSystem: linux
 
-remoteConfiguration: false
+remoteConfiguration:
+  enabled: false
 datadog:
   apiKey:  # <DATADOG_API_KEY>
   apiKeyExistingSecret:   # <DATADOG_API_KEY_SECRET>

--- a/incubator/datadog-apm/values.yaml
+++ b/incubator/datadog-apm/values.yaml
@@ -4,9 +4,7 @@ nameOverride: ""
 fullnameOverride: ""
 targetSystem: linux
 
-remoteConfiguration:
-  enabled: false
-
+remoteConfiguration: false
 datadog:
   apiKey:  # <DATADOG_API_KEY>
   apiKeyExistingSecret:   # <DATADOG_API_KEY_SECRET>

--- a/incubator/datadog-apm/values.yaml
+++ b/incubator/datadog-apm/values.yaml
@@ -4,8 +4,6 @@ nameOverride: ""
 fullnameOverride: ""
 targetSystem: linux
 
-remoteConfiguration:
-  enabled: false
 
 datadog:
   apiKey:  # <DATADOG_API_KEY>
@@ -14,7 +12,8 @@ datadog:
   appKeySecretName:   # <DATADOG_APP_KEY_SECRET>
   logLevel: INFO
   site: datadoghq.com
-
+  remoteConfiguration:
+    enabled: false
 clusterAgent:
   image:
     repository: datadog/agent

--- a/incubator/datadog-apm/values.yaml
+++ b/incubator/datadog-apm/values.yaml
@@ -4,6 +4,8 @@ nameOverride: ""
 fullnameOverride: ""
 targetSystem: linux
 
+remoteConfiguration:
+  enabled: false
 
 datadog:
   apiKey:  # <DATADOG_API_KEY>
@@ -12,8 +14,7 @@ datadog:
   appKeySecretName:   # <DATADOG_APP_KEY_SECRET>
   logLevel: INFO
   site: datadoghq.com
-  remoteConfiguration:
-    enabled: false
+
 clusterAgent:
   image:
     repository: datadog/agent


### PR DESCRIPTION
**Why This PR?**
Bumping the image version to the latest datadog image tag

Fixes #

**Changes**
Changes proposed in this pull request:

* Bumps appVersion to use latest datadog agent image
* Disables remote configuration by default since this only handles tracing

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
