### PR TITLE
[stable/goldilocks]: add support for extra RBAC rules and cluster role bindings

### DIFF
--- a/stable/goldilocks/Chart.yaml
+++ b/stable/goldilocks/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 appVersion: "v4.14.1"
-version: 9.1.0
+version: 9.2.0
 kubeVersion: ">= 1.22.0-0"
 description: |
   A Helm chart for running Fairwinds Goldilocks. See https://github.com/FairwindsOps/goldilocks

--- a/stable/goldilocks/README.md
+++ b/stable/goldilocks/README.md
@@ -104,6 +104,8 @@ This will completely remove the VPA and then re-install it using the new method.
 | dashboard.excludeContainers | string | `"linkerd-proxy,istio-proxy"` | Container names to exclude from displaying in the Goldilocks dashboard |
 | dashboard.rbac.create | bool | `true` | If set to true, rbac resources will be created for the dashboard |
 | dashboard.rbac.enableArgoproj | bool | `true` | If set to true, the clusterrole will give access to argoproj.io resources |
+| dashboard.rbac.extraRules | list | `[]` |  |
+| dashboard.rbac.extraClusterRoleBindings | list | `[]` |  |
 | dashboard.serviceAccount.create | bool | `true` | If true, a service account will be created for the dashboard. If set to false, you must set `dashboard.serviceAccount.name` |
 | dashboard.serviceAccount.name | string | `nil` | The name of an existing service account to use for the controller. Combined with `dashboard.serviceAccount.create` |
 | dashboard.deployment.annotations | object | `{}` | Extra annotations for the dashboard deployment |

--- a/stable/goldilocks/templates/dashboard-clusterrole.yaml
+++ b/stable/goldilocks/templates/dashboard-clusterrole.yaml
@@ -41,4 +41,7 @@ rules:
       - 'get'
       - 'list'
   {{- end }}
+  {{- if .Values.dashboard.rbac.extraRules -}}
+  {{ toYaml .Values.dashboard.rbac.extraRules | nindent 2 }}
+  {{- end }}
 {{- end }}

--- a/stable/goldilocks/templates/dashboard-clusterrolebinding.yaml
+++ b/stable/goldilocks/templates/dashboard-clusterrolebinding.yaml
@@ -17,4 +17,26 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "dashboard.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
+
+{{- range $.Values.dashboard.rbac.extraClusterRoleBindings }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "goldilocks.fullname" $ }}-dashboard-{{ . }}
+  labels:
+    app.kubernetes.io/name: {{ include "goldilocks.name" $ }}
+    helm.sh/chart: {{ include "goldilocks.chart" $ }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+    app.kubernetes.io/component: dashboard
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "goldilocks.fullname" $ }}-dashboard
+    namespace: {{ $.Release.Namespace }}
+{{- end }}
 {{- end }}

--- a/stable/goldilocks/values.yaml
+++ b/stable/goldilocks/values.yaml
@@ -118,6 +118,10 @@ dashboard:
     create: true
     # dashboard.rbac.enableArgoproj -- If set to true, the clusterrole will give access to argoproj.io resources
     enableArgoproj: true
+    # controller.rbac.extraRules -- Extra rbac rules for the controller clusterrole
+    extraRules: []
+    # controller.rbac.extraClusterRoleBindings -- A list of ClusterRoles for which ClusterRoleBindings will be created for the ServiceAccount, if enabled
+    extraClusterRoleBindings: []
   serviceAccount:
     # dashboard.serviceAccount.create -- If true, a service account will be created for the dashboard. If set to false, you must set `dashboard.serviceAccount.name`
     create: true


### PR DESCRIPTION
* Added support for additional RBAC rules in dashboard-clusterrole.yaml.
* Implemented extra `ClusterRoleBindings` in dashboard-clusterrolebinding.yaml for enhanced role management.

**Why This PR?**
The dashboard also needs extra permissions when calling `controllerUtils`, these should be exposed for extensions by the user. 

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
