### PR TITLE
[stable/goldilocks]: add extra rbac rule for goldilocks dashboard

### DIFF
--- a/stable/goldilocks/Chart.yaml
+++ b/stable/goldilocks/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 appVersion: "v4.13.0"
-version: 9.0.1
+version: 9.0.2
 kubeVersion: ">= 1.22.0-0"
 description: |
   A Helm chart for running Fairwinds Goldilocks. See https://github.com/FairwindsOps/goldilocks

--- a/stable/goldilocks/README.md
+++ b/stable/goldilocks/README.md
@@ -104,6 +104,7 @@ This will completely remove the VPA and then re-install it using the new method.
 | dashboard.excludeContainers | string | `"linkerd-proxy,istio-proxy"` | Container names to exclude from displaying in the Goldilocks dashboard |
 | dashboard.rbac.create | bool | `true` | If set to true, rbac resources will be created for the dashboard |
 | dashboard.rbac.enableArgoproj | bool | `true` | If set to true, the clusterrole will give access to argoproj.io resources |
+| dashboard.rbac.extraRules | list | `[]` | Extra rbac rules for the dashboard clusterrole |
 | dashboard.serviceAccount.create | bool | `true` | If true, a service account will be created for the dashboard. If set to false, you must set `dashboard.serviceAccount.name` |
 | dashboard.serviceAccount.name | string | `nil` | The name of an existing service account to use for the controller. Combined with `dashboard.serviceAccount.create` |
 | dashboard.deployment.annotations | object | `{}` | Extra annotations for the dashboard deployment |

--- a/stable/goldilocks/templates/dashboard-clusterrole.yaml
+++ b/stable/goldilocks/templates/dashboard-clusterrole.yaml
@@ -41,4 +41,7 @@ rules:
       - 'get'
       - 'list'
   {{- end }}
+  {{- if .Values.dashboard.rbac.extraRules }}
+    {{- toYaml .Values.dashboard.rbac.extraRules | nindent 2 }}
+  {{- end }}
 {{- end }}

--- a/stable/goldilocks/values.yaml
+++ b/stable/goldilocks/values.yaml
@@ -118,6 +118,8 @@ dashboard:
     create: true
     # dashboard.rbac.enableArgoproj -- If set to true, the clusterrole will give access to argoproj.io resources
     enableArgoproj: true
+    # dashboard.rbac.extraRules -- Extra rbac rules for the dashboard clusterrole
+    extraRules: []
   serviceAccount:
     # dashboard.serviceAccount.create -- If true, a service account will be created for the dashboard. If set to false, you must set `dashboard.serviceAccount.name`
     create: true


### PR DESCRIPTION
**Why This PR?**
When we use a Custom Resource definition to deploy K8s workloads, we need to add an RBAC rule granting the `read,list,watch` permissions to the goldilocks controller for that CR, using `.Values.controller.rbac.extraRules`. This way the controller can read CR which is the top level owner of the workload.     
The same thing needs to be done for the dashboard, as right now it just doesn't show any resource at all, which has our CR as the top level owner. Strange thing is that, there are no RBAC error messages in the dashboard pod indicating RBAC issues, which normally shows on the controller.    
This PR introduces new variable `.Values.dashboard.rbac.extraRules` which allows users to define custom RBAC rules for dashboard `ClusterRole`

This basically fixes issue [#729](https://github.com/FairwindsOps/goldilocks/issues/729) which has been opened a few months ago and is now auto-closed.

**Changes**
Changes proposed in this pull request:

* Add `.Values.dashboard.rbac.extraRules` variable to allow users adding custom RBAC rules for dashboard cluster role

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
