### PR TITLE
update supported k8s versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,38 +131,26 @@ workflows:
       - lint-scripts
       - lint-charts
       - rok8s/kubernetes_e2e_tests:
-          name: "End-To-End Kubernetes 1.27"
-          kind_node_image: "kindest/node:v1.27.16@sha256:2d21a61643eafc439905e18705b8186f3296384750a835ad7a005dceb9546d20"
-          executor:
-            name: ci-images-xlarge
-          <<: *kind_configuration_helm3
-      - rok8s/kubernetes_e2e_tests:
-          name: "End-To-End Kubernetes 1.28"
-          kind_node_image: "kindest/node:v1.28.15@sha256:a7c05c7ae043a0b8c818f5a06188bc2c4098f6cb59ca7d1856df00375d839251"
-          executor:
-            name: ci-images-xlarge
-          <<: *kind_configuration_helm3
-      - rok8s/kubernetes_e2e_tests:
-          name: "End-To-End Kubernetes 1.29"
-          kind_node_image: "kindest/node:v1.29.14@sha256:8703bd94ee24e51b778d5556ae310c6c0fa67d761fae6379c8e0bb480e6fea29"
-          executor:
-            name: ci-images-xlarge
-          <<: *kind_configuration_helm3
-      - rok8s/kubernetes_e2e_tests:
           name: "End-To-End Kubernetes 1.30"
-          kind_node_image: "kindest/node:v1.30.10@sha256:4de75d0e82481ea846c0ed1de86328d821c1e6a6a91ac37bf804e5313670e507"
+          kind_node_image: "kindest/node:v1.30.13@sha256:397209b3d947d154f6641f2d0ce8d473732bd91c87d9575ade99049aa33cd648"
           executor:
             name: ci-images-xlarge
           <<: *kind_configuration_helm3
       - rok8s/kubernetes_e2e_tests:
           name: "End-To-End Kubernetes 1.31"
-          kind_node_image: "kindest/node:v1.31.6@sha256:28b7cbb993dfe093c76641a0c95807637213c9109b761f1d422c2400e22b8e87"
+          kind_node_image: "kindest/node:v1.31.12@sha256:0f5cc49c5e73c0c2bb6e2df56e7df189240d83cf94edfa30946482eb08ec57d2"
           executor:
             name: ci-images-xlarge
           <<: *kind_configuration_helm3
       - rok8s/kubernetes_e2e_tests:
           name: "End-To-End Kubernetes 1.32"
-          kind_node_image: "kindest/node:v1.32.3@sha256:b36e76b4ad37b88539ce5e07425f77b29f73a8eaaebf3f1a8bc9c764401d118c"
+          kind_node_image: "kindest/node:v1.32.8@sha256:abd489f042d2b644e2d033f5c2d900bc707798d075e8186cb65e3f1367a9d5a1"
+          executor:
+            name: ci-images-xlarge
+          <<: *kind_configuration_helm3
+      - rok8s/kubernetes_e2e_tests:
+          name: "End-To-End Kubernetes 1.33"
+          kind_node_image: "kindest/node:v1.33.4@sha256:25a6018e48dfcaee478f4a59af81157a437f15e6e140bf103f85a2e7cd0cbbf2"
           executor:
             name: ci-images-xlarge
           <<: *kind_configuration_helm3


### PR DESCRIPTION
**Why This PR?**
- Remove k8s unsupported versions
- Add new k8s versions
- Use the latest 4 versions 1.30~1.33

Fixes #

**Changes**
Changes proposed in this pull request:
- Update k8s versions

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
