### PR TITLE
[stable/insights-agent] Added new cluster name parameter to prometheus collector

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 4.2.2
+* prometheus cluster name parameter
+
 ## 4.2.1
 * prometheus service account
 

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 4.2.1
+version: 4.2.2
 appVersion: 9.2.1
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png

--- a/stable/insights-agent/templates/prometheus-metrics/cronjob.yaml
+++ b/stable/insights-agent/templates/prometheus-metrics/cronjob.yaml
@@ -22,7 +22,7 @@ spec:
             - name: PROMETHEUS_ADDRESS
               value: {{ (index .Values "prometheus-metrics"  "address") | quote }}
             - name: CLUSTER_NAME
-              value: {{ (index .Values "prometheus-metrics"  "providerClusterName") | quote }}
+              value: {{ (index .Values "prometheus-metrics"  "managedPrometheusClusterName") | quote }}
             {{ include "proxy-env-spec" . | indent 12 | trim }}
             {{ include "security-context" . | indent 12 | trim }}
           {{ include "uploaderContainer" . | indent 10 | trim }}

--- a/stable/insights-agent/templates/prometheus-metrics/cronjob.yaml
+++ b/stable/insights-agent/templates/prometheus-metrics/cronjob.yaml
@@ -21,6 +21,8 @@ spec:
             env:
             - name: PROMETHEUS_ADDRESS
               value: {{ (index .Values "prometheus-metrics"  "address") | quote }}
+            - name: CLUSTER_NAME
+              value: {{ (index .Values "prometheus-metrics"  "providerClusterName") | quote }}
             {{ include "proxy-env-spec" . | indent 12 | trim }}
             {{ include "security-context" . | indent 12 | trim }}
           {{ include "uploaderContainer" . | indent 10 | trim }}

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -315,6 +315,7 @@ prometheus-metrics:
   schedule: "0/10 * * * *"
   timeout: 300
   address: "http://prometheus-server"
+  providerClusterName: ""
   image:
     repository: quay.io/fairwinds/prometheus-collector
     tag: "1.4"

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -315,7 +315,7 @@ prometheus-metrics:
   schedule: "0/10 * * * *"
   timeout: 300
   address: "http://prometheus-server"
-  providerClusterName: ""
+  managedPrometheusClusterName: ""
   image:
     repository: quay.io/fairwinds/prometheus-collector
     tag: "1.4"


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
