### PR TITLE
[stable/fairwinds-insights] - add sync action-items and IaC files cronjob

### DIFF
--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.4.0
+* Adds `cronjobs.sync-action-items-iac-files` definition - this cronjob is responsible for linking action-items and IaC Files
+
 ## 2.3.0
 * Adds `useReadReplica` to cronjobs to enable `postgresql.readReplica` injection instead of primary database
 

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "16.2"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 2.3.0
+version: 2.4.0
 kubeVersion: ">= 1.22.0-0"
 maintainers:
   - name: rbren

--- a/stable/fairwinds-insights/README.md
+++ b/stable/fairwinds-insights/README.md
@@ -55,6 +55,7 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | cronjobs.trial-end | object | `{"command":"trial_end_downgrade","schedule":""}` | Options for the trial-end job. |
 | cronjobs.move-health-scores-to-ts | object | `{"command":"move_resource_health_scores_to_ts","schedule":"*/30 * * * *"}` | Options for the move-health-scores-to-ts job. |
 | cronjobs.image-vulns-refresh | object | `{"command":"image_vulnerabilities_refresher","schedule":"*/30 * * * *"}` | Options for the image-vulns-refresh job. |
+| cronjobs.sync-action-items-iac-files | object | `{"command":"sync_action_items_iac_files","schedule":"0 * * * *"}` | Options for the sync-action-items-iac-files cronjob. |
 | selfHostedSecret | string | `nil` |  |
 | additionalEnvironmentVariables | object | `{}` | Additional Environment Variables to set on the Fairwinds Insights pods. |
 | rbac.serviceAccount.annotations | object | `{}` | Annotations to add to the service account |

--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -41,8 +41,7 @@ openApiImage:
   # -- Docker image repository for the Open API server
   repository: swaggerapi/swagger-ui
   # -- Overrides tag for the Open API server, defaults to image.tag
-  tag: v4.1.3  # NOTE: if you're changing this, be sure to look at templates/openapi-nginx-conf.yaml
-
+  tag: v4.1.3 # NOTE: if you're changing this, be sure to look at templates/openapi-nginx-conf.yaml
 
 options:
   # -- Which version of the Insights Agent is supported by this version of Fairwinds Insights
@@ -72,7 +71,6 @@ options:
     cpu: 1000m
     memory: 1Gi
 
-
 cronjobOptions:
   # -- Default security context for cronjobs
   securityContext:
@@ -96,7 +94,7 @@ cronjobOptions:
 cronjobs:
   # -- Options for the action-items filters refresher job.
   action-item-filters-refresh:
-    command: 'action_items_filters_refresher'
+    command: action_items_filters_refresher
     schedule: "0/15 * * * *"
 
   # -- Options for the action item stats job
@@ -106,14 +104,14 @@ cronjobs:
 
   # -- Options for the realtime alerts job
   alerts-realtime:
-    command: 'notifications_digest'
+    command: notifications_digest
     interval: 10m
     schedule: "5/10 * * * *"
 
   # -- Options for the benchmark job
   benchmark:
     command: benchmark
-    schedule: ''
+    schedule: ""
 
   # -- Options for the update tickets job.
   update-tickets:
@@ -149,17 +147,17 @@ cronjobs:
   # -- Options for the email digest job.
   email:
     command: email_digest
-    schedule: ''
+    schedule: ""
 
   # -- Options for the hubspot job.
   hubspot:
-    command: 'hubspot_sync'
-    schedule: ''
+    command: hubspot_sync
+    schedule: ""
     useReadReplica: true
 
   # -- Options for digest notifications job
   notifications-digest:
-    command: 'notifications_digest'
+    command: notifications_digest
     schedule: "0 16 * * *"
     interval: 24h
 
@@ -200,6 +198,11 @@ cronjobs:
     command: image_vulnerabilities_refresher
     schedule: "*/30 * * * *"
 
+  # -- Options for the sync-action-items-iac-files cronjob.
+  sync-action-items-iac-files:
+    command: sync_action_items_iac_files
+    schedule: "0 * * * *"
+
 selfHostedSecret:
 
 # -- Additional Environment Variables to set on the Fairwinds Insights pods.
@@ -225,18 +228,18 @@ dashboard:
     max: 4
     # -- Scaling metrics
     metrics:
-    - type: Resource
-      resource:
-        name: cpu
-        target:
-          type: Utilization
-          averageUtilization: 75
-    - type: Resource
-      resource:
-        name: memory
-        target:
-          type: Utilization
-          averageUtilization: 75
+      - type: Resource
+        resource:
+          name: cpu
+          target:
+            type: Utilization
+            averageUtilization: 75
+      - type: Resource
+        resource:
+          name: memory
+          target:
+            type: Utilization
+            averageUtilization: 75
   # -- Resources for the front end pods.
   resources:
     limits:
@@ -270,18 +273,18 @@ api:
     max: 4
     # -- Scaling metrics
     metrics:
-    - type: Resource
-      resource:
-        name: cpu
-        target:
-          type: Utilization
-          averageUtilization: 75
-    - type: Resource
-      resource:
-        name: memory
-        target:
-          type: Utilization
-          averageUtilization: 75
+      - type: Resource
+        resource:
+          name: cpu
+          target:
+            type: Utilization
+            averageUtilization: 75
+      - type: Resource
+        resource:
+          name: memory
+          target:
+            type: Utilization
+            averageUtilization: 75
   # -- Resources for the API server.
   resources:
     limits:
@@ -321,18 +324,18 @@ openApi:
     max: 3
     # -- Scaling metrics
     metrics:
-    - type: Resource
-      resource:
-        name: cpu
-        target:
-          type: Utilization
-          averageUtilization: 75
-    - type: Resource
-      resource:
-        name: memory
-        target:
-          type: Utilization
-          averageUtilization: 75
+      - type: Resource
+        resource:
+          name: cpu
+          target:
+            type: Utilization
+            averageUtilization: 75
+      - type: Resource
+        resource:
+          name: memory
+          target:
+            type: Utilization
+            averageUtilization: 75
   # -- Resources for the Open API server.
   resources:
     limits:
@@ -526,9 +529,9 @@ minio:
   install: true
   # -- Create the following buckets for the newly installed Minio
   buckets:
-  - name: reports
-    policy: none
-    purge: false
+    - name: reports
+      policy: none
+      purge: false
   # -- Resources for Minio
   resources:
     requests:

--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -41,7 +41,7 @@ openApiImage:
   # -- Docker image repository for the Open API server
   repository: swaggerapi/swagger-ui
   # -- Overrides tag for the Open API server, defaults to image.tag
-  tag: v4.1.3 # NOTE: if you're changing this, be sure to look at templates/openapi-nginx-conf.yaml
+  tag: v4.1.3  # NOTE: if you're changing this, be sure to look at templates/openapi-nginx-conf.yaml
 
 options:
   # -- Which version of the Insights Agent is supported by this version of Fairwinds Insights


### PR DESCRIPTION
**Why This PR?**
This PR adds the new cronjob to sync action-items and IaC Files

Fixes internal INSIGHTS-406

**Changes**
Changes proposed in this pull request:

* Add new cronjob

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
