### PR TITLE
[stable/insights-agent] bump trivy to 0.30

### DIFF
--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -626,7 +626,7 @@ automatedPullRequestJob:
 
 repoScanJob:
   enabled: false
-  insightsCIVersion: "5.7"
+  insightsCIVersion: "5.4"
   hpa:
     enabled: true
     min: 2

--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -626,7 +626,7 @@ automatedPullRequestJob:
 
 repoScanJob:
   enabled: false
-  insightsCIVersion: "5.4"
+  insightsCIVersion: "5.7"
   hpa:
     enabled: true
     min: 2

--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 4.4.10
 * bumped trivy to 0.30
+* bumped CI version for auto-scan to 5.7
 
 ## 4.4.9
 * bumped kube-bench to 0.5

--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## 4.4.10
 * bumped trivy to 0.30
-* bumped CI version for auto-scan to 5.7
 
 ## 4.4.9
 * bumped kube-bench to 0.5

--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 4.4.10
+* bumped trivy to 0.30
+
 ## 4.4.9
 * bumped kube-bench to 0.5
 

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 4.4.9
+version: 4.4.10
 appVersion: 9.2.1
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -288,7 +288,7 @@ trivy:
   env:
   image:
     repository: quay.io/fairwinds/fw-trivy
-    tag: "0.29"
+    tag: "0.30"
   serviceAccount:
     annotations:
   resources:


### PR DESCRIPTION
**Why This PR?**
Bumps trivy version to 0.30

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
