### PR TITLE
Change kubectl image from bitnami to alpine repository

### DIFF
--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.1.5
+* Change kubectl image from bitnami to rancher repository
+
 ## 3.1.4
 * Add option to require SSO when accessing Admin API
 

--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 3.1.5
-* Change kubectl image from bitnami to rancher repository
+* Change kubectl image from bitnami to alpine repository
 
 ## 3.1.4
 * Add option to require SSO when accessing Admin API

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "17.0"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 3.1.4
+version: 3.1.5
 kubeVersion: ">= 1.22.0-0"
 maintainers:
   - name: rbren

--- a/stable/fairwinds-insights/README.md
+++ b/stable/fairwinds-insights/README.md
@@ -204,8 +204,8 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | migrateHealthScoreJob.resources.limits.memory | string | `"1024Mi"` |  |
 | migrateHealthScoreJob.resources.requests.cpu | string | `"80m"` |  |
 | migrateHealthScoreJob.resources.requests.memory | string | `"128Mi"` |  |
-| cronjobExecutor.image.repository | string | `"bitnami/kubectl"` |  |
-| cronjobExecutor.image.tag | string | `"1.22.8"` |  |
+| cronjobExecutor.image.repository | string | `"rancher/kubectl"` |  |
+| cronjobExecutor.image.tag | string | `"v1.31.12"` |  |
 | cronjobExecutor.resources.limits.cpu | string | `"100m"` |  |
 | cronjobExecutor.resources.limits.memory | string | `"64Mi"` |  |
 | cronjobExecutor.resources.requests.cpu | string | `"1m"` |  |

--- a/stable/fairwinds-insights/README.md
+++ b/stable/fairwinds-insights/README.md
@@ -205,7 +205,7 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | migrateHealthScoreJob.resources.requests.cpu | string | `"80m"` |  |
 | migrateHealthScoreJob.resources.requests.memory | string | `"128Mi"` |  |
 | cronjobExecutor.image.repository | string | `"rancher/kubectl"` |  |
-| cronjobExecutor.image.tag | string | `"v1.31.12"` |  |
+| cronjobExecutor.image.tag | string | `"v1.33.4"` |  |
 | cronjobExecutor.resources.limits.cpu | string | `"100m"` |  |
 | cronjobExecutor.resources.limits.memory | string | `"64Mi"` |  |
 | cronjobExecutor.resources.requests.cpu | string | `"1m"` |  |

--- a/stable/fairwinds-insights/README.md
+++ b/stable/fairwinds-insights/README.md
@@ -204,8 +204,8 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | migrateHealthScoreJob.resources.limits.memory | string | `"1024Mi"` |  |
 | migrateHealthScoreJob.resources.requests.cpu | string | `"80m"` |  |
 | migrateHealthScoreJob.resources.requests.memory | string | `"128Mi"` |  |
-| cronjobExecutor.image.repository | string | `"rancher/kubectl"` |  |
-| cronjobExecutor.image.tag | string | `"v1.33.4"` |  |
+| cronjobExecutor.image.repository | string | `"alpine/kubectl"` |  |
+| cronjobExecutor.image.tag | string | `"1.33.3"` |  |
 | cronjobExecutor.resources.limits.cpu | string | `"100m"` |  |
 | cronjobExecutor.resources.limits.memory | string | `"64Mi"` |  |
 | cronjobExecutor.resources.requests.cpu | string | `"1m"` |  |

--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -638,7 +638,7 @@ migrateHealthScoreJob:
 cronjobExecutor:
   image:
     repository: rancher/kubectl
-    tag: "v1.31.12"
+    tag: "v1.33.4"
   resources:
     limits:
       cpu: 100m

--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -637,8 +637,8 @@ migrateHealthScoreJob:
 
 cronjobExecutor:
   image:
-    repository: bitnami/kubectl
-    tag: "1.22.8"
+    repository: rancher/kubectl
+    tag: "v1.31.12"
   resources:
     limits:
       cpu: 100m

--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -637,8 +637,8 @@ migrateHealthScoreJob:
 
 cronjobExecutor:
   image:
-    repository: rancher/kubectl
-    tag: "v1.33.4"
+    repository: alpine/kubectl
+    tag: "1.33.3"
   resources:
     limits:
       cpu: 100m

--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 4.8.0
+version: 4.8.1
 appVersion: 1.4.1
 maintainers:
   - name: sudermanjr

--- a/stable/vpa/README.md
+++ b/stable/vpa/README.md
@@ -233,8 +233,8 @@ recommender:
 | admissionController.httpPort | int | `8000` | Port of the admission controller for the mutating webhooks |
 | admissionController.metricsPort | int | `8944` | Port of the admission controller where metrics can be received from |
 | tests.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":10324}` | The security context for the containers run as helm hook tests |
-| tests.image.repository | string | `"bitnami/kubectl"` | An image used for testing containing bash, cat and kubectl |
-| tests.image.tag | string | `""` | An image tag for the tests image |
+| tests.image.repository | string | `"rancher/kubectl"` | An image used for testing containing bash, cat and kubectl |
+| tests.image.tag | string | `"v1.31.12"` | An image tag for the tests image |
 | tests.image.pullPolicy | string | `"Always"` | The pull policy for the tests image. |
 | metrics-server | object | `{"enabled":false}` | configuration options for the [metrics server Helm chart](https://github.com/kubernetes-sigs/metrics-server/tree/master/charts/metrics-server). See the projects [README.md](https://github.com/kubernetes-sigs/metrics-server/tree/master/charts/metrics-server#configuration) for all available options |
 | metrics-server.enabled | bool | `false` | Whether or not the metrics server Helm chart should be installed |

--- a/stable/vpa/README.md
+++ b/stable/vpa/README.md
@@ -233,7 +233,7 @@ recommender:
 | admissionController.httpPort | int | `8000` | Port of the admission controller for the mutating webhooks |
 | admissionController.metricsPort | int | `8944` | Port of the admission controller where metrics can be received from |
 | tests.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":10324}` | The security context for the containers run as helm hook tests |
-| tests.image.repository | string | `"rancher/kubectl"` | An image used for testing containing bash, cat and kubectl |
+| tests.image.repository | string | `"rancher/kubectl"` | An image used for testing containing sh, cat and kubectl |
 | tests.image.tag | string | `"v1.33.4"` | An image tag for the tests image |
 | tests.image.pullPolicy | string | `"Always"` | The pull policy for the tests image. |
 | metrics-server | object | `{"enabled":false}` | configuration options for the [metrics server Helm chart](https://github.com/kubernetes-sigs/metrics-server/tree/master/charts/metrics-server). See the projects [README.md](https://github.com/kubernetes-sigs/metrics-server/tree/master/charts/metrics-server#configuration) for all available options |

--- a/stable/vpa/README.md
+++ b/stable/vpa/README.md
@@ -233,8 +233,8 @@ recommender:
 | admissionController.httpPort | int | `8000` | Port of the admission controller for the mutating webhooks |
 | admissionController.metricsPort | int | `8944` | Port of the admission controller where metrics can be received from |
 | tests.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":10324}` | The security context for the containers run as helm hook tests |
-| tests.image.repository | string | `"rancher/kubectl"` | An image used for testing containing sh, cat and kubectl |
-| tests.image.tag | string | `"v1.33.4"` | An image tag for the tests image |
+| tests.image.repository | string | `"alpine/kubectl"` | An image used for testing containing sh, cat and kubectl |
+| tests.image.tag | string | `"1.33.3"` | An image tag for the tests image |
 | tests.image.pullPolicy | string | `"Always"` | The pull policy for the tests image. |
 | metrics-server | object | `{"enabled":false}` | configuration options for the [metrics server Helm chart](https://github.com/kubernetes-sigs/metrics-server/tree/master/charts/metrics-server). See the projects [README.md](https://github.com/kubernetes-sigs/metrics-server/tree/master/charts/metrics-server#configuration) for all available options |
 | metrics-server.enabled | bool | `false` | Whether or not the metrics server Helm chart should be installed |

--- a/stable/vpa/README.md
+++ b/stable/vpa/README.md
@@ -234,7 +234,7 @@ recommender:
 | admissionController.metricsPort | int | `8944` | Port of the admission controller where metrics can be received from |
 | tests.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":10324}` | The security context for the containers run as helm hook tests |
 | tests.image.repository | string | `"rancher/kubectl"` | An image used for testing containing bash, cat and kubectl |
-| tests.image.tag | string | `"v1.31.12"` | An image tag for the tests image |
+| tests.image.tag | string | `"v1.33.4"` | An image tag for the tests image |
 | tests.image.pullPolicy | string | `"Always"` | The pull policy for the tests image. |
 | metrics-server | object | `{"enabled":false}` | configuration options for the [metrics server Helm chart](https://github.com/kubernetes-sigs/metrics-server/tree/master/charts/metrics-server). See the projects [README.md](https://github.com/kubernetes-sigs/metrics-server/tree/master/charts/metrics-server#configuration) for all available options |
 | metrics-server.enabled | bool | `false` | Whether or not the metrics server Helm chart should be installed |

--- a/stable/vpa/templates/tests/_test_helpers.tpl
+++ b/stable/vpa/templates/tests/_test_helpers.tpl
@@ -14,8 +14,8 @@ Get kubectl image name
 */}}
 {{- define "vpa.test.image" -}}
 {{- if .Values.tests.image }}
-{{- printf "%s:%s" (default "rancher/kubectl" .Values.tests.image.repository) (default (include "vpa.test.tag" . ) .Values.tests.image.tag) }}
+{{- printf "%s:%s" (default "alpine/kubectl" .Values.tests.image.repository) (default (include "vpa.test.tag" . ) .Values.tests.image.tag) }}
 {{- else }}
-{{- printf "rancher/kubectl:%s" (include "vpa.test.tag" . ) }}
+{{- printf "alpine/kubectl:%s" (include "vpa.test.tag" . ) }}
 {{- end }}
 {{- end }}

--- a/stable/vpa/templates/tests/_test_helpers.tpl
+++ b/stable/vpa/templates/tests/_test_helpers.tpl
@@ -14,8 +14,8 @@ Get kubectl image name
 */}}
 {{- define "vpa.test.image" -}}
 {{- if .Values.tests.image }}
-{{- printf "%s:%s" (default "bitnami/kubectl" .Values.tests.image.repository) (default (include "vpa.test.tag" . ) .Values.tests.image.tag) }}
+{{- printf "%s:%s" (default "rancher/kubectl" .Values.tests.image.repository) (default (include "vpa.test.tag" . ) .Values.tests.image.tag) }}
 {{- else }}
-{{- printf "bitnami/kubectl:%s" (include "vpa.test.tag" . ) }}
+{{- printf "rancher/kubectl:%s" (include "vpa.test.tag" . ) }}
 {{- end }}
 {{- end }}

--- a/stable/vpa/templates/tests/create-vpa.yaml
+++ b/stable/vpa/templates/tests/create-vpa.yaml
@@ -21,11 +21,11 @@ spec:
       {{- if .Values.tests.image }}
       imagePullPolicy: {{ .Values.tests.image.pullPolicy }}
       {{- end }}
-      command: ['bash']
+      command: ['sh']
       args:
         - -c
         - |
-          #!/bin/bash
+          #!/bin/sh
 
           set -ex
           cat <<EOF | kubectl -n {{ .Release.Namespace }} apply -f -

--- a/stable/vpa/templates/tests/webhook.yaml
+++ b/stable/vpa/templates/tests/webhook.yaml
@@ -22,11 +22,11 @@ spec:
       {{- if .Values.tests.image }}
       imagePullPolicy: {{ .Values.tests.image.pullPolicy }}
       {{- end }}
-      command: ['bash']
+      command: ['sh']
       args:
         - -c
         - |
-          #!/bin/bash
+          #!/bin/sh
 
           set -ex
 

--- a/stable/vpa/values.yaml
+++ b/stable/vpa/values.yaml
@@ -338,9 +338,9 @@ tests:
         - ALL
   image:
     # tests.image.repository -- An image used for testing containing sh, cat and kubectl
-    repository: rancher/kubectl
+    repository: alpine/kubectl
     # tests.image.tag -- An image tag for the tests image
-    tag: "v1.33.4"
+    tag: "1.33.3"
     # tests.image.pullPolicy -- The pull policy for the tests image.
     pullPolicy: Always
 

--- a/stable/vpa/values.yaml
+++ b/stable/vpa/values.yaml
@@ -340,7 +340,7 @@ tests:
     # tests.image.repository -- An image used for testing containing bash, cat and kubectl
     repository: rancher/kubectl
     # tests.image.tag -- An image tag for the tests image
-    tag: "v1.31.12"
+    tag: "v1.33.4"
     # tests.image.pullPolicy -- The pull policy for the tests image.
     pullPolicy: Always
 

--- a/stable/vpa/values.yaml
+++ b/stable/vpa/values.yaml
@@ -338,9 +338,9 @@ tests:
         - ALL
   image:
     # tests.image.repository -- An image used for testing containing bash, cat and kubectl
-    repository: bitnami/kubectl
+    repository: rancher/kubectl
     # tests.image.tag -- An image tag for the tests image
-    tag: ""
+    tag: "v1.31.12"
     # tests.image.pullPolicy -- The pull policy for the tests image.
     pullPolicy: Always
 

--- a/stable/vpa/values.yaml
+++ b/stable/vpa/values.yaml
@@ -337,7 +337,7 @@ tests:
       drop:
         - ALL
   image:
-    # tests.image.repository -- An image used for testing containing bash, cat and kubectl
+    # tests.image.repository -- An image used for testing containing sh, cat and kubectl
     repository: rancher/kubectl
     # tests.image.tag -- An image tag for the tests image
     tag: "v1.33.4"


### PR DESCRIPTION
**Why This PR?**
[internal INS-1296] change kubectl image from `bitnami` to `rancher` repository

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
