### PR TITLE
[stable/insights-agent] Expose onDemandJobRunner.pollInterval configuration

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 4.8.2
+* Expose `onDemandJobRunner.pollInterval` configuration
+
 ## 4.8.1
 * Bumped admission to remove support to OPA v1
 

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 4.8.1
+version: 4.8.2
 appVersion: 9.2.1
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png

--- a/stable/insights-agent/templates/on-demand-job-runner/deployment.yaml
+++ b/stable/insights-agent/templates/on-demand-job-runner/deployment.yaml
@@ -51,6 +51,8 @@ spec:
               name: {{ include "insights-agent.fullname" . }}-token
               {{ end -}}
               key: token
+        - name: POLL_INTERVAL
+          value: {{ .Values.onDemandJobRunner.pollInterval | quote }}
         {{- with .Values.onDemandJobRunner.containerSecurityContext }}
         securityContext:
           {{- toYaml . | nindent 12 }}

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -702,6 +702,7 @@ kyverno:
 
 onDemandJobRunner:
   enabled: true
+  pollInterval: "15s"
   image:
     repository: quay.io/fairwinds/on-demand-job-runner
     tag: "0.1"


### PR DESCRIPTION
**Why This PR?** (INS-1255)
This PR exposes `onDemandJobRunner.pollInterval` configuration with default of 15s

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
