### PR TITLE
[incubator/datadog-apm] feat: dd app version to 7.59.0, hpa cpu scaler optional, allow unlimi…

### DIFF
--- a/incubator/datadog-apm/Chart.yaml
+++ b/incubator/datadog-apm/Chart.yaml
@@ -1,10 +1,9 @@
-# A modified chart based off of datadog chart v2.4.25
 apiVersion: v2
 name: datadog-apm
 description: A modified chart that only installs the datadog-apm agent
 type: application
-version: 1.0.0
-appVersion: 7.55.2
+version: 1.1.0
+appVersion: 7.59.0
 maintainers:
   - name: sudermanjr
   - name: Azahorscak

--- a/incubator/datadog-apm/README.md
+++ b/incubator/datadog-apm/README.md
@@ -44,6 +44,7 @@ A modified chart that only installs the datadog-apm agent
 | clusterAgent.apm.enabled | bool | `true` |  |
 | clusterAgent.apm.nonLocalTraffic | bool | `true` |  |
 | clusterAgent.apm.receiverPort | int | `8126` |  |
+| clusterAgent.apm.unlimited | bool | `true` |  |
 | clusterAgent.additionalEnvVars | object | `{}` |  |
 | clusterAgent.metricsProvider.enabled | bool | `true` |  |
 | clusterAgent.metricsProvider.port | int | `8126` |  |
@@ -75,7 +76,10 @@ A modified chart that only installs the datadog-apm agent
 | clusterAgent.hpa.enabled | bool | `true` |  |
 | clusterAgent.hpa.minReplicas | int | `2` |  |
 | clusterAgent.hpa.maxReplicas | int | `6` |  |
+| clusterAgent.hpa.memoryScaler | bool | `true` |  |
 | clusterAgent.hpa.averageMemoryUtilization | int | `75` |  |
+| clusterAgent.hpa.cpuScaler | bool | `false` |  |
+| clusterAgent.hpa.averageCPUUtilization | int | `60` |  |
 | clusterAgent.createPodDisruptionBudget | bool | `true` |  |
 | podAnnotations | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |

--- a/incubator/datadog-apm/templates/cluster-agent-deployment.yaml
+++ b/incubator/datadog-apm/templates/cluster-agent-deployment.yaml
@@ -175,6 +175,12 @@ spec:
             value: {{ .Values.clusterAgent.apm.nonLocalTraffic | quote }}
           - name: DD_APM_RECEIVER_PORT
             value: {{ .Values.clusterAgent.apm.receiverPort | quote }}
+          {{- if .Values.clusterAgent.apm.unlimited }}
+          - name: DD_APM_MAX_MEMORY
+            value: "0"
+          - name: DD_APM_MAX_CPU_PERCENT
+            value: "0"
+          {{- end }}
         {{- include "additional-env-entries" .Values.clusterAgent.additionalEnvVars | indent 10 }}
         {{- include "additional-env-dict-entries" .Values.clusterAgent.additionalEnvDict | indent 10 }}
 {{- if .Values.clusterAgent.env }}

--- a/incubator/datadog-apm/templates/cluster-agent-hpa.yaml
+++ b/incubator/datadog-apm/templates/cluster-agent-hpa.yaml
@@ -12,10 +12,20 @@ spec:
   maxReplicas: {{ .Values.clusterAgent.hpa.maxReplicas }}
   minReplicas: {{ .Values.clusterAgent.hpa.minReplicas }}
   metrics:
-    - type: Resource
-      resource:
-        name: memory
-        target:
-          averageUtilization: {{ .Values.clusterAgent.hpa.averageMemoryUtilization }}
-          type: Utilization
+  {{- if .Values.clusterAgent.hpa.memoryScaler }}
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        averageUtilization: {{ .Values.clusterAgent.hpa.averageMemoryUtilization }}
+        type: Utilization
+  {{- end }}
+  {{- if .Values.clusterAgent.hpa.cpuScaler }}
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        averageUtilization: {{ .Values.clusterAgent.hpa.averageCPUUtilization }}
+        type: Utilization
+  {{- end }}
 {{- end }}

--- a/incubator/datadog-apm/values.yaml
+++ b/incubator/datadog-apm/values.yaml
@@ -29,6 +29,7 @@ clusterAgent:
     enabled: true
     nonLocalTraffic: true
     receiverPort: 8126
+    unlimited: true
   additionalEnvVars: {}
   metricsProvider:
     enabled: true
@@ -71,7 +72,10 @@ clusterAgent:
     enabled: true
     minReplicas: 2
     maxReplicas: 6
+    memoryScaler: true
     averageMemoryUtilization: 75
+    cpuScaler: false
+    averageCPUUtilization: 60
   createPodDisruptionBudget: true
 
 podAnnotations: {}


### PR DESCRIPTION
…ted resource usage by trace-agent

**Why This PR?**
For better resource usage and app bump

Fixes #

**Changes**
Changes proposed in this pull request:

* Allows cpu resource scaling on the hpa
* Enables unlimited resource usage by the apm agent by default.
* Bumps image to 7.59.0

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
