### PR TITLE
[stable/insights-agent] add mount tmp by default for trivy

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 4.4.14
+* Change parameter mountTmp=true as default for trivy
+
 ## 4.4.13
 * Add support for `SERVICE_ACCOUNT_ANNOTATIONS` environment variable on trivy
 

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 4.4.13
+version: 4.4.14
 appVersion: 9.2.1
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png

--- a/stable/insights-agent/README.md
+++ b/stable/insights-agent/README.md
@@ -99,6 +99,8 @@ Parameter | Description | Default
 `{report}.annotations` | annotations for the CronJob | {}
 `{report}.jobLabels` | labels for the Jobs created by the CronJob | {}
 `{report}.jobAnnotations` | annotations for the Jobs created by the CronJob | {}
+`{report}.SkipVolumes` | skip volume creation if set | 
+`{report}.mountTmp` | mount `/tmp` folder if set |
 `polaris.config` | A custom [polaris configuration](https://polaris.docs.fairwinds.com/customization/configuration/)
 `polaris.extraArgs` | A string of custom arguments to pass to the polaris CLI, e.g. `--disallow-annotation-exemptions=true` | 
 `kube-hunter.logLevel` | DEFAULT, INFO, or WARNING | `INFO`

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -286,6 +286,8 @@ trivy:
   insecureSSL: false
   # trivy.env -- A map of environment variables that will be set for the trivy container.
   env:
+    TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,ghcr.io/aquasecurity/trivy-db:2,public.ecr.aws/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db:2
+    TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,ghcr.io/aquasecurity/trivy-java-db:2,public.ecr.aws/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db:2
   image:
     repository: quay.io/fairwinds/fw-trivy
     tag: "0.30"

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -295,6 +295,7 @@ trivy:
     requests:
       cpu: 100m
       memory: 1Gi
+  mountTmp: true
 
 pluto:
   enabled: false

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -297,7 +297,6 @@ trivy:
     requests:
       cpu: 100m
       memory: 1Gi
-  mountTmp: true
 
 pluto:
   enabled: false

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -286,8 +286,8 @@ trivy:
   insecureSSL: false
   # trivy.env -- A map of environment variables that will be set for the trivy container.
   env:
-    TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,ghcr.io/aquasecurity/trivy-db:2,public.ecr.aws/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db:2
-    TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,ghcr.io/aquasecurity/trivy-java-db:2,public.ecr.aws/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db:2
+    TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db:2
+    TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db:2
   image:
     repository: quay.io/fairwinds/fw-trivy
     tag: "0.30"


### PR DESCRIPTION
**Why This PR?**
Add `mountTmp: true` by default for `trivy` -- this is required for `gcloud` output config and files

Fixes internal INSIGHTS-431

**Changes**
Changes proposed in this pull request:

* Adds `mountTmp: true` to trivy report

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
