### PR TITLE
[circleci] update Kubernetes versions for End-To-End tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,26 +131,26 @@ workflows:
       - lint-scripts
       - lint-charts
       - rok8s/kubernetes_e2e_tests:
-          name: "End-To-End Kubernetes 1.24"
-          kind_node_image: "kindest/node:v1.24.7@sha256:577c630ce8e509131eab1aea12c022190978dd2f745aac5eb1fe65c0807eb315"
-          executor:
-            name: ci-images-large
-          <<: *kind_configuration_helm3
-      - rok8s/kubernetes_e2e_tests:
-          name: "End-To-End Kubernetes 1.25"
-          kind_node_image: "kindest/node:v1.25.3@sha256:f52781bc0d7a19fb6c405c2af83abfeb311f130707a0e219175677e366cc45d1"
-          executor:
-            name: ci-images-large
-          <<: *kind_configuration_helm3
-      - rok8s/kubernetes_e2e_tests:
-          name: "End-To-End Kubernetes 1.26"
-          kind_node_image: "kindest/node:v1.26.6@sha256:6e2d8b28a5b601defe327b98bd1c2d1930b49e5d8c512e1895099e4504007adb"
-          executor:
-            name: ci-images-large
-          <<: *kind_configuration_helm3
-      - rok8s/kubernetes_e2e_tests:
           name: "End-To-End Kubernetes 1.27"
-          kind_node_image: "kindest/node:v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72"
+          kind_node_image: "kindest/node:v1.27.13@sha256:17439fa5b32290e3ead39ead1250dca1d822d94a10d26f1981756cd51b24b9d8"
+          executor:
+            name: ci-images-large
+          <<: *kind_configuration_helm3
+      - rok8s/kubernetes_e2e_tests:
+          name: "End-To-End Kubernetes 1.28"
+          kind_node_image: "kindest/node:v1.28.9@sha256:dca54bc6a6079dd34699d53d7d4ffa2e853e46a20cd12d619a09207e35300bd0"
+          executor:
+            name: ci-images-large
+          <<: *kind_configuration_helm3
+      - rok8s/kubernetes_e2e_tests:
+          name: "End-To-End Kubernetes 1.29"
+          kind_node_image: "kindest/node:v1.29.4@sha256:3abb816a5b1061fb15c6e9e60856ec40d56b7b52bcea5f5f1350bc6e2320b6f8"
+          executor:
+            name: ci-images-large
+          <<: *kind_configuration_helm3
+      - rok8s/kubernetes_e2e_tests:
+          name: "End-To-End Kubernetes 1.30"
+          kind_node_image: "kindest/node:v1.30.2@sha256:ecfe5841b9bee4fe9690f49c118c33629fa345e3350a0c67a5a34482a99d6bba"
           executor:
             name: ci-images-large
           <<: *kind_configuration_helm3


### PR DESCRIPTION
**Why This PR?**
update Kubernetes versions for End-To-End tests

Fixes #

**Changes**
Changes proposed in this pull request:

* update Kubernetes versions for End-To-End tests

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
