### PR TITLE
[stable/vpa] fix: Add patch and update verbs to events resource

### DIFF
--- a/stable/vpa/CHANGELOG.md
+++ b/stable/vpa/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 4.7.3
+
+### Added
+
+- `vpa-actor` ClusterRole now supports `patch` and `update` on `events`

--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 4.7.2
+version: 4.7.3
 appVersion: 1.0.0
 maintainers:
   - name: sudermanjr

--- a/stable/vpa/templates/clusterroles.yaml
+++ b/stable/vpa/templates/clusterroles.yaml
@@ -40,6 +40,8 @@ rules:
       - list
       - watch
       - create
+      - patch
+      - update
   - apiGroups:
       - "poc.autoscaling.k8s.io"
     resources:


### PR DESCRIPTION
**Why This PR?**

I found the below log in the Updater:

```
E0610 11:12:03.019632   	1 event.go:359] "Server rejected event (will not retry!)" err="events \"prometheus-vpa.1847a9dc234a924f\" is forbidden: User \"system:serviceaccount:monitoring:verticalpodautoscaler-vpa-updater\" cannot patch resource \"events\" in API group
```

This has been added to the upstream rbac:
- https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/deploy/vpa-rbac.yaml#L40-L41

Fixes #

**Changes**
Changes proposed in this pull request:

* Add patch and update verbs to events resource
* Added a CHANGELOG for vpa

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
