### PR TITLE
[stable/fairwinds-insights] fix default PostgreSQL host in configuration files

### DIFF
--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 4.0.4
+* Fix temporal default postgres host
+
 ## 4.0.3
 * Reverted hook weight
 

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "17.0"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 4.0.3
+version: 4.0.4
 kubeVersion: ">= 1.22.0-0"
 maintainers:
   - name: rbren

--- a/stable/fairwinds-insights/README.md
+++ b/stable/fairwinds-insights/README.md
@@ -313,7 +313,7 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | temporal.server.config.persistence.default.driver | string | `"sql"` |  |
 | temporal.server.config.persistence.default.sql.driver | string | `"postgres12"` |  |
 | temporal.server.config.persistence.default.sql.database | string | `"temporal"` |  |
-| temporal.server.config.persistence.default.sql.host | string | `"insights-postgresql"` |  |
+| temporal.server.config.persistence.default.sql.host | string | `"insights-postgres-rw"` |  |
 | temporal.server.config.persistence.default.sql.port | int | `5432` |  |
 | temporal.server.config.persistence.default.sql.user | string | `"postgres"` |  |
 | temporal.server.config.persistence.default.sql.existingSecret | string | `"fwinsights-postgresql"` |  |
@@ -327,7 +327,7 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | temporal.server.config.persistence.visibility.driver | string | `"sql"` |  |
 | temporal.server.config.persistence.visibility.sql.driver | string | `"postgres12"` |  |
 | temporal.server.config.persistence.visibility.sql.database | string | `"temporal_visibility"` |  |
-| temporal.server.config.persistence.visibility.sql.host | string | `"insights-postgresql"` |  |
+| temporal.server.config.persistence.visibility.sql.host | string | `"insights-postgres-rw"` |  |
 | temporal.server.config.persistence.visibility.sql.port | int | `5432` |  |
 | temporal.server.config.persistence.visibility.sql.user | string | `"postgres"` |  |
 | temporal.server.config.persistence.visibility.sql.existingSecret | string | `"fwinsights-postgresql"` |  |

--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -848,7 +848,7 @@ temporal:
           sql:
             driver: "postgres12"
             database: temporal
-            host: insights-postgresql
+            host: insights-postgres-rw
             port: 5432
             user: postgres
             existingSecret: fwinsights-postgresql
@@ -869,7 +869,7 @@ temporal:
           sql:
             driver: "postgres12"
             database: temporal_visibility
-            host: insights-postgresql
+            host: insights-postgres-rw
             port: 5432
             user: postgres
             existingSecret: fwinsights-postgresql


### PR DESCRIPTION
**Why This PR?**
fix default PostgreSQL host in configuration files
internal INS-1342

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
