### PR TITLE
feat(stable/goldilocks): move metrics-server subchart off bitnami

### DIFF
--- a/stable/goldilocks/Chart.lock
+++ b/stable/goldilocks/Chart.lock
@@ -3,7 +3,7 @@ dependencies:
   repository: https://charts.fairwinds.com/stable
   version: 4.5.0
 - name: metrics-server
-  repository: https://charts.bitnami.com/bitnami
-  version: 7.2.10
-digest: sha256:421c85776237d045f59f0d1dee55e7fe13b3d394369174666c81288a99f145f4
-generated: "2024-07-29T10:28:02.96546-06:00"
+  repository: https://kubernetes-sigs.github.io/metrics-server/
+  version: 3.13.0
+digest: sha256:0f44e79bb3a71a82e2fd4af312f5cc273c8f3540fc3747b6a06ed7c11eb31819
+generated: "2025-08-12T09:35:50.016072-06:00"

--- a/stable/goldilocks/Chart.yaml
+++ b/stable/goldilocks/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 appVersion: "v4.14.1"
-version: 9.2.0
+version: 10.0.0
 kubeVersion: ">= 1.22.0-0"
 description: |
   A Helm chart for running Fairwinds Goldilocks. See https://github.com/FairwindsOps/goldilocks
@@ -20,6 +20,6 @@ dependencies:
     repository: https://charts.fairwinds.com/stable
     condition: vpa.enabled
   - name: metrics-server
-    version: 7.2.*
-    repository: https://charts.bitnami.com/bitnami
+    version: 3.*.*
+    repository: https://kubernetes-sigs.github.io/metrics-server/
     condition: metrics-server.enabled

--- a/stable/goldilocks/README.md
+++ b/stable/goldilocks/README.md
@@ -23,6 +23,10 @@ Fairwinds has published a chart for installing VPA [in our stable repo](https://
 
 ## Major Version Upgrade Notes
 
+## Upgrading from v9.x.x to v10.x.x
+
+The only breaking change is to move the metrics-server sub-chart from bitnami to kubernetes-sigs. Generally we provide the sub-chart only as a convenience for testing. In production environments, metrics-server is a critical cluster component that should be managed separately. However in an abundance of caution, we are doing a major release to indicate this change.
+
 ## Upgrading from v6.x.x to v7.x.x
 
 In this change, the VPA helm chart was upgraded to the latest version, including a major bump. We recommend you to check [the VPA Helm chart changelog](https://github.com/FairwindsOps/charts/tree/master/stable/vpa#breaking-upgrading-from--v17x-to-200) to ensure a smooth upgrade.

--- a/stable/goldilocks/README.md.gotmpl
+++ b/stable/goldilocks/README.md.gotmpl
@@ -23,6 +23,10 @@ Fairwinds has published a chart for installing VPA [in our stable repo](https://
 
 ## Major Version Upgrade Notes
 
+## Upgrading from v9.x.x to v10.x.x
+
+The only breaking change is to move the metrics-server sub-chart from bitnami to kubernetes-sigs. Generally we provide the sub-chart only as a convenience for testing. In production environments, metrics-server is a critical cluster component that should be managed separately. However in an abundance of caution, we are doing a major release to indicate this change.
+
 ## Upgrading from v6.x.x to v7.x.x
 
 In this change, the VPA helm chart was upgraded to the latest version, including a major bump. We recommend you to check [the VPA Helm chart changelog](https://github.com/FairwindsOps/charts/tree/master/stable/vpa#breaking-upgrading-from--v17x-to-200) to ensure a smooth upgrade.

--- a/stable/goldilocks/ci/test-values.yaml
+++ b/stable/goldilocks/ci/test-values.yaml
@@ -4,6 +4,8 @@ vpa:
 
 metrics-server:
   enabled: true
+  args:
+    - "--kubelet-insecure-tls"
 
 controller:
   flags:

--- a/stable/goldilocks/ci/test-values.yaml
+++ b/stable/goldilocks/ci/test-values.yaml
@@ -4,9 +4,6 @@ vpa:
 
 metrics-server:
   enabled: true
-  extraArgs:
-    - --kubelet-insecure-tls
-    - --kubelet-preferred-address-types=InternalIP
 
 controller:
   flags:


### PR DESCRIPTION
**Why This PR?**

Remove bitnami reference in Goldilocks sub-charts

Related to: #1640

**Changes**
Changes proposed in this pull request:

* Replace sub-chart for metrisc-server with kubernets-sigs

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.