### PR TITLE
[stable/insights-agent] INSIGHTS-460 - Bump VPA to 4.7.1 in charts

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 4.4.16
+* bump VPA to 4.7.1
+
 ## 4.4.15
 * bump trivy to 0.31
 

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 4.4.15
+version: 4.4.16
 appVersion: 9.2.1
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png

--- a/stable/insights-agent/requirements.yaml
+++ b/stable/insights-agent/requirements.yaml
@@ -17,7 +17,7 @@ dependencies:
   condition: falco.installFalco
   alias: falcosecurity
 - name: vpa
-  version: '4.4.5'
+  version: '4.7.1'
   repository: https://charts.fairwinds.com/stable
   condition: right-sizer.enableClosedBeta
   alias: right-sizer-vpa


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.


[Internal Ticket INSIGHTS-460](https://fairwinds.myjetbrains.com/youtrack/issue/INSIGHTS-460)