### PR TITLE
[stable/goldilocks] Bump VPA subchart to 4.8.x (VPA 1.4.x)

### DIFF
--- a/stable/goldilocks/Chart.lock
+++ b/stable/goldilocks/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: vpa
   repository: https://charts.fairwinds.com/stable
-  version: 4.5.0
+  version: 4.8.1
 - name: metrics-server
   repository: https://kubernetes-sigs.github.io/metrics-server/
   version: 3.13.0
-digest: sha256:0f44e79bb3a71a82e2fd4af312f5cc273c8f3540fc3747b6a06ed7c11eb31819
-generated: "2025-08-12T09:35:50.016072-06:00"
+digest: sha256:fee10eb48175073d599cd2d03ab3d3a967a15ce8716f399e097874d35f46c782
+generated: "2025-08-19T19:27:15.417689-04:00"

--- a/stable/goldilocks/Chart.yaml
+++ b/stable/goldilocks/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 appVersion: "v4.14.1"
-version: 10.0.0
+version: 10.1.0
 kubeVersion: ">= 1.22.0-0"
 description: |
   A Helm chart for running Fairwinds Goldilocks. See https://github.com/FairwindsOps/goldilocks
@@ -16,7 +16,7 @@ keywords:
   - kubernetes
 dependencies:
   - name: vpa
-    version: 4.5.*
+    version: 4.8.*
     repository: https://charts.fairwinds.com/stable
     condition: vpa.enabled
   - name: metrics-server


### PR DESCRIPTION
**Why This PR?**
Goldilocks installs VPA via the fairwinds-stable/vpa subchart. The pinned version was referencing VPA 1.0.0. This updates the dependency to a 4.8.x release that packages VPA ~1.4.x.

Change related to #1603

**Changes**

Changes proposed in this pull request:

* Bump vpa dependencies version from `4.5.*` to `4.8.*`
* Bump chart version from `10.0.0` to `10.1.0`
* Regenerate `Chart.lock` 

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [ ] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
