### PR TITLE
[stable/fairwinds-insights] feat: add topologySpreadConstraints field and defaults

### DIFF
--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.10.0
+* Adds node and zone topologySpreadConstrants and sets defaults on all deployments
+
 ## 2.9.1
 * Updated default cronjob for cluster deletion
 

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "16.4"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 2.9.1
+version: 2.10.0
 kubeVersion: ">= 1.22.0-0"
 maintainers:
   - name: rbren

--- a/stable/fairwinds-insights/README.md
+++ b/stable/fairwinds-insights/README.md
@@ -72,6 +72,16 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | dashboard.resources | object | `{"limits":{"cpu":"1000m","memory":"1024Mi"},"requests":{"cpu":"250m","memory":"256Mi"}}` | Resources for the front end pods. |
 | dashboard.nodeSelector | object | `{}` | Node Selector for the front end pods. |
 | dashboard.tolerations | list | `[]` | Tolerations for the front end pods. |
+| dashboard.topologySpreadConstraints[0].maxSkew | int | `1` |  |
+| dashboard.topologySpreadConstraints[0].topologyKey | string | `"topology.kubernetes.io/zone"` |  |
+| dashboard.topologySpreadConstraints[0].whenUnsatisfiable | string | `"ScheduleAnyway"` |  |
+| dashboard.topologySpreadConstraints[0].labelSelector.matchLabels."app.kubernetes.io/component" | string | `"dashboard"` |  |
+| dashboard.topologySpreadConstraints[0].labelSelector.matchLabels."app.kubernetes.io/name" | string | `"fairwinds-insights"` |  |
+| dashboard.topologySpreadConstraints[1].maxSkew | int | `1` |  |
+| dashboard.topologySpreadConstraints[1].topologyKey | string | `"kubernetes.io/hostname"` |  |
+| dashboard.topologySpreadConstraints[1].whenUnsatisfiable | string | `"ScheduleAnyway"` |  |
+| dashboard.topologySpreadConstraints[1].labelSelector.matchLabels."app.kubernetes.io/component" | string | `"dashboard"` |  |
+| dashboard.topologySpreadConstraints[1].labelSelector.matchLabels."app.kubernetes.io/name" | string | `"fairwinds-insights"` |  |
 | dashboard.securityContext.runAsUser | int | `101` | The user ID to run the Dashboard under. comes from https://github.com/nginxinc/docker-nginx-unprivileged/blob/main/stable/alpine/Dockerfile |
 | api.port | int | `8080` | Port for the API server to listen on. |
 | api.pdb.enabled | bool | `false` | Create a pod disruption budget for the API server. |
@@ -83,6 +93,16 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | api.resources | object | `{"limits":{"cpu":"1000m","memory":"1024Mi"},"requests":{"cpu":"250m","memory":"256Mi"}}` | Resources for the API server. |
 | api.nodeSelector | object | `{}` | Node Selector for the API server. |
 | api.tolerations | list | `[]` | Tolerations for the API server. |
+| api.topologySpreadConstraints[0].maxSkew | int | `1` |  |
+| api.topologySpreadConstraints[0].topologyKey | string | `"topology.kubernetes.io/zone"` |  |
+| api.topologySpreadConstraints[0].whenUnsatisfiable | string | `"ScheduleAnyway"` |  |
+| api.topologySpreadConstraints[0].labelSelector.matchLabels."app.kubernetes.io/component" | string | `"api"` |  |
+| api.topologySpreadConstraints[0].labelSelector.matchLabels."app.kubernetes.io/name" | string | `"fairwinds-insights"` |  |
+| api.topologySpreadConstraints[1].maxSkew | int | `1` |  |
+| api.topologySpreadConstraints[1].topologyKey | string | `"kubernetes.io/hostname"` |  |
+| api.topologySpreadConstraints[1].whenUnsatisfiable | string | `"ScheduleAnyway"` |  |
+| api.topologySpreadConstraints[1].labelSelector.matchLabels."app.kubernetes.io/component" | string | `"api"` |  |
+| api.topologySpreadConstraints[1].labelSelector.matchLabels."app.kubernetes.io/name" | string | `"fairwinds-insights"` |  |
 | api.securityContext.runAsUser | int | `10324` | The user ID to run the API server under. |
 | api.ingress.enabled | bool | `true` | Enable the Open API ingress |
 | api.service.type | string | `nil` | Service type for Open API server |
@@ -96,6 +116,16 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | openApi.resources | object | `{"limits":{"cpu":"256m","memory":"256Mi"},"requests":{"cpu":"100m","memory":"100Mi"}}` | Resources for the Open API server. |
 | openApi.nodeSelector | object | `{}` | Node Selector for the Open API server. |
 | openApi.tolerations | list | `[]` | Tolerations for the Open API server. |
+| openApi.topologySpreadConstraints[0].maxSkew | int | `1` |  |
+| openApi.topologySpreadConstraints[0].topologyKey | string | `"topology.kubernetes.io/zone"` |  |
+| openApi.topologySpreadConstraints[0].whenUnsatisfiable | string | `"ScheduleAnyway"` |  |
+| openApi.topologySpreadConstraints[0].labelSelector.matchLabels."app.kubernetes.io/component" | string | `"open-api"` |  |
+| openApi.topologySpreadConstraints[0].labelSelector.matchLabels."app.kubernetes.io/name" | string | `"fairwinds-insights"` |  |
+| openApi.topologySpreadConstraints[1].maxSkew | int | `1` |  |
+| openApi.topologySpreadConstraints[1].topologyKey | string | `"kubernetes.io/hostname"` |  |
+| openApi.topologySpreadConstraints[1].whenUnsatisfiable | string | `"ScheduleAnyway"` |  |
+| openApi.topologySpreadConstraints[1].labelSelector.matchLabels."app.kubernetes.io/component" | string | `"open-api"` |  |
+| openApi.topologySpreadConstraints[1].labelSelector.matchLabels."app.kubernetes.io/name" | string | `"fairwinds-insights"` |  |
 | openApi.ingress.enabled | bool | `true` | Enable the Open API ingress |
 | openApi.service.type | string | `nil` | Service type for Open API server |
 | dbMigration.resources | object | `{"limits":{"cpu":1,"memory":"1024Mi"},"requests":{"cpu":"80m","memory":"128Mi"}}` | Resources for the database migration job. |
@@ -195,6 +225,16 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | reportjob.resources.requests.memory | string | `"128Mi"` |  |
 | reportjob.nodeSelector | object | `{}` |  |
 | reportjob.tolerations | list | `[]` |  |
+| reportjob.topologySpreadConstraints[0].maxSkew | int | `1` |  |
+| reportjob.topologySpreadConstraints[0].topologyKey | string | `"topology.kubernetes.io/zone"` |  |
+| reportjob.topologySpreadConstraints[0].whenUnsatisfiable | string | `"ScheduleAnyway"` |  |
+| reportjob.topologySpreadConstraints[0].labelSelector.matchLabels."app.kubernetes.io/component" | string | `"api"` |  |
+| reportjob.topologySpreadConstraints[0].labelSelector.matchLabels."app.kubernetes.io/name" | string | `"fairwinds-insights"` |  |
+| reportjob.topologySpreadConstraints[1].maxSkew | int | `1` |  |
+| reportjob.topologySpreadConstraints[1].topologyKey | string | `"kubernetes.io/hostname"` |  |
+| reportjob.topologySpreadConstraints[1].whenUnsatisfiable | string | `"ScheduleAnyway"` |  |
+| reportjob.topologySpreadConstraints[1].labelSelector.matchLabels."app.kubernetes.io/component" | string | `"api"` |  |
+| reportjob.topologySpreadConstraints[1].labelSelector.matchLabels."app.kubernetes.io/name" | string | `"fairwinds-insights"` |  |
 | reportjob.terminationGracePeriodSeconds | int | `600` |  |
 | automatedPullRequestJob.enabled | bool | `true` |  |
 | automatedPullRequestJob.hpa.enabled | bool | `true` |  |
@@ -214,6 +254,16 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | automatedPullRequestJob.resources.requests.memory | string | `"128Mi"` |  |
 | automatedPullRequestJob.nodeSelector | object | `{}` |  |
 | automatedPullRequestJob.tolerations | list | `[]` |  |
+| automatedPullRequestJob.topologySpreadConstraints[0].maxSkew | int | `1` |  |
+| automatedPullRequestJob.topologySpreadConstraints[0].topologyKey | string | `"topology.kubernetes.io/zone"` |  |
+| automatedPullRequestJob.topologySpreadConstraints[0].whenUnsatisfiable | string | `"ScheduleAnyway"` |  |
+| automatedPullRequestJob.topologySpreadConstraints[0].labelSelector.matchLabels."app.kubernetes.io/component" | string | `"automated-pr-job"` |  |
+| automatedPullRequestJob.topologySpreadConstraints[0].labelSelector.matchLabels."app.kubernetes.io/name" | string | `"fairwinds-insights"` |  |
+| automatedPullRequestJob.topologySpreadConstraints[1].maxSkew | int | `1` |  |
+| automatedPullRequestJob.topologySpreadConstraints[1].topologyKey | string | `"kubernetes.io/hostname"` |  |
+| automatedPullRequestJob.topologySpreadConstraints[1].whenUnsatisfiable | string | `"ScheduleAnyway"` |  |
+| automatedPullRequestJob.topologySpreadConstraints[1].labelSelector.matchLabels."app.kubernetes.io/component" | string | `"automated-pr-job"` |  |
+| automatedPullRequestJob.topologySpreadConstraints[1].labelSelector.matchLabels."app.kubernetes.io/name" | string | `"fairwinds-insights"` |  |
 | repoScanJob.enabled | bool | `false` |  |
 | repoScanJob.insightsCIVersion | string | `"5.8"` |  |
 | repoScanJob.hpa.enabled | bool | `true` |  |
@@ -233,3 +283,13 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | repoScanJob.resources.requests.memory | string | `"128Mi"` |  |
 | repoScanJob.nodeSelector | object | `{}` |  |
 | repoScanJob.tolerations | list | `[]` |  |
+| repoScanJob.topologySpreadConstraints[0].maxSkew | int | `1` |  |
+| repoScanJob.topologySpreadConstraints[0].topologyKey | string | `"topology.kubernetes.io/zone"` |  |
+| repoScanJob.topologySpreadConstraints[0].whenUnsatisfiable | string | `"ScheduleAnyway"` |  |
+| repoScanJob.topologySpreadConstraints[0].labelSelector.matchLabels."app.kubernetes.io/component" | string | `"repo-scan-job"` |  |
+| repoScanJob.topologySpreadConstraints[0].labelSelector.matchLabels."app.kubernetes.io/name" | string | `"fairwinds-insights"` |  |
+| repoScanJob.topologySpreadConstraints[1].maxSkew | int | `1` |  |
+| repoScanJob.topologySpreadConstraints[1].topologyKey | string | `"kubernetes.io/hostname"` |  |
+| repoScanJob.topologySpreadConstraints[1].whenUnsatisfiable | string | `"ScheduleAnyway"` |  |
+| repoScanJob.topologySpreadConstraints[1].labelSelector.matchLabels."app.kubernetes.io/component" | string | `"repo-scan-job"` |  |
+| repoScanJob.topologySpreadConstraints[1].labelSelector.matchLabels."app.kubernetes.io/name" | string | `"fairwinds-insights"` |  |

--- a/stable/fairwinds-insights/README.md
+++ b/stable/fairwinds-insights/README.md
@@ -228,12 +228,12 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | reportjob.topologySpreadConstraints[0].maxSkew | int | `1` |  |
 | reportjob.topologySpreadConstraints[0].topologyKey | string | `"topology.kubernetes.io/zone"` |  |
 | reportjob.topologySpreadConstraints[0].whenUnsatisfiable | string | `"ScheduleAnyway"` |  |
-| reportjob.topologySpreadConstraints[0].labelSelector.matchLabels."app.kubernetes.io/component" | string | `"api"` |  |
+| reportjob.topologySpreadConstraints[0].labelSelector.matchLabels."app.kubernetes.io/component" | string | `"reportjob"` |  |
 | reportjob.topologySpreadConstraints[0].labelSelector.matchLabels."app.kubernetes.io/name" | string | `"fairwinds-insights"` |  |
 | reportjob.topologySpreadConstraints[1].maxSkew | int | `1` |  |
 | reportjob.topologySpreadConstraints[1].topologyKey | string | `"kubernetes.io/hostname"` |  |
 | reportjob.topologySpreadConstraints[1].whenUnsatisfiable | string | `"ScheduleAnyway"` |  |
-| reportjob.topologySpreadConstraints[1].labelSelector.matchLabels."app.kubernetes.io/component" | string | `"api"` |  |
+| reportjob.topologySpreadConstraints[1].labelSelector.matchLabels."app.kubernetes.io/component" | string | `"reportjob"` |  |
 | reportjob.topologySpreadConstraints[1].labelSelector.matchLabels."app.kubernetes.io/name" | string | `"fairwinds-insights"` |  |
 | reportjob.terminationGracePeriodSeconds | int | `600` |  |
 | automatedPullRequestJob.enabled | bool | `true` |  |

--- a/stable/fairwinds-insights/templates/deployment-api.yaml
+++ b/stable/fairwinds-insights/templates/deployment-api.yaml
@@ -93,3 +93,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- with .Values.api.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/stable/fairwinds-insights/templates/deployment-automated-pr-job.yaml
+++ b/stable/fairwinds-insights/templates/deployment-automated-pr-job.yaml
@@ -64,4 +64,8 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- with .Values.automatedPullRequestJob.topologySpreadConstraints }}
+      topologySpreadConstraints:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
 {{- end }}

--- a/stable/fairwinds-insights/templates/deployment-dashboard.yaml
+++ b/stable/fairwinds-insights/templates/deployment-dashboard.yaml
@@ -79,3 +79,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- with .Values.dashboard.topologySpreadConstraints }}
+      topologySpreadConstraints:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/stable/fairwinds-insights/templates/deployment-open-api.yaml
+++ b/stable/fairwinds-insights/templates/deployment-open-api.yaml
@@ -75,3 +75,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- with .Values.api.topologySpreadConstraints }}
+      topologySpreadConstraints:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/stable/fairwinds-insights/templates/deployment-open-api.yaml
+++ b/stable/fairwinds-insights/templates/deployment-open-api.yaml
@@ -71,11 +71,11 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-    {{- with .Values.api.tolerations }}
+    {{- with .Values.openApi.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- with .Values.api.topologySpreadConstraints }}
+    {{- with .Values.openApi.topologySpreadConstraints }}
       topologySpreadConstraints:
       {{- toYaml . | nindent 8 }}
     {{- end }}

--- a/stable/fairwinds-insights/templates/deployment-repo-scan-job.yaml
+++ b/stable/fairwinds-insights/templates/deployment-repo-scan-job.yaml
@@ -69,4 +69,8 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- with .Values.repoScanJob.topologySpreadConstraints }}
+      topologySpreadConstraints:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
 {{- end }}

--- a/stable/fairwinds-insights/templates/deployment-report-job.yaml
+++ b/stable/fairwinds-insights/templates/deployment-report-job.yaml
@@ -66,4 +66,8 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- with .Values.repoJob.topologySpreadConstraints }}
+      topologySpreadConstraints:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
 {{- end }}

--- a/stable/fairwinds-insights/templates/deployment-report-job.yaml
+++ b/stable/fairwinds-insights/templates/deployment-report-job.yaml
@@ -66,7 +66,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- with .Values.reportJob.topologySpreadConstraints }}
+    {{- with .Values.reportjob.topologySpreadConstraints }}
       topologySpreadConstraints:
       {{- toYaml . | nindent 8 }}
     {{- end }}

--- a/stable/fairwinds-insights/templates/deployment-report-job.yaml
+++ b/stable/fairwinds-insights/templates/deployment-report-job.yaml
@@ -66,7 +66,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- with .Values.repoJob.topologySpreadConstraints }}
+    {{- with .Values.reportJob.topologySpreadConstraints }}
       topologySpreadConstraints:
       {{- toYaml . | nindent 8 }}
     {{- end }}

--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -272,6 +272,22 @@ dashboard:
   nodeSelector: {}
   # -- Tolerations for the front end pods.
   tolerations: []
+  # topologySpreadConstraints -- Default TopologySpreadConstraints for the front end pods.
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/component: dashboard
+          app.kubernetes.io/name: fairwinds-insights
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/component: dashboard
+          app.kubernetes.io/name: fairwinds-insights
   securityContext:
     # -- The user ID to run the Dashboard under. comes from https://github.com/nginxinc/docker-nginx-unprivileged/blob/main/stable/alpine/Dockerfile
     runAsUser: 101
@@ -317,6 +333,22 @@ api:
   nodeSelector: {}
   # -- Tolerations for the API server.
   tolerations: []
+  # topologySpreadConstraints -- Default TopologySpreadConstraints for the API server.
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/component: api
+          app.kubernetes.io/name: fairwinds-insights
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/component: api
+          app.kubernetes.io/name: fairwinds-insights
   securityContext:
     # -- The user ID to run the API server under.
     runAsUser: 10324
@@ -368,6 +400,22 @@ openApi:
   nodeSelector: {}
   # -- Tolerations for the Open API server.
   tolerations: []
+  # topologySpreadConstraints -- Default TopologySpreadConstraints for the Open API Server.
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/component: open-api
+          app.kubernetes.io/name: fairwinds-insights
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/component: open-api
+          app.kubernetes.io/name: fairwinds-insights
   ingress:
     # -- Enable the Open API ingress
     enabled: true
@@ -616,6 +664,22 @@ reportjob:
       memory: 128Mi
   nodeSelector: {}
   tolerations: []
+  # topologySpreadConstraints -- Default TopologySpreadConstraints for the reportJob Deployment.
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/component: api
+          app.kubernetes.io/name: fairwinds-insights
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/component: api
+          app.kubernetes.io/name: fairwinds-insights
   terminationGracePeriodSeconds: 600
 
 automatedPullRequestJob:
@@ -646,6 +710,22 @@ automatedPullRequestJob:
       memory: 128Mi
   nodeSelector: {}
   tolerations: []
+  # topologySpreadConstraints -- Default TopologySpreadConstraints for the autoamtedPullRequestJob Deployment.
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/component: automated-pr-job
+          app.kubernetes.io/name: fairwinds-insights
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/component: automated-pr-job
+          app.kubernetes.io/name: fairwinds-insights
 
 repoScanJob:
   enabled: false
@@ -676,3 +756,19 @@ repoScanJob:
       memory: 128Mi
   nodeSelector: {}
   tolerations: []
+  # topologySpreadConstraints -- Default TopologySpreadConstraints for the repoScanJob.
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/component: repo-scan-job
+          app.kubernetes.io/name: fairwinds-insights
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/component: repo-scan-job
+          app.kubernetes.io/name: fairwinds-insights

--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -671,14 +671,14 @@ reportjob:
       whenUnsatisfiable: ScheduleAnyway
       labelSelector:
         matchLabels:
-          app.kubernetes.io/component: api
+          app.kubernetes.io/component: reportjob
           app.kubernetes.io/name: fairwinds-insights
     - maxSkew: 1
       topologyKey: kubernetes.io/hostname
       whenUnsatisfiable: ScheduleAnyway
       labelSelector:
         matchLabels:
-          app.kubernetes.io/component: api
+          app.kubernetes.io/component: reportjob
           app.kubernetes.io/name: fairwinds-insights
   terminationGracePeriodSeconds: 600
 


### PR DESCRIPTION
**Why This PR?**
Apply default topologySpreadConstraints and allow overwriting

Fixes #

**Changes**
Changes proposed in this pull request:

*Adds field in values.yaml to specify topolgySpreadConstraints
*Sets defaults

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
