### PR TITLE
[stable/fairwinds-insights] refactor how readReplica is inject via env. vars

### DIFF
--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.3.0
+* Adds `useReadReplica` to cronjobs to enable `postgresql.readReplica` injection instead of primary database
+
 ## 2.2.7
 * Update application version to 16.2. [See the release notes for more details](https://insights.docs.fairwinds.com/release-notes)
 

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "16.2"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 2.2.7
+version: 2.3.0
 kubeVersion: ">= 1.22.0-0"
 maintainers:
   - name: rbren

--- a/stable/fairwinds-insights/README.md
+++ b/stable/fairwinds-insights/README.md
@@ -47,7 +47,7 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | cronjobs.costs-update | object | `{"command":"cloud_costs_update","includeGitHubSecret":true,"resources":{"limits":{"cpu":"500m","memory":"2Gi"},"requests":{"cpu":"500m","memory":"2Gi"}},"schedule":"15 */3 * * *"}` | Options for the cloud costs update job |
 | cronjobs.database-cleanup | object | `{"command":"database_cleanup","schedule":"0 0 * * *"}` | Options for the database cleanup job. |
 | cronjobs.email | object | `{"command":"email_digest","schedule":""}` | Options for the email digest job. |
-| cronjobs.hubspot | object | `{"command":"hubspot_sync","schedule":""}` | Options for the hubspot job. |
+| cronjobs.hubspot | object | `{"command":"hubspot_sync","schedule":"","useReadReplica":true}` | Options for the hubspot job. |
 | cronjobs.notifications-digest | object | `{"command":"notifications_digest","interval":"24h","schedule":"0 16 * * *"}` | Options for digest notifications job |
 | cronjobs.resources-recommendations | object | `{"command":"resources_recommendations","resources":{"limits":{"cpu":1,"memory":"3Gi"},"requests":{"cpu":1,"memory":"3Gi"}},"schedule":"0 2 * * *"}` | Options for the resources recommendations job |
 | cronjobs.saml | object | `{"command":"refresh_saml_metadata","schedule":"0 * * * *"}` | Options for the SAML sync job |

--- a/stable/fairwinds-insights/README.md
+++ b/stable/fairwinds-insights/README.md
@@ -121,7 +121,7 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | postgresql.primary.service.port | int | `5432` | Port of the Postgres Database |
 | postgresql.primary.persistence.enabled | bool | `true` | Create Persistent Volume with Postgres |
 | postgresql.primary.resources | object | `{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":"75m","memory":"256Mi"}}` | Resources section for Postgres |
-| postgresql.readReplica | object | `{"database":null,"host":null,"port":null,"sslMode":null,"username":null}` | Optional read replica configuration. Currently in use by [`hubspot-cronjob`] |
+| postgresql.readReplica | object | `{"database":null,"host":null,"port":null,"sslMode":null,"username":null}` | Optional read replica configuration. Set cronjob `options.useReadReplica` to `true` to enable it |
 | encryption.aes.cypherKey | string | `nil` |  |
 | timescale.fullnameOverride | string | `"timescale"` |  |
 | timescale.replicaCount | int | `1` |  |

--- a/stable/fairwinds-insights/templates/_env.yaml
+++ b/stable/fairwinds-insights/templates/_env.yaml
@@ -50,7 +50,7 @@ env:
   value: {{ . | quote }}
 {{- end }}
 # Database
-{{- if and (.Values.postgresql.readReplica) (eq .Template.Name "fairwinds-insights/templates/hubspot-cronjob.yaml") }}
+{{- if and ($options.useReadReplica) (.Values.postgresql.readReplica) }}
 - name: POSTGRES_DB
   value: {{ .Values.postgresql.readReplica.database }}
 - name: POSTGRES_USER

--- a/stable/fairwinds-insights/templates/_env.yaml
+++ b/stable/fairwinds-insights/templates/_env.yaml
@@ -1,26 +1,28 @@
 {{ define "env" }}
+{{- $cronOptions := .cronOptions }}
+{{- $ := .root }}
 # Required values
 envFrom:
 - secretRef:
-    name: {{ .Values.options.secretName }}
+    name: {{ $.Values.options.secretName }}
 env:
 - name: FAIRWINDS_HOST
-  {{- if .Values.options.host }}
-  value: {{ .Values.options.host }}
-  {{- else if gt (len .Values.ingress.hostedZones) 0 }}
-  value: {{ "https://" }}{{ include "fairwinds-insights.sanitizedPrefix" $ }}{{ index .Values.ingress.hostedZones 0 }}
+  {{- if $.Values.options.host }}
+  value: {{ $.Values.options.host }}
+  {{- else if gt (len $.Values.ingress.hostedZones) 0 }}
+  value: {{ "https://" }}{{ include "fairwinds-insights.sanitizedPrefix" $ }}{{ index $.Values.ingress.hostedZones 0 }}
   {{- end }}
-{{- if .Values.options.allowHTTPCookies }}
+{{- if $.Values.options.allowHTTPCookies }}
 - name: ALLOW_HTTP_COOKIES
   value: "true"
 {{- end }}
-{{- with .Values.additionalEnvironmentVariables }}
+{{- with $.Values.additionalEnvironmentVariables }}
 {{- range $k, $v := . }}
 - name: {{ $k }}
   value: {{ $v | quote }}
 {{- end }}
 {{- end }}
-{{- with .Values.selfHostedSecret }}
+{{- with $.Values.selfHostedSecret }}
 - name: FAIRWINDS_CERTIFICATE_LOCATION
   value: /var/run/secrets/self-hosted/current.pem
 - name: SELF_HOSTED_PUBLIC_KEY
@@ -29,11 +31,11 @@ env:
       name: {{ . }}
       key: pubkey
 {{- end }}
-{{- with .Values.installationCode }}
+{{- with $.Values.installationCode }}
 - name: INSTALLATION_CODE
   value: {{ . | quote }}
 {{- end }}
-{{- with .Values.installationCodeSecret }}
+{{- with $.Values.installationCodeSecret }}
 - name: INSTALLATION_CODE
   valueFrom:
     secretKeyRef:
@@ -43,98 +45,98 @@ env:
 - name: CACHE_BUST_TOKEN
   value: {{ randAlphaNum 10 }}
 - name: FAIRWINDS_AGENT_CHART_TARGET_VERSION
-  value: {{ .Values.options.agentChartTargetVersion }}
+  value: {{ $.Values.options.agentChartTargetVersion }}
 # General Server
-{{- with .Values.options.authRateLimit }}
+{{- with $.Values.options.authRateLimit }}
 - name: AUTH_RATE_LIMIT
   value: {{ . | quote }}
 {{- end }}
 # Database
-{{- if and ($options.useReadReplica) (.Values.postgresql.readReplica) }}
+{{- if and ($cronOptions.useReadReplica) ($.Values.postgresql.readReplica) }}
 - name: POSTGRES_DB
-  value: {{ .Values.postgresql.readReplica.database }}
+  value: {{ $.Values.postgresql.readReplica.database }}
 - name: POSTGRES_USER
-  value: {{ .Values.postgresql.readReplica.username }}
+  value: {{ $.Values.postgresql.readReplica.username }}
 - name: POSTGRES_PORT
-  value: {{ .Values.postgresql.readReplica.port | quote }}
+  value: {{ $.Values.postgresql.readReplica.port | quote }}
 - name: POSTGRES_SSL_MODE
-  value: {{ .Values.postgresql.readReplica.sslMode | default "require" }}
+  value: {{ $.Values.postgresql.readReplica.sslMode | default "require" }}
 - name: POSTGRES_HOST
-  value: {{ .Values.postgresql.readReplica.host }}
+  value: {{ $.Values.postgresql.readReplica.host }}
 - name: POSTGRES_PASSWORD
   valueFrom:
     secretKeyRef:
-      name: {{ .Values.postgresql.auth.existingSecret }}
+      name: {{ $.Values.postgresql.auth.existingSecret }}
       key: readreplica-password
 {{- else }}
 - name: POSTGRES_DB
-  value: {{ .Values.postgresql.auth.database }}
+  value: {{ $.Values.postgresql.auth.database }}
 - name: POSTGRES_USER
-  value: {{ .Values.postgresql.auth.username }}
+  value: {{ $.Values.postgresql.auth.username }}
 - name: POSTGRES_PORT
-  value: {{ .Values.postgresql.primary.service.port | quote }}
+  value: {{ $.Values.postgresql.primary.service.port | quote }}
 - name: POSTGRES_SSL_MODE
-  value: {{ .Values.postgresql.sslMode | default "require" }}
+  value: {{ $.Values.postgresql.sslMode | default "require" }}
 - name: POSTGRES_HOST
-  value: {{ .Values.postgresql.postgresqlHost | default (printf "%s-%s" .Release.Name "postgresql") }}
-{{- if .Values.postgresql.readOnly }}
+  value: {{ $.Values.postgresql.postgresqlHost | default (printf "%s-%s" .Release.Name "postgresql") }}
+{{- if $.Values.postgresql.readOnly }}
 - name: POSTGRES_PASSWORD
   valueFrom:
     secretKeyRef:
-      name: {{ .Values.postgresql.auth.existingSecret }}
+      name: {{ $.Values.postgresql.auth.existingSecret }}
       key: readonly-password
 {{- else }}
 - name: POSTGRES_PASSWORD
   valueFrom:
     secretKeyRef:
-      name: {{ .Values.postgresql.auth.existingSecret }}
+      name: {{ $.Values.postgresql.auth.existingSecret }}
       key: postgresql-password
 {{- end }}
 {{- end }}
 # Timescale Database
 - name: TIMESCALE_DB
-  value: {{ .Values.timescale.postgresqlDatabase }}
+  value: {{ $.Values.timescale.postgresqlDatabase }}
 - name: TIMESCALE_USER
-  value: {{ .Values.timescale.postgresqlUsername }}
+  value: {{ $.Values.timescale.postgresqlUsername }}
 - name: TIMESCALE_PORT
-  value: {{ .Values.timescale.service.primary.port | quote }}
+  value: {{ $.Values.timescale.service.primary.port | quote }}
 - name: TIMESCALE_SSL_MODE
-  value: {{ .Values.timescale.sslMode | default "require" }}
+  value: {{ $.Values.timescale.sslMode | default "require" }}
 - name: TIMESCALE_HOST
-  value: {{ .Values.timescale.postgresqlHost | default (printf "%s-%s" .Release.Name "timescale") }}
-{{- if .Values.timescale.ephemeral }}
+  value: {{ $.Values.timescale.postgresqlHost | default (printf "%s-%s" .Release.Name "timescale") }}
+{{- if $.Values.timescale.ephemeral }}
 - name: TIMESCALE_PASSWORD
   valueFrom:
     secretKeyRef:
-      name: {{ .Values.timescale.secrets.credentialsSecretName }}
+      name: {{ $.Values.timescale.secrets.credentialsSecretName }}
       key: PATRONI_SUPERUSER_PASSWORD
 {{- else }}
 - name: TIMESCALE_PASSWORD
   valueFrom:
     secretKeyRef:
-      name: {{ .Values.postgresql.auth.existingSecret }}
+      name: {{ $.Values.postgresql.auth.existingSecret }}
       key: timescale-password
 {{- end }}
-{{- with .Values.options.insightsSAASHost }}
+{{- with $.Values.options.insightsSAASHost }}
 - name: INSIGHTS_SAAS_HOST
   value: {{ . | quote }}
 {{- end }}
-{{- if .Values.options.addFixtures }}
+{{- if $.Values.options.addFixtures }}
 - name: ADD_FIXTURES
   value: "true"
 {{- end }}
-{{- if .Values.reportStorage.skipFileFixtures }}
+{{- if $.Values.reportStorage.skipFileFixtures }}
 - name: SKIP_FILE_FIXTURES 
   value: "true"
 {{- end }}
 
 # Report Storage
 - name: REPORT_STORAGE_STRATEGY
-  value: {{ .Values.reportStorage.strategy }}
-{{ if eq .Values.reportStorage.strategy "minio" -}}
-{{ if .Values.reportStorage.minioHost -}}
+  value: {{ $.Values.reportStorage.strategy }}
+{{ if eq $.Values.reportStorage.strategy "minio" -}}
+{{ if $.Values.reportStorage.minioHost -}}
 - name: MINIO_HOST
-  value: {{ .Values.reportStorage.minioHost }}
+  value: {{ $.Values.reportStorage.minioHost }}
 {{ else }}
 - name: MINIO_HOST
   value: {{ printf "%s-%s" .Release.Name "fw-minio:9000" }}
@@ -142,47 +144,47 @@ env:
 - name: MINIO_ACCESS_KEY_ID
   valueFrom:
     secretKeyRef:
-      name: {{ printf "%s-%s" .Release.Name .Values.minio.nameOverride }}
+      name: {{ printf "%s-%s" .Release.Name $.Values.minio.nameOverride }}
       key: rootUser                
 - name: MINIO_SECRET_ACCESS_KEY
   valueFrom:
     secretKeyRef:
-      name: {{ printf "%s-%s" .Release.Name .Values.minio.nameOverride }}
+      name: {{ printf "%s-%s" .Release.Name $.Values.minio.nameOverride }}
       key: rootPassword
-{{ else if eq .Values.reportStorage.strategy "local" -}}
+{{ else if eq $.Values.reportStorage.strategy "local" -}}
 - name: REPORT_STORAGE_DIR
-  value: {{ .Values.reportStorage.fixturesDir | default "/db-migrations/fixtures/files" }}
+  value: {{ $.Values.reportStorage.fixturesDir | default "/db-migrations/fixtures/files" }}
 {{ end -}}
 - name: REPORT_STORAGE_REGION
-  value: {{ .Values.reportStorage.region }}
+  value: {{ $.Values.reportStorage.region }}
 - name: REPORT_STORAGE_BUCKET
-  value: {{ .Values.reportStorage.bucket | quote }}
+  value: {{ $.Values.reportStorage.bucket | quote }}
 
 # Email
 - name: EMAIL_STRATEGY
-  value: {{ .Values.email.strategy }}
+  value: {{ $.Values.email.strategy }}
 - name: EMAIL_SENDER
-  value: {{ .Values.email.sender }}
+  value: {{ $.Values.email.sender }}
 - name: EMAIL_RECIPIENT
-  value: {{ .Values.email.recipient }}
-{{ if eq .Values.email.strategy "smtp" -}}
+  value: {{ $.Values.email.recipient }}
+{{ if eq $.Values.email.strategy "smtp" -}}
 - name: SMTP_HOST
-  value: {{ .Values.email.smtpHost }}
+  value: {{ $.Values.email.smtpHost }}
 - name: SMTP_USERNAME
-  value: {{ .Values.email.smtpUsername }}
+  value: {{ $.Values.email.smtpUsername }}
 - name: SMTP_PORT
-  value: {{ .Values.email.smtpPort | quote }}
-{{ else if eq .Values.email.strategy "ses" -}}
+  value: {{ $.Values.email.smtpPort | quote }}
+{{ else if eq $.Values.email.strategy "ses" -}}
 - name: SES_AWS_REGION
-  value: {{ .Values.email.awsRegion }}
+  value: {{ $.Values.email.awsRegion }}
 {{ end -}}
 
 # Third-party integrations
-{{ with .Values.options.githubAppID -}}
+{{ with $.Values.options.githubAppID -}}
 - name: GITHUB_APP_ID
   value: {{ . | quote }}
 {{ end -}}
-{{ with .Values.options.githubAppName -}}
+{{ with $.Values.options.githubAppName -}}
 - name: GITHUB_APP_NAME
   value: {{ . | quote }}
 {{ end -}}
@@ -191,11 +193,11 @@ env:
 - name: K8S_NAMESPACE
   value: {{ .Release.Namespace }}
 - name: INSIGHTS_CI_IMAGE_VERSION
-  value: {{ .Values.repoScanJob.insightsCIVersion | quote }}
+  value: {{ $.Values.repoScanJob.insightsCIVersion | quote }}
 
 # tag used for the fixer container 
 - name: CRON_JOB_IMAGE_REPOSITORY
-  value: {{ .Values.cronjobImage.repository | quote }}
+  value: {{ $.Values.cronjobImage.repository | quote }}
 - name: CRON_JOB_IMAGE_TAG
   value: {{ include "fairwinds-insights.cronjobImageTag" . | quote }}
 {{ end }}

--- a/stable/fairwinds-insights/templates/_env.yaml
+++ b/stable/fairwinds-insights/templates/_env.yaml
@@ -78,7 +78,7 @@ env:
 - name: POSTGRES_SSL_MODE
   value: {{ $.Values.postgresql.sslMode | default "require" }}
 - name: POSTGRES_HOST
-  value: {{ $.Values.postgresql.postgresqlHost | default (printf "%s-%s" .Release.Name "postgresql") }}
+  value: {{ $.Values.postgresql.postgresqlHost | default (printf "%s-%s" $.Release.Name "postgresql") }}
 {{- if $.Values.postgresql.readOnly }}
 - name: POSTGRES_PASSWORD
   valueFrom:
@@ -103,7 +103,7 @@ env:
 - name: TIMESCALE_SSL_MODE
   value: {{ $.Values.timescale.sslMode | default "require" }}
 - name: TIMESCALE_HOST
-  value: {{ $.Values.timescale.postgresqlHost | default (printf "%s-%s" .Release.Name "timescale") }}
+  value: {{ $.Values.timescale.postgresqlHost | default (printf "%s-%s" $.Release.Name "timescale") }}
 {{- if $.Values.timescale.ephemeral }}
 - name: TIMESCALE_PASSWORD
   valueFrom:
@@ -139,17 +139,17 @@ env:
   value: {{ $.Values.reportStorage.minioHost }}
 {{ else }}
 - name: MINIO_HOST
-  value: {{ printf "%s-%s" .Release.Name "fw-minio:9000" }}
+  value: {{ printf "%s-%s" $.Release.Name "fw-minio:9000" }}
 {{ end -}}
 - name: MINIO_ACCESS_KEY_ID
   valueFrom:
     secretKeyRef:
-      name: {{ printf "%s-%s" .Release.Name $.Values.minio.nameOverride }}
+      name: {{ printf "%s-%s" $.Release.Name $.Values.minio.nameOverride }}
       key: rootUser                
 - name: MINIO_SECRET_ACCESS_KEY
   valueFrom:
     secretKeyRef:
-      name: {{ printf "%s-%s" .Release.Name $.Values.minio.nameOverride }}
+      name: {{ printf "%s-%s" $.Release.Name $.Values.minio.nameOverride }}
       key: rootPassword
 {{ else if eq $.Values.reportStorage.strategy "local" -}}
 - name: REPORT_STORAGE_DIR
@@ -191,7 +191,7 @@ env:
 
 # repo-scan-job specific
 - name: K8S_NAMESPACE
-  value: {{ .Release.Namespace }}
+  value: {{ $.Release.Namespace }}
 - name: INSIGHTS_CI_IMAGE_VERSION
   value: {{ $.Values.repoScanJob.insightsCIVersion | quote }}
 
@@ -199,5 +199,5 @@ env:
 - name: CRON_JOB_IMAGE_REPOSITORY
   value: {{ $.Values.cronjobImage.repository | quote }}
 - name: CRON_JOB_IMAGE_TAG
-  value: {{ include "fairwinds-insights.cronjobImageTag" . | quote }}
+  value: {{ include "fairwinds-insights.cronjobImageTag" $ | quote }}
 {{ end }}

--- a/stable/fairwinds-insights/templates/_env.yaml
+++ b/stable/fairwinds-insights/templates/_env.yaml
@@ -1,5 +1,5 @@
 {{ define "env" }}
-{{- $cronOptions := .cronOptions }}
+{{- $useReadReplica := .useReadReplica }}
 {{- $ := .root }}
 # Required values
 envFrom:
@@ -52,7 +52,7 @@ env:
   value: {{ . | quote }}
 {{- end }}
 # Database
-{{- if and ($cronOptions.useReadReplica) ($.Values.postgresql.readReplica) }}
+{{- if and ($useReadReplica) ($.Values.postgresql.readReplica) }}
 - name: POSTGRES_DB
   value: {{ $.Values.postgresql.readReplica.database }}
 - name: POSTGRES_USER

--- a/stable/fairwinds-insights/templates/cronjobs.yaml
+++ b/stable/fairwinds-insights/templates/cronjobs.yaml
@@ -28,7 +28,7 @@ spec:
               {{- with $options.interval }}
                 - --interval={{ . }}
               {{- end }}
-              {{- include "env" (dict "cronOptions" $options "root" $) | indent 14 }}
+              {{- include "env" (dict "useReadReplica" $options.useReadReplica "root" $) | indent 14 }}
               imagePullPolicy: Always
               resources:
                 {{- toYaml (default $.Values.cronjobOptions.resources $options.resources) | nindent 16 }}

--- a/stable/fairwinds-insights/templates/cronjobs.yaml
+++ b/stable/fairwinds-insights/templates/cronjobs.yaml
@@ -28,7 +28,7 @@ spec:
               {{- with $options.interval }}
                 - --interval={{ . }}
               {{- end }}
-              {{- include "env" $ | indent 14 }}
+              {{- include "env" (dict "cronOptions" $options "root" $) | indent 14 }}
               imagePullPolicy: Always
               resources:
                 {{- toYaml (default $.Values.cronjobOptions.resources $options.resources) | nindent 16 }}

--- a/stable/fairwinds-insights/templates/deployment-api.yaml
+++ b/stable/fairwinds-insights/templates/deployment-api.yaml
@@ -38,7 +38,7 @@ spec:
           - name: http
             containerPort: {{ .Values.api.port }}
             protocol: TCP
-          {{- include "env" . | indent 10 }}
+          {{- include "env" (dict "root" .) | indent 10 }}
           livenessProbe:
             httpGet:
               path: /health

--- a/stable/fairwinds-insights/templates/deployment-automated-pr-job.yaml
+++ b/stable/fairwinds-insights/templates/deployment-automated-pr-job.yaml
@@ -36,7 +36,7 @@ spec:
           image: "{{ .Values.apiImage.repository }}:{{ include "fairwinds-insights.apiImageTag" . }}"
           imagePullPolicy: Always
           command: ["automated_pull_requests_job"]
-          {{- include "env" . | indent 10 }}
+          {{- include "env" (dict "root" .) | indent 10 }}
           volumeMounts:
             - name: secrets
               mountPath: /var/run/secrets/github

--- a/stable/fairwinds-insights/templates/deployment-dashboard.yaml
+++ b/stable/fairwinds-insights/templates/deployment-dashboard.yaml
@@ -45,7 +45,7 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
-          {{- include "env" . | indent 10 }}
+          {{- include "env" (dict "root" .) | indent 10 }}
           livenessProbe:
             httpGet:
               path: /health

--- a/stable/fairwinds-insights/templates/deployment-repo-scan-job.yaml
+++ b/stable/fairwinds-insights/templates/deployment-repo-scan-job.yaml
@@ -36,7 +36,7 @@ spec:
           image: "{{ .Values.apiImage.repository }}:{{ include "fairwinds-insights.apiImageTag" . }}"
           imagePullPolicy: Always
           command: ["repo_scan_job"]
-          {{- include "env" . | indent 10 }}
+          {{- include "env" (dict "root" .) | indent 10 }}
           volumeMounts:
             - name: secrets
               mountPath: /var/run/secrets/github

--- a/stable/fairwinds-insights/templates/deployment-report-job.yaml
+++ b/stable/fairwinds-insights/templates/deployment-report-job.yaml
@@ -38,7 +38,7 @@ spec:
           image: "{{ .Values.apiImage.repository }}:{{ include "fairwinds-insights.apiImageTag" . }}"
           imagePullPolicy: Always
           command: ["report_job"]
-          {{- include "env" . | indent 10 }}
+          {{- include "env" (dict "root" .) | indent 10 }}
           volumeMounts:
             - name: secrets
               mountPath: /var/run/secrets/github

--- a/stable/fairwinds-insights/templates/health-scores-migration.job.yaml
+++ b/stable/fairwinds-insights/templates/health-scores-migration.job.yaml
@@ -35,7 +35,7 @@ spec:
               capabilities:
                 drop:
                   - ALL
-            {{- include "env" . | indent 12 }}
+            {{- include "env" (dict "root" .) | indent 12 }}
 
 ---
 apiVersion: batch/v1

--- a/stable/fairwinds-insights/templates/migrate-db-job.yaml
+++ b/stable/fairwinds-insights/templates/migrate-db-job.yaml
@@ -27,7 +27,7 @@ spec:
         imagePullPolicy: Always
         resources:
           {{- toYaml .Values.dbMigration.resources | nindent 10 }}
-        {{- include "env" . | indent 8 }}
+        {{- include "env" (dict "root" .) | indent 8 }}
         {{- with .Values.options.adminEmail }}
         - name: SETUP_ADMIN_EMAIL
           value: {{ . }}

--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -155,6 +155,7 @@ cronjobs:
   hubspot:
     command: 'hubspot_sync'
     schedule: ''
+    useReadReplica: true
 
   # -- Options for digest notifications job
   notifications-digest:

--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -433,7 +433,7 @@ postgresql:
       requests:
         cpu: 75m
         memory: 256Mi
-  # -- Optional read replica configuration. Currently in use by [`hubspot-cronjob`]
+  # -- Optional read replica configuration. Set cronjob `options.useReadReplica` to `true` to enable it
   readReplica:
     username:
     database:


### PR DESCRIPTION
**Why This PR?**
Refactor how `postgres.readReplica` field is injected via env. vars.

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
