### PR TITLE
[stable/all] added extraManifests to values file for extra resources deployment

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@
     quay.io/helmpack/chart-testing:v3.13.0 \
     /bin/sh -c \
     "git config --global --add safe.directory /charts && \
-    ct lint --chart-yaml-schema scripts/schema.yaml \
+    ct lint --target-branch master --chart-yaml-schema scripts/schema.yaml \
     --chart-dirs incubator --chart-dirs stable"
   ```
   > The `git config` command prevents "detected dubious ownership in repository" errors.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,17 @@
 ## Guidelines on Contributing
 
 * Lint your changes:
-  * `docker run --rm -it -v ${PWD}:/charts -w /charts quay.io/helmpack/chart-testing:v3.13.0 ct lint --chart-yaml-schema scripts/schema.yaml --chart-dirs incubator --chart-dirs stable`
+  ```
+  docker run --rm -it \
+    -v ${PWD}:/charts \
+    -w /charts \
+    quay.io/helmpack/chart-testing:v3.13.0 \
+    /bin/sh -c \
+    "git config --global --add safe.directory /charts && \
+    ct lint --chart-yaml-schema scripts/schema.yaml \
+    --chart-dirs incubator --chart-dirs stable"
+  ```
+  > The `git config` command prevents "detected dubious ownership in repository" errors.
 * End-to-end test your changes:
   * Install [kind 0.7.0+](https://github.com/kubernetes-sigs/kind/releases)
   * Install [chart-testing (ct)](https://github.com/helm/chart-testing/releases)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@
     /bin/sh -c \
     "git config --global --add safe.directory /charts && \
     ct lint --target-branch master --chart-yaml-schema scripts/schema.yaml \
-    --chart-dirs incubator --chart-dirs stable"
+    --config=scripts/ct.yaml --chart-dirs incubator --chart-dirs stable"
   ```
   > The `git config` command prevents "detected dubious ownership in repository" errors.
 * End-to-end test your changes:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 ## Guidelines on Contributing
 
 * Lint your changes:
-  * `docker run --rm -it -v ${PWD}:/charts -w /charts quay.io/helmpack/chart-testing:v2.4.0 ct lint --chart-yaml-schema scripts/schema.yaml --chart-dirs incubator --chart-dirs stable`
+  * `docker run --rm -it -v ${PWD}:/charts -w /charts quay.io/helmpack/chart-testing:v2.5.0 ct lint --chart-yaml-schema scripts/schema.yaml --chart-dirs incubator --chart-dirs stable`
 * End-to-end test your changes:
   * Install [kind 0.7.0+](https://github.com/kubernetes-sigs/kind/releases)
   * Install [chart-testing (ct)](https://github.com/helm/chart-testing/releases)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 ## Guidelines on Contributing
 
 * Lint your changes:
-  * `docker run --rm -it -v ${PWD}:/charts -w /charts quay.io/helmpack/chart-testing:v2.5.0 ct lint --chart-yaml-schema scripts/schema.yaml --chart-dirs incubator --chart-dirs stable`
+  * `docker run --rm -it -v ${PWD}:/charts -w /charts quay.io/helmpack/chart-testing:v3.13.0 ct lint --chart-yaml-schema scripts/schema.yaml --chart-dirs incubator --chart-dirs stable`
 * End-to-end test your changes:
   * Install [kind 0.7.0+](https://github.com/kubernetes-sigs/kind/releases)
   * Install [chart-testing (ct)](https://github.com/helm/chart-testing/releases)

--- a/stable/astro/Chart.yaml
+++ b/stable/astro/Chart.yaml
@@ -1,5 +1,5 @@
 name: astro
-version: 1.0.14
+version: 1.1.0
 apiVersion: v1
 appVersion: "1.5.3"
 kubeVersion: ">= 1.22.0-0"

--- a/stable/astro/README.md
+++ b/stable/astro/README.md
@@ -55,3 +55,4 @@ Kubernetes 1.11+, Helm 2.13+
 | dryRun | bool | `false` | When set to true monitors will not be managed in datadog. |
 | custom_config.enabled | bool | `false` | If true a custom configuration must be specified in `custom_config.data`. |
 | custom_config.data | string | "" | An astro configuration file. See the [Astro repo readme](https://github.com/fairwindsops/astro) for more details. |
+| extraManifests | list | `[]` | A list of extra manifests to be installed with this chart. This is useful for installing additional resources that are not part of the chart |

--- a/stable/astro/ci/test-values.yaml
+++ b/stable/astro/ci/test-values.yaml
@@ -289,3 +289,10 @@ custom_config:
             thresholds:
               critical: 3
             locked: false
+extraManifests:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: extra-configmap
+    data:
+      key: value

--- a/stable/astro/templates/extra-manifests.yaml
+++ b/stable/astro/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraManifests }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}

--- a/stable/astro/values.yaml
+++ b/stable/astro/values.yaml
@@ -331,3 +331,12 @@ custom_config:
             thresholds:
               critical: 3
             locked: false
+
+# extraManifests -- A list of extra manifests to be installed with this chart. This is useful for installing additional resources that are not part of the chart
+extraManifests: []
+  # - apiVersion: v1
+  #   kind: ConfigMap
+  #   metadata:
+  #     name: extra-configmap
+  #   data:
+  #     key: value

--- a/stable/aws-iam-authenticator/Chart.yaml
+++ b/stable/aws-iam-authenticator/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: v0.5.9
 description: Install and configure aws-iam-authenticator on your cluster.
 name: aws-iam-authenticator
-version: v1.7.6
+version: v1.8.0
 maintainers:
   - name: sudermanjr

--- a/stable/aws-iam-authenticator/README.md
+++ b/stable/aws-iam-authenticator/README.md
@@ -25,3 +25,4 @@ In this version, due to updates for Kubernetes 1.16+, the labelSelector for the 
 | resources.requests.cpu | string | `"10m"` |  |
 | resources.limits.memory | string | `"20Mi"` |  |
 | resources.limits.cpu | string | `"100m"` |  |
+| extraManifests | list | `[]` | A list of extra manifests to be installed with this chart. This is useful for installing additional resources that are not part of the chart |

--- a/stable/aws-iam-authenticator/ci/test-values.yaml
+++ b/stable/aws-iam-authenticator/ci/test-values.yaml
@@ -35,3 +35,10 @@ configMap:
     mapAccounts:
     - "012345678901"
     - "456789012345"
+extraManifests:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: extra-configmap
+    data:
+      key: value

--- a/stable/aws-iam-authenticator/templates/extra-manifests.yaml
+++ b/stable/aws-iam-authenticator/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraManifests }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}

--- a/stable/aws-iam-authenticator/values.yaml
+++ b/stable/aws-iam-authenticator/values.yaml
@@ -74,3 +74,12 @@ resources:
   limits:
     memory: 20Mi
     cpu: 100m
+
+# extraManifests -- A list of extra manifests to be installed with this chart. This is useful for installing additional resources that are not part of the chart
+extraManifests: []
+  # - apiVersion: v1
+  #   kind: ConfigMap
+  #   metadata:
+  #     name: extra-configmap
+  #   data:
+  #     key: value

--- a/stable/ecr-cleanup/Chart.yaml
+++ b/stable/ecr-cleanup/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: "0.1.7"
-version: 1.2.7
+version: 1.3.0
 description: A Helm chart to run ecr cleanup controller
 name: ecr-cleanup
 maintainers:

--- a/stable/ecr-cleanup/templates/extra-manifests.yaml
+++ b/stable/ecr-cleanup/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraManifests }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}

--- a/stable/ecr-cleanup/values.yaml
+++ b/stable/ecr-cleanup/values.yaml
@@ -40,3 +40,12 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# extraManifests -- A list of extra manifests to be installed with this chart. This is useful for installing additional resources that are not part of the chart
+extraManifests: []
+  # - apiVersion: v1
+  #   kind: ConfigMap
+  #   metadata:
+  #     name: extra-configmap
+  #   data:
+  #     key: value

--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.11.0
+* added `extraManifests` for extra resources deployment
+
 ## 2.10.6
 * revert openapi bump
 

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "16.4"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 2.10.6
+version: 2.11.0
 kubeVersion: ">= 1.22.0-0"
 maintainers:
   - name: rbren

--- a/stable/fairwinds-insights/README.md
+++ b/stable/fairwinds-insights/README.md
@@ -295,3 +295,4 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | repoScanJob.topologySpreadConstraints[1].whenUnsatisfiable | string | `"ScheduleAnyway"` |  |
 | repoScanJob.topologySpreadConstraints[1].labelSelector.matchLabels."app.kubernetes.io/component" | string | `"repo-scan-job"` |  |
 | repoScanJob.topologySpreadConstraints[1].labelSelector.matchLabels."app.kubernetes.io/name" | string | `"fairwinds-insights"` |  |
+| extraManifests | list | `[]` | A list of extra manifests to be installed with this chart. This is useful for installing additional resources that are not part of the chart |

--- a/stable/fairwinds-insights/ci/test-values.yaml
+++ b/stable/fairwinds-insights/ci/test-values.yaml
@@ -68,3 +68,11 @@ resourcesRecommendationsCronjob:
 minio:
   persistence:
     enabled: false
+
+extraManifests:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: extra-configmap
+    data:
+      key: value

--- a/stable/fairwinds-insights/templates/extra-manifests.yaml
+++ b/stable/fairwinds-insights/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraManifests }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}

--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -782,3 +782,12 @@ repoScanJob:
         matchLabels:
           app.kubernetes.io/component: repo-scan-job
           app.kubernetes.io/name: fairwinds-insights
+
+# extraManifests -- A list of extra manifests to be installed with this chart. This is useful for installing additional resources that are not part of the chart
+extraManifests: []
+  # - apiVersion: v1
+  #   kind: ConfigMap
+  #   metadata:
+  #     name: extra-configmap
+  #   data:
+  #     key: value

--- a/stable/gemini/Chart.yaml
+++ b/stable/gemini/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Automated backup and restore of PersistentVolumes using the VolumeSnapshot API
 name: gemini
-version: 2.1.3
+version: 2.2.0
 appVersion: "2.0"
 kubeVersion: ">= 1.22.0-0"
 maintainers:

--- a/stable/gemini/README.md
+++ b/stable/gemini/README.md
@@ -48,3 +48,4 @@ before upgrading, and add `--skip-crds` when running `helm install`.
 | affinity | object | `{}` | Pod affinity and pod anti-affinity allow you to specify rules about how pods should be placed relative to other pods. |
 | additionalPodLabels | object | `{}` | Additional labels added on pod |
 | additionalPodAnnotations | object | `{}` | Additional annotations added on pod |
+| extraManifests | list | `[]` | A list of extra manifests to be installed with this chart. This is useful for installing additional resources that are not part of the chart |

--- a/stable/gemini/ci/test-values.yaml
+++ b/stable/gemini/ci/test-values.yaml
@@ -1,1 +1,8 @@
 testMode: true
+extraManifests:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: extra-configmap
+    data:
+      key: value

--- a/stable/gemini/templates/extra-manifests.yaml
+++ b/stable/gemini/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraManifests }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}

--- a/stable/gemini/values.yaml
+++ b/stable/gemini/values.yaml
@@ -53,3 +53,12 @@ additionalPodLabels: {}
 # additionalPodAnnotations -- Additional annotations added on pod
 additionalPodAnnotations: {}
   # key: value
+
+# extraManifests -- A list of extra manifests to be installed with this chart. This is useful for installing additional resources that are not part of the chart
+extraManifests: []
+  # - apiVersion: v1
+  #   kind: ConfigMap
+  #   metadata:
+  #     name: extra-configmap
+  #   data:
+  #     key: value

--- a/stable/gke-node-termination-handler/Chart.yaml
+++ b/stable/gke-node-termination-handler/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: "1.0"
 description: This helm chart provides an adapter for translating GCE node termination events to graceful pod terminations in Kubernetes.
 name: gke-node-termination-handler
-version: 1.2.7
+version: 1.3.0
 maintainers:
   - name: sudermanjr

--- a/stable/gke-node-termination-handler/README.md
+++ b/stable/gke-node-termination-handler/README.md
@@ -20,3 +20,4 @@ We recommend installing gke-node-termination-handler in its own namespace.
 | args | list | `["-v=10","--logtostderr","--exclude-pods=$(POD_NAME):$(POD_NAMESPACE)","--taint=cloud.google.com/impending-node-termination::NoSchedule"]` | Command arguments. Usually you don't need to override them. |
 | extraArgs | list | `[]` | Extra arguments for command. For example, "--system-pod-grace-period=14s" to wait for 14s for regular pods to terminate. |
 | env | object | `{"SLACK_WEBHOOK_URL":""}` | Extra environment variables. For example "SLACK_WEBHOOK_URL" |
+| extraManifests | list | `[]` | A list of extra manifests to be installed with this chart. This is useful for installing additional resources that are not part of the chart |

--- a/stable/gke-node-termination-handler/templates/extra-manifests.yaml
+++ b/stable/gke-node-termination-handler/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraManifests }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}

--- a/stable/gke-node-termination-handler/values.yaml
+++ b/stable/gke-node-termination-handler/values.yaml
@@ -38,3 +38,12 @@ extraArgs: []
 # env -- Extra environment variables. For example "SLACK_WEBHOOK_URL"
 env:
   SLACK_WEBHOOK_URL: ""
+
+# extraManifests -- A list of extra manifests to be installed with this chart. This is useful for installing additional resources that are not part of the chart
+extraManifests: []
+  # - apiVersion: v1
+  #   kind: ConfigMap
+  #   metadata:
+  #     name: extra-configmap
+  #   data:
+  #     key: value

--- a/stable/goldilocks/Chart.yaml
+++ b/stable/goldilocks/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 appVersion: "v4.13.0"
-version: 9.0.2
+version: 9.1.0
 kubeVersion: ">= 1.22.0-0"
 description: |
   A Helm chart for running Fairwinds Goldilocks. See https://github.com/FairwindsOps/goldilocks

--- a/stable/goldilocks/README.md
+++ b/stable/goldilocks/README.md
@@ -125,3 +125,4 @@ This will completely remove the VPA and then re-install it using the new method.
 | dashboard.tolerations | list | `[]` |  |
 | dashboard.affinity | object | `{}` |  |
 | dashboard.topologySpreadConstraints | list | `[]` | Topology spread constraints for the dashboard pods |
+| extraManifests | list | `[]` | A list of extra manifests to be installed with this chart. This is useful for installing additional resources that are not part of the chart |

--- a/stable/goldilocks/ci/test-values.yaml
+++ b/stable/goldilocks/ci/test-values.yaml
@@ -50,3 +50,10 @@ dashboard:
   deployment:
     additionalLabels:
       test: value
+extraManifests:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: extra-configmap
+    data:
+      key: value

--- a/stable/goldilocks/templates/extra-manifests.yaml
+++ b/stable/goldilocks/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraManifests }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}

--- a/stable/goldilocks/values.yaml
+++ b/stable/goldilocks/values.yaml
@@ -181,3 +181,12 @@ dashboard:
   affinity: {}
   # dashboard.topologySpreadConstraints -- Topology spread constraints for the dashboard pods
   topologySpreadConstraints: []
+
+# extraManifests -- A list of extra manifests to be installed with this chart. This is useful for installing additional resources that are not part of the chart
+extraManifests: []
+  # - apiVersion: v1
+  #   kind: ConfigMap
+  #   metadata:
+  #     name: extra-configmap
+  #   data:
+  #     key: value

--- a/stable/helm-release-pruner/Chart.yaml
+++ b/stable/helm-release-pruner/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v3.3.0
 description: This chart deploys a cronjob that purges stale Helm releases and associated namespaces. Releases are selected based on regex patterns for release name and namespace along with a Bash `date` command date string to define the stale cutoff date and time.
 name: helm-release-pruner
-version: 3.3.0
+version: 3.4.0
 kubeVersion: ">= 1.22.0-0"
 maintainers:
   - name: rbren

--- a/stable/helm-release-pruner/README.md
+++ b/stable/helm-release-pruner/README.md
@@ -64,3 +64,4 @@ Chart version 1.0.0 introduced RBacDefinitions with rbac-manager to manage acces
 | rbac_manager.namespaceLabel | string | `""` | Label to match namespaces to grant access to |
 | fullnameOverride | string | `""` | A template override for fullname |
 | nameOverride | string | `""` | A template override for name |
+| extraManifests | list | `[]` | A list of extra manifests to be installed with this chart. This is useful for installing additional resources that are not part of the chart |

--- a/stable/helm-release-pruner/ci/test-values.yaml
+++ b/stable/helm-release-pruner/ci/test-values.yaml
@@ -9,3 +9,10 @@ pruneProfiles:
   helmReleaseFilter: "^fwinsights-"
   namespaceFilter: "^fwinsights-"
   maxReleasesToKeep: 40
+extraManifests:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: extra-configmap
+    data:
+      key: value

--- a/stable/helm-release-pruner/templates/extra-manifests.yaml
+++ b/stable/helm-release-pruner/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraManifests }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}

--- a/stable/helm-release-pruner/values.yaml
+++ b/stable/helm-release-pruner/values.yaml
@@ -63,3 +63,12 @@ rbac_manager:
 fullnameOverride: ""
 # nameOverride -- A template override for name
 nameOverride: ""
+
+# extraManifests -- A list of extra manifests to be installed with this chart. This is useful for installing additional resources that are not part of the chart
+extraManifests: []
+  # - apiVersion: v1
+  #   kind: ConfigMap
+  #   metadata:
+  #     name: extra-configmap
+  #   data:
+  #     key: value

--- a/stable/insights-admission/CHANGELOG.md
+++ b/stable/insights-admission/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.11.0
+* added `extraManifests` for extra resources deployment
+
 ## 1.10.2
 * Add GKE instructions
 

--- a/stable/insights-admission/Chart.yaml
+++ b/stable/insights-admission/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: insights-admission
 description: A Validating Webhook Admission Controller that utilizes Fairwinds Insights.
 type: application
-version: 1.10.2
+version: 1.11.0
 appVersion: "1.18"
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-admission/icon.png

--- a/stable/insights-admission/README.md
+++ b/stable/insights-admission/README.md
@@ -102,3 +102,4 @@ rules:
 | certManagerApiVersion | string | `""` | If secretName is empty, we assume that you use cert-manager to provision the admission controller certificates. This allows pinning the apiVersion rather than using helm capabilities detection. Useful for gitops tools such as ArgoCD |
 | polaris.config | string | `nil` | Configuration for Polaris |
 | test | object | `{"enabled":false,"image":{"repository":"python","tag":"3.10-alpine"}}` | Used for chart CI only - deploys a test deployment |
+| extraManifests | list | `[]` | A list of extra manifests to be installed with this chart. This is useful for installing additional resources that are not part of the chart |

--- a/stable/insights-admission/ci/test-values.yaml
+++ b/stable/insights-admission/ci/test-values.yaml
@@ -21,3 +21,10 @@ serviceAccount:
 webhookConfig:
   annotations:
     "test-annotation": "test-annotation-value"
+extraManifests:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: extra-configmap
+    data:
+      key: value

--- a/stable/insights-admission/templates/extra-manifests.yaml
+++ b/stable/insights-admission/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraManifests }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}

--- a/stable/insights-admission/values.yaml
+++ b/stable/insights-admission/values.yaml
@@ -252,3 +252,12 @@ test:
   image:
     repository: "python"
     tag: "3.10-alpine"
+
+# extraManifests -- A list of extra manifests to be installed with this chart. This is useful for installing additional resources that are not part of the chart
+extraManifests: []
+  # - apiVersion: v1
+  #   kind: ConfigMap
+  #   metadata:
+  #     name: extra-configmap
+  #   data:
+  #     key: value

--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 4.7.0
+* added `extraManifests` for extra resources deployment
+
 ## 4.6.6
 * bumped kyverno to 0.4
 

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 4.6.6
+version: 4.7.0
 appVersion: 9.2.1
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png

--- a/stable/insights-agent/ci/test-values.yaml
+++ b/stable/insights-agent/ci/test-values.yaml
@@ -183,3 +183,11 @@ right-sizer-vpa:
       insecureSkipTLSVerify: true
     args:
       - "--kubelet-insecure-tls"
+
+extraManifests:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: extra-configmap
+    data:
+      key: value

--- a/stable/insights-agent/templates/extra-manifests.yaml
+++ b/stable/insights-agent/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraManifests }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -699,3 +699,12 @@ kyverno:
       memory: 128Mi
   timeout: 300
   mountTmp: true
+
+# extraManifests -- A list of extra manifests to be installed with this chart. This is useful for installing additional resources that are not part of the chart
+extraManifests: []
+  # - apiVersion: v1
+  #   kind: ConfigMap
+  #   metadata:
+  #     name: extra-configmap
+  #   data:
+  #     key: value

--- a/stable/polaris/CHANGELOG.md
+++ b/stable/polaris/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this Helm chart will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this chart adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 5.19.0
+* added `extraManifests` for extra resources deployment
+
 ## 5.17.0
 * Removed the switch for networking apiVersion and default to networking/v1
 

--- a/stable/polaris/Chart.yaml
+++ b/stable/polaris/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Validation of best practices in your Kubernetes clusters
 name: polaris
-version: 5.18.0
+version: 5.19.0
 appVersion: "8.5"
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/polaris/master/pkg/dashboard/assets/favicon-32x32.png

--- a/stable/polaris/README.md
+++ b/stable/polaris/README.md
@@ -109,3 +109,4 @@ the 0.10.0 version of this chart will only work on kubernetes 1.14.0+
 | audit.enable | bool | `false` | Runs a one-time audit. This is used internally at Fairwinds, and may not be useful for others. |
 | audit.cleanup | bool | `false` | Whether to delete the namespace once the audit is finished. |
 | audit.outputURL | string | `""` | A URL which will receive a POST request with audit results. |
+| extraManifests | list | `[]` | A list of extra manifests to be installed with this chart. This is useful for installing additional resources that are not part of the chart |

--- a/stable/polaris/ci/test-values.yaml
+++ b/stable/polaris/ci/test-values.yaml
@@ -17,3 +17,10 @@ webhook:
     apiVersion: cert-manager.io/v1
   deploymentAnnotations:
     foo: bar
+extraManifests:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: extra-configmap
+    data:
+      key: value

--- a/stable/polaris/templates/extra-manifests.yaml
+++ b/stable/polaris/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraManifests }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}

--- a/stable/polaris/values.yaml
+++ b/stable/polaris/values.yaml
@@ -257,3 +257,12 @@ audit:
   cleanup: false
   # audit.outputURL -- A URL which will receive a POST request with audit results.
   outputURL: ""
+
+# extraManifests -- A list of extra manifests to be installed with this chart. This is useful for installing additional resources that are not part of the chart
+extraManifests: []
+  # - apiVersion: v1
+  #   kind: ConfigMap
+  #   metadata:
+  #     name: extra-configmap
+  #   data:
+  #     key: value

--- a/stable/rbac-manager/Chart.yaml
+++ b/stable/rbac-manager/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rbac-manager
-version: 1.21.0
+version: 1.22.0
 appVersion: 1.9.0
 kubeVersion: ">= 1.22.0-0"
 description: A Kubernetes operator that simplifies the management of Role Bindings and Service Accounts.

--- a/stable/rbac-manager/README.md
+++ b/stable/rbac-manager/README.md
@@ -77,3 +77,4 @@ In the above workflow, an RBAC Definition installed between revision 1 and 2 sho
 | serviceMonitor.namespace | string | `""` | The namespace to deploy the serviceMonitor into |
 | serviceMonitor.interval | string | `"60s"` | How often to scrape the metrics endpoint |
 | serviceMonitor.relabelings | list | `[]` | RelabelConfigs to apply to samples before scraping |
+| extraManifests | list | `[]` | A list of extra manifests to be installed with this chart. This is useful for installing additional resources that are not part of the chart |

--- a/stable/rbac-manager/ci/test-values.yaml
+++ b/stable/rbac-manager/ci/test-values.yaml
@@ -3,3 +3,11 @@ extraArgs:
 
 deploymentLabels:
   test: test
+
+extraManifests:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: extra-configmap
+    data:
+      key: value

--- a/stable/rbac-manager/templates/extra-manifests.yaml
+++ b/stable/rbac-manager/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraManifests }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}

--- a/stable/rbac-manager/values.yaml
+++ b/stable/rbac-manager/values.yaml
@@ -78,3 +78,12 @@ serviceMonitor:
   interval: 60s
   # serviceMonitor.relabelings -- RelabelConfigs to apply to samples before scraping
   relabelings: []
+
+# extraManifests -- A list of extra manifests to be installed with this chart. This is useful for installing additional resources that are not part of the chart
+extraManifests: []
+  # - apiVersion: v1
+  #   kind: ConfigMap
+  #   metadata:
+  #     name: extra-configmap
+  #   data:
+  #     key: value

--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 4.7.2
+version: 4.8.0
 appVersion: 1.0.0
 maintainers:
   - name: sudermanjr

--- a/stable/vpa/README.md
+++ b/stable/vpa/README.md
@@ -238,3 +238,4 @@ recommender:
 | tests.image.pullPolicy | string | `"Always"` | The pull policy for the tests image. |
 | metrics-server | object | `{"enabled":false}` | configuration options for the [metrics server Helm chart](https://github.com/kubernetes-sigs/metrics-server/tree/master/charts/metrics-server). See the projects [README.md](https://github.com/kubernetes-sigs/metrics-server/tree/master/charts/metrics-server#configuration) for all available options |
 | metrics-server.enabled | bool | `false` | Whether or not the metrics server Helm chart should be installed |
+| extraManifests | list | `[]` | A list of extra manifests to be installed with this chart. This is useful for installing additional resources that are not part of the chart |

--- a/stable/vpa/ci/test-values.yaml
+++ b/stable/vpa/ci/test-values.yaml
@@ -93,3 +93,10 @@ metrics-server:
     insecureSkipTLSVerify: true
   args:
     - "--kubelet-insecure-tls"
+extraManifests:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: extra-configmap
+    data:
+      key: value

--- a/stable/vpa/templates/extra-manifests.yaml
+++ b/stable/vpa/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraManifests }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}

--- a/stable/vpa/values.yaml
+++ b/stable/vpa/values.yaml
@@ -348,3 +348,12 @@ tests:
 metrics-server:
   # metrics-server.enabled -- Whether or not the metrics server Helm chart should be installed
   enabled: false
+
+# extraManifests -- A list of extra manifests to be installed with this chart. This is useful for installing additional resources that are not part of the chart
+extraManifests: []
+  # - apiVersion: v1
+  #   kind: ConfigMap
+  #   metadata:
+  #     name: extra-configmap
+  #   data:
+  #     key: value


### PR DESCRIPTION
**Why This PR?**
Added `extraManifests` to all charts `values.yaml`.

I am using Traefik and wishes to use `ForwardAuth` middleware (ingress-nginx equivalent of the auth-url and more annotations) to forward authentication to a server (oauth2). 
Traefik does not use annotations which can be placed on the Ingress resource but a CRD, therefore extraManifests are really useful on charts for this reason and other tools use cases.

Fixes #

None, but I could create the issue.

**Changes**
Changes proposed in this pull request:

* Fixing chart-testing docker command along upgrading it to latest version 3.13.0 which supports Helm v3 (I couldn't test using current Charts version without encountering bug).
* Introducting `extraManifests` to all values.yaml, which template is called `extra-manifests.yaml`

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.

**Extra checklist:**

* [X] Modified CHANGELOG.md for `fairwinds-insight`, `insights-agent`, `polaris` and `insights-admission`.
* [X] Added test to e2e with a dummy configmap.