### PR TITLE
[stable/goldilocks] Add pod priority class for goldilocks

### DIFF
--- a/stable/goldilocks/Chart.yaml
+++ b/stable/goldilocks/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 appVersion: "v4.13.0"
-version: 9.0.1
+version: 9.1.0
 kubeVersion: ">= 1.22.0-0"
 description: |
   A Helm chart for running Fairwinds Goldilocks. See https://github.com/FairwindsOps/goldilocks

--- a/stable/goldilocks/README.md
+++ b/stable/goldilocks/README.md
@@ -92,6 +92,7 @@ This will completely remove the VPA and then re-install it using the new method.
 | controller.deployment.annotations | object | `{}` | Extra annotations for the controller deployment |
 | controller.deployment.additionalLabels | object | `{}` | Extra labels for the controller deployment |
 | controller.deployment.podAnnotations | object | `{}` | Extra annotations for the controller pod |
+| controller.deployment.priorityClassName | object | `{}` | Extra annotations for the controller pod |
 | dashboard.basePath | string | `nil` | Path on which the dashboard is served. Defaults to `/` |
 | dashboard.enabled | bool | `true` | If true, the dashboard component will be installed |
 | dashboard.revisionHistoryLimit | int | `10` | Number of old replicasets to retain, default is 10, 0 will garbage-collect old replicasets |

--- a/stable/goldilocks/templates/controller-deployment.yaml
+++ b/stable/goldilocks/templates/controller-deployment.yaml
@@ -46,7 +46,7 @@ spec:
       {{- end }}
       {{- with .Values.controller.priorityClassName }}
       priorityClassName: 
-        {{- toYaml .Values.controller.priorityClassName | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ template "controller.serviceAccountName" . }}
       securityContext:

--- a/stable/goldilocks/templates/controller-deployment.yaml
+++ b/stable/goldilocks/templates/controller-deployment.yaml
@@ -44,7 +44,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.controller.priorityClassName }}
+      {{- if .Values.controller.priorityClassName }}
       priorityClassName: 
         {{- toYaml .Values.controller.priorityClassName | nindent 8 }}
       {{- end }}

--- a/stable/goldilocks/templates/controller-deployment.yaml
+++ b/stable/goldilocks/templates/controller-deployment.yaml
@@ -44,7 +44,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.controller.priorityClassName }}
+      {{- with .Values.controller.priorityClassName }}
       priorityClassName: 
         {{- toYaml .Values.controller.priorityClassName | nindent 8 }}
       {{- end }}

--- a/stable/goldilocks/templates/controller-deployment.yaml
+++ b/stable/goldilocks/templates/controller-deployment.yaml
@@ -1,3 +1,4 @@
+
 {{- if .Values.controller.enabled }}
 apiVersion: apps/v1
 kind: Deployment
@@ -42,6 +43,9 @@ spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.controller.priorityClassName }}
+      priorityClassName: {{ . }}
       {{- end }}
       serviceAccountName: {{ template "controller.serviceAccountName" . }}
       securityContext:

--- a/stable/goldilocks/templates/controller-deployment.yaml
+++ b/stable/goldilocks/templates/controller-deployment.yaml
@@ -45,7 +45,8 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.controller.priorityClassName }}
-      priorityClassName: {{ . }}
+      priorityClassName: 
+        {{- toYaml .Values.controller.priorityClassName | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ template "controller.serviceAccountName" . }}
       securityContext:

--- a/stable/goldilocks/values.yaml
+++ b/stable/goldilocks/values.yaml
@@ -90,6 +90,8 @@ controller:
 
     # controller.deployment.podAnnotations -- Extra annotations for the controller pod
     podAnnotations: {}
+    # controller.deployment.priorityClassName -- Extra annotations for the controller pod
+    priorityClassName: {}
 
 dashboard:
   # dashboard.basePath -- Path on which the dashboard is served. Defaults to `/`
@@ -143,7 +145,8 @@ dashboard:
 
     # dashboard.ingress.ingressClassName -- From Kubernetes 1.18+ this field is supported in case your ingress controller supports it. When set, you do not need to add the ingress class as annotation.
     ingressClassName:
-    annotations: {}
+    annotations:
+      {}
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
     hosts:

--- a/stable/goldilocks/values.yaml
+++ b/stable/goldilocks/values.yaml
@@ -145,8 +145,7 @@ dashboard:
 
     # dashboard.ingress.ingressClassName -- From Kubernetes 1.18+ this field is supported in case your ingress controller supports it. When set, you do not need to add the ingress class as annotation.
     ingressClassName:
-    annotations:
-      {}
+    annotations: {}
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
     hosts:


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_
There is no pod priority class support available for goldilocks start so this change add pod priority class in goldilocks deployment 
Fixes  https://github.com/FairwindsOps/charts/issues/1544

**Changes**
Changes proposed in this pull request:
* The addition of a pod priority class allows users to specify their own values based on their requirements, as there are no hardcoded defaults.


**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
