### PR TITLE
[stable/insights-agent] Added flag to skip prometheus non zero validation

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 4.3.2
+## 4.4.0
 * added prometheus flag to skip non zero validation
 
 ## 4.3.1

--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 4.3.2
+* added prometheus flag to skip non zero validation
+
 ## 4.3.1
 * bumped plugins version
 

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 4.3.1
+version: 4.3.2
 appVersion: 9.2.1
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 4.3.2
+version: 4.4.0
 appVersion: 9.2.1
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png

--- a/stable/insights-agent/templates/prometheus-metrics/cronjob.yaml
+++ b/stable/insights-agent/templates/prometheus-metrics/cronjob.yaml
@@ -24,7 +24,7 @@ spec:
             - name: CLUSTER_NAME
               value: {{ (index .Values "prometheus-metrics"  "managedPrometheusClusterName") | quote }}
             - name: SKIP_NON_ZERO_METRICS_CHECK
-              value: {{ (index .Values "prometheus-metrics"  "skipNonZeroMetricsCheck") }}
+              value: {{ (index .Values "prometheus-metrics"  "skipNonZeroMetricsCheck") | quote }}
             {{ include "proxy-env-spec" . | indent 12 | trim }}
             {{ include "security-context" . | indent 12 | trim }}
           {{ include "uploaderContainer" . | indent 10 | trim }}

--- a/stable/insights-agent/templates/prometheus-metrics/cronjob.yaml
+++ b/stable/insights-agent/templates/prometheus-metrics/cronjob.yaml
@@ -23,6 +23,8 @@ spec:
               value: {{ (index .Values "prometheus-metrics"  "address") | quote }}
             - name: CLUSTER_NAME
               value: {{ (index .Values "prometheus-metrics"  "managedPrometheusClusterName") | quote }}
+            - name: SKIP_NON_ZERO_METRICS_CHECK
+              value: {{ (index .Values "prometheus-metrics"  "skipNonZeroMetricsCheck") }}
             {{ include "proxy-env-spec" . | indent 12 | trim }}
             {{ include "security-context" . | indent 12 | trim }}
           {{ include "uploaderContainer" . | indent 10 | trim }}

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -316,6 +316,7 @@ prometheus-metrics:
   timeout: 300
   address: "http://prometheus-server"
   managedPrometheusClusterName: ""
+  skipNonZeroMetricsCheck: false
   image:
     repository: quay.io/fairwinds/prometheus-collector
     tag: "1.4"


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
