### PR TITLE
[stable/insights-agent] bump Prometheus chart to the latest (Prometheus Server v3.2.1)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,25 +132,37 @@ workflows:
       - lint-charts
       - rok8s/kubernetes_e2e_tests:
           name: "End-To-End Kubernetes 1.27"
-          kind_node_image: "kindest/node:v1.27.13@sha256:17439fa5b32290e3ead39ead1250dca1d822d94a10d26f1981756cd51b24b9d8"
+          kind_node_image: "kindest/node:v1.27.16@sha256:2d21a61643eafc439905e18705b8186f3296384750a835ad7a005dceb9546d20"
           executor:
             name: ci-images-large
           <<: *kind_configuration_helm3
       - rok8s/kubernetes_e2e_tests:
           name: "End-To-End Kubernetes 1.28"
-          kind_node_image: "kindest/node:v1.28.9@sha256:dca54bc6a6079dd34699d53d7d4ffa2e853e46a20cd12d619a09207e35300bd0"
+          kind_node_image: "kindest/node:v1.28.15@sha256:a7c05c7ae043a0b8c818f5a06188bc2c4098f6cb59ca7d1856df00375d839251"
           executor:
             name: ci-images-large
           <<: *kind_configuration_helm3
       - rok8s/kubernetes_e2e_tests:
           name: "End-To-End Kubernetes 1.29"
-          kind_node_image: "kindest/node:v1.29.4@sha256:3abb816a5b1061fb15c6e9e60856ec40d56b7b52bcea5f5f1350bc6e2320b6f8"
+          kind_node_image: "kindest/node:v1.29.14@sha256:8703bd94ee24e51b778d5556ae310c6c0fa67d761fae6379c8e0bb480e6fea29"
           executor:
             name: ci-images-large
           <<: *kind_configuration_helm3
       - rok8s/kubernetes_e2e_tests:
           name: "End-To-End Kubernetes 1.30"
-          kind_node_image: "kindest/node:v1.30.2@sha256:ecfe5841b9bee4fe9690f49c118c33629fa345e3350a0c67a5a34482a99d6bba"
+          kind_node_image: "kindest/node:v1.30.10@sha256:4de75d0e82481ea846c0ed1de86328d821c1e6a6a91ac37bf804e5313670e507"
+          executor:
+            name: ci-images-large
+          <<: *kind_configuration_helm3
+      - rok8s/kubernetes_e2e_tests:
+          name: "End-To-End Kubernetes 1.31"
+          kind_node_image: "kindest/node:v1.31.6@sha256:28b7cbb993dfe093c76641a0c95807637213c9109b761f1d422c2400e22b8e87"
+          executor:
+            name: ci-images-large
+          <<: *kind_configuration_helm3
+      - rok8s/kubernetes_e2e_tests:
+          name: "End-To-End Kubernetes 1.32"
+          kind_node_image: "kindest/node:v1.32.3@sha256:b36e76b4ad37b88539ce5e07425f77b29f73a8eaaebf3f1a8bc9c764401d118c"
           executor:
             name: ci-images-large
           <<: *kind_configuration_helm3

--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 4.6.0
 * Update Prometheus Server Chart to 27.7.1 (Prom Server v3.2.1)
+* Add E2E tests for k8s versions 1.31 and 1.32
 
 ## 4.5.1
 * Added SKIP_KSM_NON_ZERO_METRICS_CHECK

--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 4.6.0
+* Update chart to use Prometheus Server v3
+
 ## 4.5.1
 * Added SKIP_KSM_NON_ZERO_METRICS_CHECK
 

--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 4.6.0
-* Update chart to use Prometheus Server v3
+* Update Prometheus Server Chart to 27.7.1 (Prom Server v3.2.1)
 
 ## 4.5.1
 * Added SKIP_KSM_NON_ZERO_METRICS_CHECK

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 4.5.1
+version: 4.5.2
 appVersion: 9.2.1
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 4.5.2
+version: 4.6.0
 appVersion: 9.2.1
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png

--- a/stable/insights-agent/requirements.yaml
+++ b/stable/insights-agent/requirements.yaml
@@ -5,7 +5,7 @@ dependencies:
   condition: goldilocks.enabled
 - name: prometheus
   repository: https://prometheus-community.github.io/helm-charts
-  version: '25.30.1'
+  version: '26.1.0'
   condition: prometheus-metrics.installPrometheusServer
 - name: insights-admission
   repository: https://charts.fairwinds.com/stable

--- a/stable/insights-agent/requirements.yaml
+++ b/stable/insights-agent/requirements.yaml
@@ -5,7 +5,7 @@ dependencies:
   condition: goldilocks.enabled
 - name: prometheus
   repository: https://prometheus-community.github.io/helm-charts
-  version: '26.1.0'
+  version: '27.7.1'
   condition: prometheus-metrics.installPrometheusServer
 - name: insights-admission
   repository: https://charts.fairwinds.com/stable


### PR DESCRIPTION
**Why This PR?**
Bump Prometheus chart to the latest (Prometheus Server v3.2.1)

Fixes #

**Changes**
Changes proposed in this pull request:

* Bump Prometheus chart to the latest
* Update E2E tests
* Add E2E tests for k8s 1.31 and 1.32

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
