### PR TITLE
[stable/goldilocks] fix: wrong `topologySpreadConstraints` helm value being used for dashboard

### DIFF
--- a/stable/goldilocks/Chart.yaml
+++ b/stable/goldilocks/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 appVersion: "v4.13.0"
-version: 9.0.1
+version: 9.0.2
 kubeVersion: ">= 1.22.0-0"
 description: |
   A Helm chart for running Fairwinds Goldilocks. See https://github.com/FairwindsOps/goldilocks

--- a/stable/goldilocks/ci/pre-test-script.sh
+++ b/stable/goldilocks/ci/pre-test-script.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+# This will label the first ndoe that is returned by kubectl get nodes so that we can test
+# the topologySpreadConstraints with `topologyKey: topology.kubernetes.io/zone`
+kubectl label $(kubectl get nodes -o name | head -n 1) topology.kubernetes.io/zone=test-zone-a

--- a/stable/goldilocks/ci/pre-test-script.sh
+++ b/stable/goldilocks/ci/pre-test-script.sh
@@ -2,4 +2,5 @@
 
 # This will label the first ndoe that is returned by kubectl get nodes so that we can test
 # the topologySpreadConstraints with `topologyKey: topology.kubernetes.io/zone`
-kubectl label $(kubectl get nodes -o name | head -n 1) topology.kubernetes.io/zone=test-zone-a
+FIRST_NODE="$(kubectl get nodes -o name | head -n 1)"
+kubectl label "$FIRST_NODE" topology.kubernetes.io/zone=test-zone-a

--- a/stable/goldilocks/ci/pre-test-script.sh
+++ b/stable/goldilocks/ci/pre-test-script.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# This will label the first ndoe that is returned by kubectl get nodes so that we can test
-# the topologySpreadConstraints with `topologyKey: topology.kubernetes.io/zone`
+# This will label the first node that is returned by kubectl get nodes so that we can test
+# the `topologySpreadConstraints` with `topologyKey: topology.kubernetes.io/zone`
 FIRST_NODE="$(kubectl get nodes -o name | head -n 1)"
 kubectl label "$FIRST_NODE" topology.kubernetes.io/zone=test-zone-a

--- a/stable/goldilocks/templates/dashboard-deployment.yaml
+++ b/stable/goldilocks/templates/dashboard-deployment.yaml
@@ -100,7 +100,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- with .Values.controller.topologySpreadConstraints }}
+    {{- with .Values.dashboard.topologySpreadConstraints }}
       topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
     {{- end }}


### PR DESCRIPTION
**Why This PR?**

Simple fix for the wrong `controller.topologySpreadConstraints` value being used instead of `dashboard.topologySpreadConstraints`.

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
