### PR TITLE
FWIN-1052/Add-On-Test-helm-release-pruner

### DIFF
--- a/stable/helm-release-pruner/Chart.yaml
+++ b/stable/helm-release-pruner/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: v3.2.0
+appVersion: v3.3.0
 description: This chart deploys a cronjob that purges stale Helm releases and associated namespaces. Releases are selected based on regex patterns for release name and namespace along with a Bash `date` command date string to define the stale cutoff date and time.
 name: helm-release-pruner
-version: 3.2.12
+version: 3.3.0
 kubeVersion: ">= 1.22.0-0"
 maintainers:
   - name: rbren

--- a/stable/helm-release-pruner/README.md
+++ b/stable/helm-release-pruner/README.md
@@ -41,7 +41,7 @@ Chart version 1.0.0 introduced RBacDefinitions with rbac-manager to manage acces
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | image.repository | string | `"quay.io/fairwinds/helm-release-pruner"` | Repo for image that the job runs on |
-| image.tag | string | `"v3.2.1"` | The image tag to use |
+| image.tag | string | `"v3.3.0"` | The image tag to use |
 | image.pullPolicy | string | `"Always"` | The image pull policy. We do not recommend changing this |
 | podAnnotations | object | `{}` |  |
 | job.backoffLimit | int | `3` | The backoff limit for the job |

--- a/stable/helm-release-pruner/values.yaml
+++ b/stable/helm-release-pruner/values.yaml
@@ -4,7 +4,7 @@ image:
   # image.repository -- Repo for image that the job runs on
   repository: quay.io/fairwinds/helm-release-pruner
   # image.tag -- The image tag to use
-  tag: v3.2.1
+  tag: v3.3.0
   # image.pullPolicy -- The image pull policy. We do not recommend changing this
   pullPolicy: Always
 


### PR DESCRIPTION
**Why This PR?**
Update Helm Release Pruner to 3.3.0


**Changes**
Changes proposed in this pull request:

* Helm Release Pruner to 3.3.0

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
