### PR TITLE
[stable/goldilocks] Update port-forward to service

### DIFF
--- a/stable/goldilocks/Chart.yaml
+++ b/stable/goldilocks/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 appVersion: "v4.10.0"
-version: 8.0.1
+version: 8.0.2
 kubeVersion: ">= 1.22.0-0"
 description: |
   A Helm chart for running Fairwinds Goldilocks. See https://github.com/FairwindsOps/goldilocks

--- a/stable/goldilocks/templates/NOTES.txt
+++ b/stable/goldilocks/templates/NOTES.txt
@@ -15,7 +15,6 @@
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "goldilocks.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
   echo http://$SERVICE_IP:{{ .Values.dashboard.service.port }}
 {{- else if contains "ClusterIP" .Values.dashboard.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "goldilocks.name" . }},app.kubernetes.io/instance={{ .Release.Name }},app.kubernetes.io/component=dashboard" -o jsonpath="{.items[0].metadata.name}")
-  echo "Visit http://127.0.0.1:8080 to use your application"
   kubectl -n goldilocks port-forward svc/goldilocks-dashboard 8080:80
+  echo "Visit http://127.0.0.1:8080 to use your application"  
 {{- end }}

--- a/stable/goldilocks/templates/NOTES.txt
+++ b/stable/goldilocks/templates/NOTES.txt
@@ -17,5 +17,5 @@
 {{- else if contains "ClusterIP" .Values.dashboard.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "goldilocks.name" . }},app.kubernetes.io/instance={{ .Release.Name }},app.kubernetes.io/component=dashboard" -o jsonpath="{.items[0].metadata.name}")
   echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl port-forward $POD_NAME 8080:80
+  kubectl -n goldilocks port-forward svc/goldilocks-dashboard 8080:80
 {{- end }}


### PR DESCRIPTION
**Why This PR?**
Installed goldilocks using helm. 
![helm_install_goldilocks](https://github.com/FairwindsOps/charts/assets/12839607/87aa11ea-c8c1-4c4f-a8b6-d38cc010325f)

While trying to access the dashboard using pod, getting this error:

```
$ kubectl -n goldilocks port-forward goldilocks-dashboard-f89794564-pbbwt 8080:80
Forwarding from 127.0.0.1:8080 -> 80
Forwarding from [::1]:8080 -> 80
Handling connection for 8080
Handling connection for 8080
E0611 19:32:59.240457   17523 portforward.go:409] an error occurred forwarding 8080 -> 80: error forwarding port 80 to pod 7d19cca61c6e8b1dab80d902986c66d39b0e4debf3d957e401c0e67ba4bef38f, uid : failed to execute portforward in network namespace "/var/run/netns/cni-cac88060-d0e6-9f7a-b967-23eebd741896": failed to connect to localhost:80 inside namespace "7d19cca61c6e8b1dab80d902986c66d39b0e4debf3d957e401c0e67ba4bef38f", IPv4: dial tcp4 127.0.0.1:80: connect: connection refused IPv6 dial tcp6: address localhost: no suitable address found
```

Fixes #

This error can be avoided if port forwarding and service is used.

`$ kubectl -n goldilocks port-forward svc/goldilocks-dashboard 8080:80`

**Changes**
Changes proposed in this pull request:

* Update NOTES.txt with service name.


**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
