### PR TITLE
[stable/goldilocks] update to goldilocks 4.13.0 and update VPA dependency to latest

### DIFF
--- a/stable/goldilocks/Chart.lock
+++ b/stable/goldilocks/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: vpa
   repository: https://charts.fairwinds.com/stable
-  version: 3.0.2
+  version: 4.5.0
 - name: metrics-server
   repository: https://charts.bitnami.com/bitnami
-  version: 6.4.1
-digest: sha256:7a923abb2a353b828b45e0ae502ac0bb21b009312490ff7f4b50aebc9a29bea0
-generated: "2023-10-27T11:14:25.826905956+09:00"
+  version: 7.2.10
+digest: sha256:421c85776237d045f59f0d1dee55e7fe13b3d394369174666c81288a99f145f4
+generated: "2024-07-29T10:28:02.96546-06:00"

--- a/stable/goldilocks/Chart.yaml
+++ b/stable/goldilocks/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: "v4.10.0"
-version: 8.0.2
+appVersion: "v4.13.0"
+version: 9.0.0
 kubeVersion: ">= 1.22.0-0"
 description: |
   A Helm chart for running Fairwinds Goldilocks. See https://github.com/FairwindsOps/goldilocks
@@ -16,10 +16,10 @@ keywords:
   - kubernetes
 dependencies:
   - name: vpa
-    version: 3.0.*
+    version: 4.5.*
     repository: https://charts.fairwinds.com/stable
     condition: vpa.enabled
   - name: metrics-server
-    version: 6.4.1
+    version: 7.2.*
     repository: https://charts.bitnami.com/bitnami
     condition: metrics-server.enabled

--- a/stable/goldilocks/README.md
+++ b/stable/goldilocks/README.md
@@ -65,7 +65,7 @@ This will completely remove the VPA and then re-install it using the new method.
 | metrics-server.enabled | bool | `false` | If true, the metrics-server will be installed as a sub-chart |
 | metrics-server.apiService.create | bool | `true` |  |
 | image.repository | string | `"us-docker.pkg.dev/fairwinds-ops/oss/goldilocks"` | Repository for the goldilocks image |
-| image.tag | string | `"v4.10.0"` | The goldilocks image tag to use |
+| image.tag | string | `"v4.13.0"` | The goldilocks image tag to use |
 | image.pullPolicy | string | `"Always"` | imagePullPolicy - Highly recommended to leave this as `Always` |
 | imagePullSecrets | list | `[]` | A list of image pull secret names to use |
 | nameOverride | string | `""` |  |

--- a/stable/goldilocks/values.yaml
+++ b/stable/goldilocks/values.yaml
@@ -17,7 +17,7 @@ image:
   # image.repository -- Repository for the goldilocks image
   repository: us-docker.pkg.dev/fairwinds-ops/oss/goldilocks
   # image.tag -- The goldilocks image tag to use
-  tag: v4.10.0
+  tag: v4.13.0
   # image.pullPolicy -- imagePullPolicy - Highly recommended to leave this as `Always`
   pullPolicy: Always
 


### PR DESCRIPTION
**Why This PR?**
Update to latest versions

**Changes**
Changes proposed in this pull request:

* Goldilocks 4.13.0
* VPA 4.5.*
* metris-server 7.2.*

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.