### PR TITLE
[incubator/timescale] Reverting timescale version

### DIFF
--- a/incubator/timescale/Chart.yaml
+++ b/incubator/timescale/Chart.yaml
@@ -4,8 +4,8 @@
 apiVersion: v1
 name: timescaledb-single
 description: 'TimescaleDB HA Deployment.'
-appVersion: 0.33.4  # Added to make linter happy
-version: 0.33.7
+appVersion: 0.33.5  # Added to make linter happy
+version: 0.33.8
 icon: https://cdn.iconscout.com/icon/free/png-256/timescaledb-1958407-1651618.png
 
 # appVersion specifies the version of the software, which can vary wildly,

--- a/incubator/timescale/README.md
+++ b/incubator/timescale/README.md
@@ -28,7 +28,7 @@ TimescaleDB HA Deployment.
 | clusterName | string | `""` |  |
 | version | string | `nil` |  |
 | image.repository | string | `"timescale/timescaledb-ha"` |  |
-| image.tag | string | `"pg14.13-ts2.17.1-all"` |  |
+| image.tag | string | `"pg14.11-ts2.14.2-all"` |  |
 | image.pullPolicy | string | `"Always"` |  |
 | curlImage.repository | string | `"curlimages/curl"` |  |
 | curlImage.tag | string | `"7.87.0"` |  |

--- a/incubator/timescale/values.yaml
+++ b/incubator/timescale/values.yaml
@@ -20,7 +20,7 @@ image:
   # Image was built from
   # https://github.com/timescale/timescaledb-docker-ha
   repository: timescale/timescaledb-ha
-  tag: pg14.13-ts2.17.1-all
+  tag: pg14.11-ts2.14.2-all
   pullPolicy: Always
 
 # There are job and cronjob resources that run during updates or backups that use curl image


### PR DESCRIPTION
**Why This PR?**
Revert timescale version due some issues we are still addressing

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
