### PR TITLE
[stable/insights-admission] INS-941 Add polaris config to insights-admission

### DIFF
--- a/stable/insights-admission/CHANGELOG.md
+++ b/stable/insights-admission/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 1.10.1
-* Bump insights-admission to version 1.19
+* Add support to polaris config
 
 ## 1.10.0
 * Bump insights-admission to version 1.18

--- a/stable/insights-admission/CHANGELOG.md
+++ b/stable/insights-admission/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.10.1
+* Bump insights-admission to version 1.19
+
 ## 1.10.0
 * Bump insights-admission to version 1.18
 

--- a/stable/insights-admission/Chart.yaml
+++ b/stable/insights-admission/Chart.yaml
@@ -3,7 +3,7 @@ name: insights-admission
 description: A Validating Webhook Admission Controller that utilizes Fairwinds Insights.
 type: application
 version: 1.10.1
-appVersion: "1.19"
+appVersion: "1.18"
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-admission/icon.png
 maintainers:

--- a/stable/insights-admission/Chart.yaml
+++ b/stable/insights-admission/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: insights-admission
 description: A Validating Webhook Admission Controller that utilizes Fairwinds Insights.
 type: application
-version: 1.10.0
-appVersion: "1.18"
+version: 1.10.1
+appVersion: "1.19"
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-admission/icon.png
 maintainers:

--- a/stable/insights-admission/README.md
+++ b/stable/insights-admission/README.md
@@ -100,4 +100,5 @@ rules:
 | secretName | string | `""` | If you are providing your own certificate then this is the name of the secret holding the certificate. |
 | clusterDomain | string | `"cluster.local"` | The base domain to use for cluster DNS |
 | certManagerApiVersion | string | `""` | If secretName is empty, we assume that you use cert-manager to provision the admission controller certificates. This allows pinning the apiVersion rather than using helm capabilities detection. Useful for gitops tools such as ArgoCD |
+| polaris.config | string | `nil` | Configuration for Polaris |
 | test | object | `{"enabled":false,"image":{"repository":"python","tag":"3.10-alpine"}}` | Used for chart CI only - deploys a test deployment |

--- a/stable/insights-admission/ci/test-values.yaml
+++ b/stable/insights-admission/ci/test-values.yaml
@@ -21,3 +21,14 @@ serviceAccount:
 webhookConfig:
   annotations:
     "test-annotation": "test-annotation-value"
+polaris:
+  config:
+    customChecks:
+      checks:
+        - name: test-check
+          enabled: true
+          severity: high
+          description: "This is a test check"
+          remediation: "This is a test remediation"
+          category: "Test"
+          type: "Test"

--- a/stable/insights-admission/ci/test-values.yaml
+++ b/stable/insights-admission/ci/test-values.yaml
@@ -21,14 +21,3 @@ serviceAccount:
 webhookConfig:
   annotations:
     "test-annotation": "test-annotation-value"
-polaris:
-  config:
-    customChecks:
-      checks:
-        - name: test-check
-          enabled: true
-          severity: high
-          description: "This is a test check"
-          remediation: "This is a test remediation"
-          category: "Test"
-          type: "Test"

--- a/stable/insights-admission/ci/test-values.yaml
+++ b/stable/insights-admission/ci/test-values.yaml
@@ -32,4 +32,3 @@ polaris:
           remediation: "This is a test remediation"
           category: "Test"
           type: "Test"
-  

--- a/stable/insights-admission/ci/test-values.yaml
+++ b/stable/insights-admission/ci/test-values.yaml
@@ -32,3 +32,4 @@ polaris:
           remediation: "This is a test remediation"
           category: "Test"
           type: "Test"
+  

--- a/stable/insights-admission/templates/configmap.polaris.yaml
+++ b/stable/insights-admission/templates/configmap.polaris.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.polaris.config" }}
+{{- if .Values.polaris.config }}
 {{- with .Values.polaris.config }}
 apiVersion: v1
 kind: ConfigMap

--- a/stable/insights-admission/templates/configmap.polaris.yaml
+++ b/stable/insights-admission/templates/configmap.polaris.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.polaris }}
 {{- if .Values.polaris.config }}
 {{- with .Values.polaris.config }}
 apiVersion: v1
@@ -9,5 +10,6 @@ metadata:
 data:
   config.yaml: |
     {{- toYaml . | nindent 4 }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/stable/insights-admission/templates/configmap.polaris.yaml
+++ b/stable/insights-admission/templates/configmap.polaris.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.polaris.config" }}
 {{- with .Values.polaris.config }}
 apiVersion: v1
 kind: ConfigMap
@@ -8,4 +9,5 @@ metadata:
 data:
   config.yaml: |
     {{- toYaml . | nindent 4 }}
+{{- end }}
 {{- end }}

--- a/stable/insights-admission/templates/configmap.polaris.yaml
+++ b/stable/insights-admission/templates/configmap.polaris.yaml
@@ -1,0 +1,11 @@
+{{- with .Values.polaris.config }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: admission-polaris
+  labels:
+    app: insights-agent
+data:
+  config.yaml: |
+    {{- toYaml . | nindent 4 }}
+{{- end }}

--- a/stable/insights-admission/templates/deployment.yaml
+++ b/stable/insights-admission/templates/deployment.yaml
@@ -61,6 +61,12 @@ spec:
           - name: secret
             mountPath: /opt/cert/
             readOnly: true
+          {{- if .Values.polaris.config }}
+          - name: polaris-config
+            mountPath: /opt/app/polaris-config.yaml
+            subPath: polaris-config.yaml
+            readOnly: true
+          {{- end }}
 {{ include "ssl-cert-file-volumemount-spec" . | indent 10 }}
           env:
           # This is always specified as pluto is enabled in Insights settings.
@@ -123,3 +129,9 @@ spec:
           secretName: {{ include "insights-admission.fullname" . }}
 {{ include "ssl-cert-file-volume-spec" . | indent 6 }}
           {{- end }}
+      {{- if .Values.polaris.config }}
+      - name: polaris-config
+        configMap:
+          name: admission-polaris
+      {{- end }}
+

--- a/stable/insights-admission/templates/deployment.yaml
+++ b/stable/insights-admission/templates/deployment.yaml
@@ -64,7 +64,7 @@ spec:
           {{- if .Values.polaris.config }}
           - name: polaris-config
             mountPath: /opt/app/polaris-config.yaml
-            subPath: polaris-config.yaml
+            subPath: config.yaml
             readOnly: true
           {{- end }}
 {{ include "ssl-cert-file-volumemount-spec" . | indent 10 }}

--- a/stable/insights-admission/templates/deployment.yaml
+++ b/stable/insights-admission/templates/deployment.yaml
@@ -61,11 +61,13 @@ spec:
           - name: secret
             mountPath: /opt/cert/
             readOnly: true
+          {{- if .Values.polaris }}  
           {{- if .Values.polaris.config }}
           - name: polaris-config
             mountPath: /opt/app/polaris-config.yaml
             subPath: config.yaml
             readOnly: true
+          {{- end }}
           {{- end }}
 {{ include "ssl-cert-file-volumemount-spec" . | indent 10 }}
           env:
@@ -129,9 +131,12 @@ spec:
           secretName: {{ include "insights-admission.fullname" . }}
 {{ include "ssl-cert-file-volume-spec" . | indent 6 }}
           {{- end }}
+      {{- if .Values.polaris }}    
       {{- if .Values.polaris.config }}
       - name: polaris-config
         configMap:
           name: admission-polaris
       {{- end }}
+      {{- end }}
+
 

--- a/stable/insights-admission/values.yaml
+++ b/stable/insights-admission/values.yaml
@@ -236,6 +236,10 @@ clusterDomain: cluster.local
 # certManagerApiVersion -- If secretName is empty, we assume that you use cert-manager to provision the admission controller certificates. This allows pinning the apiVersion rather than using helm capabilities detection. Useful for gitops tools such as ArgoCD
 certManagerApiVersion: ""
 
+polaris:
+  # -- Configuration for Polaris
+  config:
+
 # test -- Used for chart CI only - deploys a test deployment
 test:
   enabled: false


### PR DESCRIPTION
**Why This PR?**
Enable Polaris admission configuration.


**Changes**
Changes proposed in this pull request:

* Add additional values
* Add polaris configmap for admission

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
