### PR TITLE
[stable/fairwinds-insights] add default temporal namespace fwinsights

### DIFF
--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.1.5
+* Add default temporal namespace for fwinsights
+
 ## 3.1.4
 * Add option to require SSO when accessing Admin API
 

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "17.0"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 3.1.5
+version: 3.1.6
 kubeVersion: ">= 1.22.0-0"
 maintainers:
   - name: rbren

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "17.0"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 3.1.4
+version: 3.1.5
 kubeVersion: ">= 1.22.0-0"
 maintainers:
   - name: rbren

--- a/stable/fairwinds-insights/README.md
+++ b/stable/fairwinds-insights/README.md
@@ -308,6 +308,9 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | temporal.postgresql.enabled | bool | `true` |  |
 | temporal.server.replicaCount | int | `1` |  |
 | temporal.server.config.logLevel | string | `"debug"` |  |
+| temporal.server.config.namespaces.create | bool | `true` |  |
+| temporal.server.config.namespaces.namespace[0].name | string | `"fwinsights"` |  |
+| temporal.server.config.namespaces.namespace[0].retention | string | `"7d"` |  |
 | temporal.server.config.persistence.default.driver | string | `"sql"` |  |
 | temporal.server.config.persistence.default.sql.driver | string | `"postgres12"` |  |
 | temporal.server.config.persistence.default.sql.database | string | `"temporal"` |  |

--- a/stable/fairwinds-insights/README.md
+++ b/stable/fairwinds-insights/README.md
@@ -310,7 +310,7 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | temporal.server.config.logLevel | string | `"debug"` |  |
 | temporal.server.config.namespaces.create | bool | `true` |  |
 | temporal.server.config.namespaces.namespace[0].name | string | `"fwinsights"` |  |
-| temporal.server.config.namespaces.namespace[0].retention | string | `"7d"` |  |
+| temporal.server.config.namespaces.namespace[0].retention | string | `"3d"` |  |
 | temporal.server.config.persistence.default.driver | string | `"sql"` |  |
 | temporal.server.config.persistence.default.sql.driver | string | `"postgres12"` |  |
 | temporal.server.config.persistence.default.sql.database | string | `"temporal"` |  |

--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -806,6 +806,11 @@ temporal:
     replicaCount: 1
     config:
       logLevel: "debug"
+      namespaces:
+        create: true
+        namespace:
+          - name: fwinsights
+            retention: 7d
       persistence:
         default:
           driver: "sql"

--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -810,7 +810,7 @@ temporal:
         create: true
         namespace:
           - name: fwinsights
-            retention: 7d
+            retention: 3d
       persistence:
         default:
           driver: "sql"


### PR DESCRIPTION
**Why This PR?**
Adds default temporal namespace `fwinsights`

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
