### PR TITLE
[stable/fairwinds-agent] add ghcr, ecr and docker as fallback for trivy

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 4.4.14
+* Add fallback OCI repositories for trivy (ghcr, ecr and docker)
+
 ## 4.4.13
 * Add support for `SERVICE_ACCOUNT_ANNOTATIONS` environment variable on trivy
 

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 4.4.13
+version: 4.4.14
 appVersion: 9.2.1
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -286,6 +286,8 @@ trivy:
   insecureSSL: false
   # trivy.env -- A map of environment variables that will be set for the trivy container.
   env:
+    TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db:2,public.ecr.aws/aquasecurity/trivy-db:2,docker.io/aquasec/trivy-db:2
+    TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db:1,public.ecr.aws/aquasecurity/trivy-java-db:1,docker.io/aquasec/trivy-java-db:1
   image:
     repository: quay.io/fairwinds/fw-trivy
     tag: "0.30"


### PR DESCRIPTION
**Why This PR?**
Add fallback OCI repositories for trivy

Fixes internal INSIGHTS-432

**Changes**
Changes proposed in this pull request:

* Add fallback OCI repositories for trivy by default

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
