### PR TITLE
[stable/insights-agent] Prometheus plugin: added support to service account annotations

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 4.2.1
+* prometheus service account
+
 ## 4.2.0
 * Collecting Idle usage from prometheus plugin
 

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 4.2.0
+version: 4.2.1
 appVersion: 9.2.1
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png

--- a/stable/insights-agent/templates/prometheus-metrics/rbac.yaml
+++ b/stable/insights-agent/templates/prometheus-metrics/rbac.yaml
@@ -5,10 +5,10 @@ metadata:
   name: {{ include "insights-agent.fullname" . }}-prometheus-metrics
   labels:
     app: insights-agent
-  {{- with .Values "prometheus-metrics" "serviceAccount" "annotations" }}
+  {{- if  (index $.Values "prometheus-metrics" "serviceAccount" "annotations") }}
   annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end -}}
+    {{- toYaml (index $.Values "prometheus-metrics" "serviceAccount" "annotations") | nindent 4 }}
+  {{- end }}  
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/stable/insights-agent/templates/prometheus-metrics/rbac.yaml
+++ b/stable/insights-agent/templates/prometheus-metrics/rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "insights-agent.fullname" . }}-prometheus-metrics
   labels:
     app: insights-agent
-  {{- with .Values "prometheus-metrics" "serviceAccount" "annotations" }}
+  {{- with .Values.prometheus-metrics.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end -}}

--- a/stable/insights-agent/templates/prometheus-metrics/rbac.yaml
+++ b/stable/insights-agent/templates/prometheus-metrics/rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "insights-agent.fullname" . }}-prometheus-metrics
   labels:
     app: insights-agent
-  {{- with .Values "prometheus-metrics" "serviceAccount.annotations" }}
+  {{- with .Values.prometheus-metrics.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end -}}

--- a/stable/insights-agent/templates/prometheus-metrics/rbac.yaml
+++ b/stable/insights-agent/templates/prometheus-metrics/rbac.yaml
@@ -7,7 +7,8 @@ metadata:
     app: insights-agent
   {{- with .Values "prometheus-metrics" "serviceAccount" "annotations" }}
   annotations:
-    {{- toYaml . | nindent 4 }}    
+    {{- toYaml . | nindent 4 }}
+  {{- end -}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/stable/insights-agent/templates/prometheus-metrics/rbac.yaml
+++ b/stable/insights-agent/templates/prometheus-metrics/rbac.yaml
@@ -5,10 +5,12 @@ metadata:
   name: {{ include "insights-agent.fullname" . }}-prometheus-metrics
   labels:
     app: insights-agent
+  {{- if  (index $.Values "prometheus-metrics" "serviceAccount") }}
   {{- if  (index $.Values "prometheus-metrics" "serviceAccount" "annotations") }}
   annotations:
     {{- toYaml (index $.Values "prometheus-metrics" "serviceAccount" "annotations") | nindent 4 }}
-  {{- end }}  
+  {{- end }}
+  {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/stable/insights-agent/templates/prometheus-metrics/rbac.yaml
+++ b/stable/insights-agent/templates/prometheus-metrics/rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "insights-agent.fullname" . }}-prometheus-metrics
   labels:
     app: insights-agent
-  {{- with .Values.prometheus-metrics.serviceAccount.annotations }}
+  {{- with .Values "prometheus-metrics" "serviceAccount.annotations" }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end -}}

--- a/stable/insights-agent/templates/prometheus-metrics/rbac.yaml
+++ b/stable/insights-agent/templates/prometheus-metrics/rbac.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "insights-agent.fullname" . }}-prometheus-metrics
   labels:
     app: insights-agent
+  {{- with .Values "prometheus-metrics" "serviceAccount" "annotations" }}
+  annotations:
+    {{- toYaml . | nindent 4 }}    
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/stable/insights-agent/templates/prometheus-metrics/rbac.yaml
+++ b/stable/insights-agent/templates/prometheus-metrics/rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "insights-agent.fullname" . }}-prometheus-metrics
   labels:
     app: insights-agent
-  {{- with .Values.prometheus-metrics.serviceAccount.annotations }}
+  {{- with .Values "prometheus-metrics" "serviceAccount" "annotations" }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end -}}

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -323,7 +323,7 @@ prometheus-metrics:
       cpu: 100m
       memory: 128Mi
   serviceAccount:
-    annotations:      
+    annotations:
 
 prometheus:
   kubeStateMetrics:

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -322,6 +322,8 @@ prometheus-metrics:
     requests:
       cpu: 100m
       memory: 128Mi
+  serviceAccount:
+    annotations:      
 
 prometheus:
   kubeStateMetrics:


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
