### PR TITLE
[stable/insights-agent] Include APIVersion field for pvc in Falco sts

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 4.6.3
+* Defines apiVersion and Kind fields for falco sts volumeclaimtemplate
 
 ## 4.6.2
 * Bumped version for insights-admission upgrade

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 4.6.2
+version: 4.6.3
 appVersion: 9.2.1
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png

--- a/stable/insights-agent/templates/falco/deployment.yaml
+++ b/stable/insights-agent/templates/falco/deployment.yaml
@@ -18,7 +18,9 @@ spec:
 {{- end }}
 {{- if and .Values.falco.statefulset .Values.falco.persistence.enabled }}
   volumeClaimTemplates:
-  - metadata:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim 
+    metadata:
         name: output-data
       {{- with .Values.falco.persistence.annotations }}
         annotations:


### PR DESCRIPTION
**Why This PR?**
Falco statefulset is preventing syncing via gitops tooling as cluster is appending the volumeclaimtemplate field with apiVersion and kind.

**Changes**
Changes proposed in this pull request:

* Hardcoded apiversion and kind to allow gitops tools to sync falco statefulset in cluster

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
