### PR TITLE
[stable/vpa] Add imagePullSecrets to all helm tests

### DIFF
--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 4.7.1
+version: 4.7.2
 appVersion: 1.0.0
 maintainers:
   - name: sudermanjr

--- a/stable/vpa/templates/tests/crds-available.yaml
+++ b/stable/vpa/templates/tests/crds-available.yaml
@@ -27,4 +27,8 @@ spec:
         - crd
         - verticalpodautoscalercheckpoints.autoscaling.k8s.io
         - verticalpodautoscalers.autoscaling.k8s.io
+  {{- with .Values.imagePullSecrets }}
+  imagePullSecrets:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   restartPolicy: Never

--- a/stable/vpa/templates/tests/create-vpa.yaml
+++ b/stable/vpa/templates/tests/create-vpa.yaml
@@ -44,4 +44,8 @@ spec:
 
           kubectl -n {{ .Release.Namespace }} describe vpa test-vpa
           kubectl -n {{ .Release.Namespace }} delete vpa test-vpa
+  {{- with .Values.imagePullSecrets }}
+  imagePullSecrets:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   restartPolicy: Never

--- a/stable/vpa/templates/tests/metrics.yaml
+++ b/stable/vpa/templates/tests/metrics.yaml
@@ -26,4 +26,8 @@ spec:
         - get
         - --raw
         - "/apis/metrics.k8s.io/v1beta1/nodes"
+  {{- with .Values.imagePullSecrets }}
+  imagePullSecrets:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   restartPolicy: Never

--- a/stable/vpa/templates/tests/webhook.yaml
+++ b/stable/vpa/templates/tests/webhook.yaml
@@ -71,5 +71,9 @@ spec:
             echo "Service configured in mutating webhook {{ include "vpa.fullname" . }}-webhook-config is '$WEBHOOK_SERVICE' not '$SERVICE'"
           fi
           exit 1;
+  {{- with .Values.imagePullSecrets }}
+  imagePullSecrets:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   restartPolicy: Never
 {{- end }}


### PR DESCRIPTION
**Why This PR?**
Currently, imagePullSecrets are not being added to tests, which is problematic if test images should be pulled from a private repository. if imagePullSecrets is set, this PR adds them also to the test images so they can then be retrieved from private repositories that require authentication.

Fixes #1565

**Changes**
Changes proposed in this pull request:

* Adds the imagePullSecrets to all test pods.

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
