### PR TITLE
[stable/vpa] add securityContext for certgen pods

### DIFF
--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 4.4.6
+version: 4.5.0
 appVersion: 1.0.0
 maintainers:
   - name: sudermanjr

--- a/stable/vpa/README.md
+++ b/stable/vpa/README.md
@@ -202,7 +202,8 @@ recommender:
 | admissionController.certGen.image.pullPolicy | string | `"Always"` | The pull policy for the certgen image. Recommend not changing this |
 | admissionController.certGen.env | object | `{}` | Additional environment variables to be added to the certgen container. Format is KEY: Value format |
 | admissionController.certGen.resources | object | `{}` | The resources block for the certgen pod |
-| admissionController.certGen.securityContext | object | `{}` | The securityContext block for the certgen pod |
+| admissionController.certGen.securityContext | object | `{}` | The securityContext block for the certgen container(s) |
+| admissionController.certGen.podSecurityContext | object | `{}` | The securityContext block for the certgen pod(s) |
 | admissionController.certGen.nodeSelector | object | `{}` |  |
 | admissionController.certGen.tolerations | list | `[]` |  |
 | admissionController.certGen.affinity | object | `{}` |  |

--- a/stable/vpa/templates/webhooks/jobs/certgen-create.yaml
+++ b/stable/vpa/templates/webhooks/jobs/certgen-create.yaml
@@ -35,7 +35,11 @@ spec:
             - --secret-name={{ include "vpa.webhook.secret" . }}
           resources:
             {{- toYaml .Values.admissionController.certGen.resources | nindent 12 }}
-      {{- with .Values.admissionController.certGen.securityContext }}
+          {{- with .Values.admissionController.certGen.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.admissionController.certGen.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/stable/vpa/templates/webhooks/jobs/certgen-patch.yaml
+++ b/stable/vpa/templates/webhooks/jobs/certgen-patch.yaml
@@ -36,7 +36,11 @@ spec:
             - --log-level=debug
           resources:
             {{- toYaml .Values.admissionController.certGen.resources | nindent 12 }}
-      {{- with .Values.admissionController.certGen.securityContext }}
+          {{- with .Values.admissionController.certGen.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.admissionController.certGen.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/stable/vpa/values.yaml
+++ b/stable/vpa/values.yaml
@@ -221,8 +221,10 @@ admissionController:
     env: {}
     # admissionController.certGen.resources -- The resources block for the certgen pod
     resources: {}
-    # admissionController.certGen.securityContext -- The securityContext block for the certgen pod
+    # admissionController.certGen.securityContext -- The securityContext block for the certgen container(s)
     securityContext: {}
+    # admissionController.certGen.podSecurityContext -- The securityContext block for the certgen pod(s)
+    podSecurityContext: {}
     nodeSelector: {}
     tolerations: []
     affinity: {}


### PR DESCRIPTION
**Why This PR?**
This PR adds individual securityContext for the containers belonging to the certgen jobs and renames the current Helm-Value `securityContext` to `podSecurityContext` because it fits the use case better (Also noticed that you use the same naming for both deployments already).

Fixes #
-

**Changes**
Changes proposed in this pull request:
-

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
