### PR TITLE
[stable/yelb] fix: Fix deployment appserver template for kustomize

### DIFF
--- a/incubator/yelb/Chart.yaml
+++ b/incubator/yelb/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: yelb
 description: A Helm chart to deploy the yelb demo app
 type: application
-version: 0.1.0
-appVersion: 'v0.1.0'
+version: 0.1.1
+appVersion: 'v0.1.1'
 maintainers:
   - name: sudermanjr
 dependencies:

--- a/incubator/yelb/templates/deployment-appserver.yaml
+++ b/incubator/yelb/templates/deployment-appserver.yaml
@@ -34,7 +34,7 @@ spec:
         - name: {{ .Chart.Name }}
           env:
             - name: RACK_ENV
-            - name: custom
+              value: custom
             - name: REDIS_SERVER_ENDPOINT
               value: {{ include "yelb.fullname" . }}-valkey-master
             - name: YELB_DB_SERVER_ENDPOINT

--- a/incubator/yelb/templates/deployment-appserver.yaml
+++ b/incubator/yelb/templates/deployment-appserver.yaml
@@ -34,7 +34,7 @@ spec:
         - name: {{ .Chart.Name }}
           env:
             - name: RACK_ENV
-              name: custom
+            - name: custom
             - name: REDIS_SERVER_ENDPOINT
               value: {{ include "yelb.fullname" . }}-valkey-master
             - name: YELB_DB_SERVER_ENDPOINT


### PR DESCRIPTION
**Why This PR?**
The kustomize build command is falling with error:
```
Error: yaml: unmarshal errors:
  line 36: mapping key "name" already defined at line 35
 ```

Fixes #
Fixed appserver deployment template syntax in env block

**Changes**
Changes proposed in this pull request:
Fixed appserver deployment template syntax in env block
*
*

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
