### PR TITLE
[stable/polaris] Added mergeConfig flag to helm chart

### DIFF
--- a/stable/polaris/Chart.yaml
+++ b/stable/polaris/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Validation of best practices in your Kubernetes clusters
 name: polaris
-version: 5.17.1
+version: 5.18.0
 appVersion: "8.5"
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/polaris/master/pkg/dashboard/assets/favicon-32x32.png

--- a/stable/polaris/README.md
+++ b/stable/polaris/README.md
@@ -38,6 +38,7 @@ the 0.10.0 version of this chart will only work on kubernetes 1.14.0+
 | config | string | `nil` | The [polaris configuration](https://github.com/FairwindsOps/polaris#configuration). If not provided then the [default](https://github.com/FairwindsOps/polaris/blob/master/examples/config.yaml) config from Polaris is used. |
 | configUrl | string | `nil` | Use a config from an accessible URL source.  NOTE: `config` & `configUrl` are mutually exclusive.  Setting `configURL` will take precedence over `config`.  Only one may be used. configUrl: https://example.com/config.yaml |
 | additionalExemptions | string | `nil` | List of additional exemptions to append to the exemptions given in `config` |
+| mergeConfig | bool | `false` | If the config should be merged with the default config. See https://github.com/FairwindsOps/polaris/pull/1075 |
 | image.repository | string | `"quay.io/fairwinds/polaris"` | Image repo |
 | image.tag | string | `""` | The Polaris Image tag to use. Defaults to the Chart's AppVersion |
 | image.pullPolicy | string | `"Always"` | Image pull policy |

--- a/stable/polaris/ci/test-values.yaml
+++ b/stable/polaris/ci/test-values.yaml
@@ -1,5 +1,3 @@
-mergeConfig: true
-
 dashboard:
   ingress:
     enabled: true

--- a/stable/polaris/ci/test-values.yaml
+++ b/stable/polaris/ci/test-values.yaml
@@ -1,3 +1,5 @@
+mergeConfig: true
+
 dashboard:
   ingress:
     enabled: true

--- a/stable/polaris/templates/dashboard.deployment.yaml
+++ b/stable/polaris/templates/dashboard.deployment.yaml
@@ -79,6 +79,9 @@ spec:
         - --log-level
         - {{ .Values.dashboard.logLevel | quote }}
         {{- end }}
+        {{- if .Values.mergeConfig }}
+        - --merge-config
+        {{- end }}
         image: '{{.Values.image.repository}}:{{.Values.image.tag | default .Chart.AppVersion }}'
         imagePullPolicy: '{{.Values.image.pullPolicy}}'
         name: dashboard

--- a/stable/polaris/values.yaml
+++ b/stable/polaris/values.yaml
@@ -8,6 +8,9 @@ configUrl: null
 # additionalExemptions -- List of additional exemptions to append to the exemptions given in `config`
 additionalExemptions: null
 
+# mergeConfig -- If the config should be merged with the default config. See https://github.com/FairwindsOps/polaris/pull/1075
+mergeConfig: false
+
 
 image:
   # image.repository -- Image repo


### PR DESCRIPTION
**Why This PR?**
The flag "mergeConfig" is possible to use for the docker command, but is not possible in helm chart. This has caused us to have two ways of configuration our Polaris, for local checks, we can use a custom config file, and use the 'mergeConfig' flag, while our deployment, needs the full configuration override.

Fixes #

**Changes**
Changes proposed in this pull request:

Add the flag to the helm chart, by default setting it to false, so that it's only set if deliberately set to true.
This also ensures that the helm-chart deployment, and manual deployment are consistent

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
