### PR TITLE
[stable/fairwinds-insights] add annotation support to insights service-accounts

### DIFF
--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.2.2
+* `rbac.serviceAccount.annotations` are now applied to all Insights related service-accounts
+* fix `serviceAccountName` on Insights cronjobs templates
+
 ## 2.2.1
 * Update application version to 16.0. [See the release notes for more details](https://insights.docs.fairwinds.com/release-notes)
 

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "16.0"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 2.2.1
+version: 2.2.2
 kubeVersion: ">= 1.22.0-0"
 maintainers:
   - name: rbren

--- a/stable/fairwinds-insights/templates/cronjob-executor.rbac.yaml
+++ b/stable/fairwinds-insights/templates/cronjob-executor.rbac.yaml
@@ -4,9 +4,15 @@ metadata:
   name: {{ include "fairwinds-insights.fullname" . }}-cronjob-executor
   labels:
     app: fairwinds-insights
+  {{ with .Values.rbac.serviceAccount.annotations }}
+  annotations:
+  {{-   range $key, $value := . }}
+    {{ $key }}: {{ $value | quote }}
+  {{-   end }}
+  {{- end }}
 ---
-kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
 metadata:
   name: {{ include "fairwinds-insights.fullname" . }}-cronjob-executor
   labels:

--- a/stable/fairwinds-insights/templates/cronjobs.yaml
+++ b/stable/fairwinds-insights/templates/cronjobs.yaml
@@ -19,6 +19,7 @@ spec:
           imagePullSecrets:
             - name: {{ . }}
           {{- end }}
+          serviceAccountName: {{ include "fairwinds-insights.fullname" . }}-cronjob-executor
           containers:
             - name: {{ $name }}
               image: "{{ $.Values.cronjobImage.repository }}:{{ include "fairwinds-insights.cronjobImageTag" $ }}"

--- a/stable/fairwinds-insights/templates/cronjobs.yaml
+++ b/stable/fairwinds-insights/templates/cronjobs.yaml
@@ -19,7 +19,7 @@ spec:
           imagePullSecrets:
             - name: {{ . }}
           {{- end }}
-          serviceAccountName: {{ include "fairwinds-insights.fullname" . }}-cronjob-executor
+          serviceAccountName: {{ include "fairwinds-insights.fullname" $ }}-cronjob-executor
           containers:
             - name: {{ $name }}
               image: "{{ $.Values.cronjobImage.repository }}:{{ include "fairwinds-insights.cronjobImageTag" $ }}"

--- a/stable/fairwinds-insights/templates/rbac-automated-pr-job.yaml
+++ b/stable/fairwinds-insights/templates/rbac-automated-pr-job.yaml
@@ -5,6 +5,12 @@ metadata:
   name: {{ include "fairwinds-insights.fullname" . }}-automated-pr-job
   labels:
     app: {{ include "fairwinds-insights.fullname" . }}-automated-pr-job
+  {{ with .Values.rbac.serviceAccount.annotations }}
+  annotations:
+  {{-   range $key, $value := . }}
+    {{ $key }}: {{ $value | quote }}
+  {{-   end }}
+  {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/stable/fairwinds-insights/templates/rbac-repo-scan-job.yaml
+++ b/stable/fairwinds-insights/templates/rbac-repo-scan-job.yaml
@@ -5,9 +5,15 @@ metadata:
   name: {{ include "fairwinds-insights.fullname" . }}-repo-scan-job
   labels:
     app: {{ include "fairwinds-insights.fullname" . }}-repo-scan-job
+  {{ with .Values.rbac.serviceAccount.annotations }}
+  annotations:
+  {{-   range $key, $value := . }}
+    {{ $key }}: {{ $value | quote }}
+  {{-   end }}
+  {{- end }}
 ---
-kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
 metadata:
   name: {{ include "fairwinds-insights.fullname" . }}-repo-scan-job
   labels:


### PR DESCRIPTION
**Why This PR?**

* `rbac.serviceAccount.annotations` are now applied to all Insights related service-accounts
* fix `serviceAccountName` on Insights cronjobs templates

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.


[Internal Ticket INSIGHTS-10](https://fairwinds.myjetbrains.com/youtrack/issue/INSIGHTS-10)

[Internal Ticket INSIGHTS-105](https://fairwinds.myjetbrains.com/youtrack/issue/INSIGHTS-105)