### PR TITLE
[stable/vpa] feat(certgen): set default strict security context for vpa certGen job

### DIFF
--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 4.6.0
+version: 4.7.0
 appVersion: 1.0.0
 maintainers:
   - name: sudermanjr

--- a/stable/vpa/README.md
+++ b/stable/vpa/README.md
@@ -202,8 +202,8 @@ recommender:
 | admissionController.certGen.image.pullPolicy | string | `"Always"` | The pull policy for the certgen image. Recommend not changing this |
 | admissionController.certGen.env | object | `{}` | Additional environment variables to be added to the certgen container. Format is KEY: Value format |
 | admissionController.certGen.resources | object | `{}` | The resources block for the certgen pod |
-| admissionController.certGen.securityContext | object | `{}` | The securityContext block for the certgen container(s) |
-| admissionController.certGen.podSecurityContext | object | `{}` | The securityContext block for the certgen pod(s) |
+| admissionController.certGen.podSecurityContext | object | `{"runAsNonRoot":true,"runAsUser":65534,"seccompProfile":{"type":"RuntimeDefault"}}` | The securityContext block for the certgen pod(s) |
+| admissionController.certGen.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | The securityContext block for the certgen container(s) |
 | admissionController.certGen.nodeSelector | object | `{}` |  |
 | admissionController.certGen.tolerations | list | `[]` |  |
 | admissionController.certGen.affinity | object | `{}` |  |

--- a/stable/vpa/values.yaml
+++ b/stable/vpa/values.yaml
@@ -221,13 +221,13 @@ admissionController:
     env: {}
     # admissionController.certGen.resources -- The resources block for the certgen pod
     resources: {}
-    # admissionController.certGen.securityContext -- The securityContext block for the certgen container(s)
+    # admissionController.certGen.podSecurityContext -- The securityContext block for the certgen pod(s)
     podSecurityContext:
       runAsNonRoot: true
       runAsUser: 65534
       seccompProfile:
         type: RuntimeDefault
-    # admissionController.certGen.podSecurityContext -- The securityContext block for the certgen pod(s)
+    # admissionController.certGen.securityContext -- The securityContext block for the certgen container(s)
     securityContext:
       readOnlyRootFilesystem: true
       allowPrivilegeEscalation: false

--- a/stable/vpa/values.yaml
+++ b/stable/vpa/values.yaml
@@ -222,9 +222,18 @@ admissionController:
     # admissionController.certGen.resources -- The resources block for the certgen pod
     resources: {}
     # admissionController.certGen.securityContext -- The securityContext block for the certgen container(s)
-    securityContext: {}
+    podSecurityContext:
+      runAsNonRoot: true
+      runAsUser: 65534
+      seccompProfile:
+        type: RuntimeDefault
     # admissionController.certGen.podSecurityContext -- The securityContext block for the certgen pod(s)
-    podSecurityContext: {}
+    securityContext:
+      readOnlyRootFilesystem: true
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
     nodeSelector: {}
     tolerations: []
     affinity: {}


### PR DESCRIPTION
**Why This PR?**
Sets default certgen job security context the same as the rest of the chart.

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
