### PR TITLE
[stable/vpa] feat: add leader locking permissions for updater and recommender

### DIFF
--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 4.9.0
+version: 4.9.1
 appVersion: 1.4.1
 maintainers:
   - name: sudermanjr

--- a/stable/vpa/templates/roles.yaml
+++ b/stable/vpa/templates/roles.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: system:leader-locking-{{ include "vpa.serviceAccountName" . }}-updater
-  namespace: {{ .Release.Namespace }}
+  namespace: kube-system
 rules:
   - apiGroups:
       - "coordination.k8s.io"
@@ -27,7 +27,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: system:leader-locking-{{ include "vpa.serviceAccountName" . }}-updater
-  namespace: {{ .Release.Namespace }}
+  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -41,7 +41,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: system:leader-locking-{{ include "vpa.serviceAccountName" . }}-recommender
-  namespace: {{ .Release.Namespace }}
+  namespace: kube-system
 rules:
   - apiGroups:
       - "coordination.k8s.io"
@@ -66,7 +66,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: system:leader-locking-{{ include "vpa.serviceAccountName" . }}-recommender
-  namespace: {{ .Release.Namespace }}
+  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/stable/vpa/templates/roles.yaml
+++ b/stable/vpa/templates/roles.yaml
@@ -1,0 +1,78 @@
+{{- if .Values.rbac.create }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: system:leader-locking-{{ include "vpa.serviceAccountName" . }}-updater
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups:
+      - "coordination.k8s.io"
+    resources:
+      - leases
+    verbs:
+      - create
+  - apiGroups:
+      - "coordination.k8s.io"
+    resourceNames:
+      - vpa-updater
+    resources:
+      - leases
+    verbs:
+      - get
+      - watch
+      - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: system:leader-locking-{{ include "vpa.serviceAccountName" . }}-updater
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: system:leader-locking-{{ include "vpa.serviceAccountName" . }}-updater
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "vpa.serviceAccountName" . }}-updater
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: system:leader-locking-{{ include "vpa.serviceAccountName" . }}-recommender
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups:
+      - "coordination.k8s.io"
+    resources:
+      - leases
+    verbs:
+      - create
+  - apiGroups:
+      - "coordination.k8s.io"
+    resourceNames:
+      # TODO: Clean vpa-recommender up once vpa-recommender-lease is used everywhere. See https://github.com/kubernetes/autoscaler/issues/7461.
+      - vpa-recommender
+      - vpa-recommender-lease
+    resources:
+      - leases
+    verbs:
+      - get
+      - watch
+      - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: system:leader-locking-{{ include "vpa.serviceAccountName" . }}-recommender
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: system:leader-locking-{{ include "vpa.serviceAccountName" . }}-recommender
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "vpa.serviceAccountName" . }}-recommender
+    namespace: {{ .Release.Namespace }}
+{{- end }}


### PR DESCRIPTION
**Why This PR?**

The latest version of the vertical pod autoscaler now includes leader election for the updater and recommender components

Mentioned in https://github.com/FairwindsOps/charts/pull/1538#issuecomment-2956343912

**Changes**
Changes proposed in this pull request:

* adding roles and rolebindings for updater/recommender with lease related permissions.

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
