### PR TITLE
[stable/fairwinds-insights] use postgres-partman 16.0 as default for ephemeral deployments 

### DIFF
--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.2.5
+* upgrade bitnami postgres chart dependency and postgres-partman version
+
 ## 2.2.4
 * bumped insights plugins target version
 

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
   - name: mhoss019
 dependencies:
   - name: postgresql
-    version: 14.0.5
+    version: 15.5.18
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.ephemeral
   - name: minio

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,11 +2,12 @@ apiVersion: v2
 appVersion: "16.1"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 2.2.4
+version: 2.2.5
 kubeVersion: ">= 1.22.0-0"
 maintainers:
   - name: rbren
-  - name: mhoss019
+  - name: vitor.vezani
+  - name: jdesouza
 dependencies:
   - name: postgresql
     version: 15.5.18

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -6,7 +6,7 @@ version: 2.2.5
 kubeVersion: ">= 1.22.0-0"
 maintainers:
   - name: rbren
-  - name: vitor.vezani
+  - name: vitorvezani
   - name: jdesouza
 dependencies:
   - name: postgresql

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
   - name: jdesouza
 dependencies:
   - name: postgresql
-    version: 14.0.5
+    version: 15.5.18
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.ephemeral
   - name: minio

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
   - name: jdesouza
 dependencies:
   - name: postgresql
-    version: 15.5.18
+    version: 14.0.5
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.ephemeral
   - name: minio

--- a/stable/fairwinds-insights/README.md
+++ b/stable/fairwinds-insights/README.md
@@ -110,7 +110,7 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | postgresql.postMigrate | bool | `false` | Set to `true` to run migrations after the upgrade |
 | postgresql.image.registry | string | `"quay.io"` |  |
 | postgresql.image.repository | string | `"fairwinds/postgres-partman"` |  |
-| postgresql.image.tag | string | `"14.4"` |  |
+| postgresql.image.tag | string | `"16.0"` |  |
 | postgresql.ephemeral | bool | `true` | Use the ephemeral postgresql chart by default |
 | postgresql.sslMode | string | `"require"` | SSL mode for connecting to the database |
 | postgresql.tls | object | `{"certFilename":"tls.crt","certKeyFilename":"tls.key","certificatesSecret":"fwinsights-postgresql-ca","enabled":true}` | TLS mode for connecting to the database |

--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -400,7 +400,7 @@ postgresql:
   image:
     registry: quay.io
     repository: fairwinds/postgres-partman
-    tag: "14.4"
+    tag: "16.0"
   # -- Use the ephemeral postgresql chart by default
   ephemeral: true
   # -- SSL mode for connecting to the database


### PR DESCRIPTION
**Why This PR?**
- upgrade bitnami postgres dependency chart
- upgrade postgres-partman image version


Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.


[Internal Ticket INSIGHTS-213](https://fairwinds.myjetbrains.com/youtrack/issue/INSIGHTS-213)