### PR TITLE
stable/vpa

### DIFF
--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 4.7.2
+version: 4.7.3
 appVersion: 1.0.0
 maintainers:
   - name: sudermanjr

--- a/stable/vpa/templates/admission-controller-deployment.yaml
+++ b/stable/vpa/templates/admission-controller-deployment.yaml
@@ -7,6 +7,7 @@ metadata:
   {{- .Values.admissionController.annotations | toYaml | nindent 4 }}
   {{- end }}
   name: {{ include "vpa.fullname" . }}-admission-controller
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: admission-controller
     {{- include "vpa.labels" . | nindent 4 }}

--- a/stable/vpa/templates/admission-controller-pdb.yaml
+++ b/stable/vpa/templates/admission-controller-pdb.yaml
@@ -4,6 +4,7 @@ apiVersion: {{ ternary "policy/v1" "policy/v1beta1" (semverCompare ">=1.21.0-0" 
 kind: PodDisruptionBudget
 metadata:
   name: "{{ template "vpa.fullname" . }}-admission-controller-pdb"
+  namespace: {{ .Release.Namespace }}
 spec:
   {{- toYaml .Values.admissionController.podDisruptionBudget | nindent 2 }}
   selector:

--- a/stable/vpa/templates/admission-controller-service-account.yaml
+++ b/stable/vpa/templates/admission-controller-service-account.yaml
@@ -4,6 +4,7 @@ kind: ServiceAccount
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 metadata:
   name: {{ include "vpa.serviceAccountName" . }}-admission-controller
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "vpa.labels" . | nindent 4 }}
     app.kubernetes.io/component: admission-controller

--- a/stable/vpa/templates/admission-controller-service.yaml
+++ b/stable/vpa/templates/admission-controller-service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "vpa.fullname" . }}-webhook
+  namespace: {{ .Release.Namespace }}
 spec:
   ports:
     - port: 443

--- a/stable/vpa/templates/recommender-deployment.yaml
+++ b/stable/vpa/templates/recommender-deployment.yaml
@@ -7,6 +7,7 @@ metadata:
   {{- .Values.recommender.annotations | toYaml | nindent 4 }}
   {{- end }}
   name: {{ include "vpa.fullname" . }}-recommender
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: recommender
     {{- include "vpa.labels" . | nindent 4 }}

--- a/stable/vpa/templates/recommender-pdb.yaml
+++ b/stable/vpa/templates/recommender-pdb.yaml
@@ -4,6 +4,7 @@ apiVersion: {{ ternary "policy/v1" "policy/v1beta1" (semverCompare ">=1.21.0-0" 
 kind: PodDisruptionBudget
 metadata:
   name: "{{ template "vpa.fullname" . }}-recommender-pdb"
+  namespace: {{ .Release.Namespace }}
 spec:
   {{- toYaml .Values.recommender.podDisruptionBudget | nindent 2 }}
   selector:

--- a/stable/vpa/templates/recommender-podmonitor.yaml
+++ b/stable/vpa/templates/recommender-podmonitor.yaml
@@ -4,6 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: {{ include "vpa.fullname" . }}-recommender
+  namespace: {{ .Release.Namespace }}
   {{- with .Values.recommender.podMonitor.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/stable/vpa/templates/recommender-service-account.yaml
+++ b/stable/vpa/templates/recommender-service-account.yaml
@@ -4,6 +4,7 @@ kind: ServiceAccount
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 metadata:
   name: {{ include "vpa.serviceAccountName" . }}-recommender
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "vpa.labels" . | nindent 4 }}
     app.kubernetes.io/component: recommender

--- a/stable/vpa/templates/updater-deployment.yaml
+++ b/stable/vpa/templates/updater-deployment.yaml
@@ -7,6 +7,7 @@ metadata:
   {{- .Values.updater.annotations | toYaml | nindent 4 }}
   {{- end }}
   name: {{ include "vpa.fullname" . }}-updater
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: updater
     {{- include "vpa.labels" . | nindent 4 }}

--- a/stable/vpa/templates/updater-pdb.yaml
+++ b/stable/vpa/templates/updater-pdb.yaml
@@ -4,6 +4,7 @@ apiVersion: {{ ternary "policy/v1" "policy/v1beta1" (semverCompare ">=1.21.0-0" 
 kind: PodDisruptionBudget
 metadata:
   name: "{{ template "vpa.fullname" . }}-updater-pdb"
+  namespace: {{ .Release.Namespace }}
 spec:
   {{- toYaml .Values.updater.podDisruptionBudget | nindent 2 }}
   selector:

--- a/stable/vpa/templates/updater-podmonitor.yaml
+++ b/stable/vpa/templates/updater-podmonitor.yaml
@@ -4,6 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: {{ include "vpa.fullname" . }}-updater
+  namespace: {{ .Release.Namespace }}
   {{- with .Values.updater.podMonitor.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/stable/vpa/templates/updater-service-account.yaml
+++ b/stable/vpa/templates/updater-service-account.yaml
@@ -4,6 +4,7 @@ kind: ServiceAccount
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 metadata:
   name: {{ include "vpa.serviceAccountName" . }}-updater
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "vpa.labels" . | nindent 4 }}
     app.kubernetes.io/component: updater


### PR DESCRIPTION
**Why This PR?**
I was trying to deploy the VPA with terraform using helm_release, but because there was no namespace in the template, the deployment was always being performed in the default namespace, it was not respecting the namespace that I was informing in the code.

Fixes #

**Changes**
Changes proposed in this pull request:

* Added namespace property to vpa template
*

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
