### PR TITLE
[stable/insights-agent] Add support for `SERVICE_ACCOUNT_ANNOTATIONS` environment variable on…

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 4.5.0
+## 4.4.13
 * Add support for `SERVICE_ACCOUNT_ANNOTATIONS` environment variable on trivy
 
 ## 4.4.12

--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 4.5.0
+* Add support for `SERVICE_ACCOUNT_ANNOTATIONS` environment variable on trivy
+
 ## 4.4.12
 * bumped nova to 3.11
 

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 4.5.0
+version: 4.4.13
 appVersion: 9.2.1
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 4.4.12
+version: 4.5.0
 appVersion: 9.2.1
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png

--- a/stable/insights-agent/templates/trivy/cronjob.yaml
+++ b/stable/insights-agent/templates/trivy/cronjob.yaml
@@ -75,6 +75,10 @@ spec:
             {{- end }}
             - name: NAMESPACE_ALLOWLIST
               value: {{ join "," .Values.trivy.namespaceAllowlist | lower }}
+            - name: SERVICE_ACCOUNT_ANNOTATIONS
+              value: >
+                {{- $annotations := .Values.trivy.serviceAccount.annotations }}
+                {{ $annotations | toJson }}
             {{ include "security-context" . | indent 12 | trim }}
           {{ include "uploaderContainer" . | indent 10 | trim }}
 {{- end -}}


### PR DESCRIPTION
… trivy

**Why This PR?**
Add support for `SERVICE_ACCOUNT_ANNOTATIONS` environment variable on trivy

Fixes #

**Changes**
Changes proposed in this pull request:

* forwards the `trivy.serviceAccount.annotations` to trivy pod, so it can infer if it is running inside GKE using the default workload identity service account label (`iam.gke.io/gcp-service-account`) 
*

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
