### PR TITLE
[stable/fairwinds-insights] INS-1357: Failed to create modcache index dir: mkdir /.cache: read-only file system

### DIFF
--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 4.0.5
+* Fixed go 1.25 cache diretory
+
 ## 4.0.4
 * Fix temporal default postgres host
 

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "17.0"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 4.0.4
+version: 4.0.5
 kubeVersion: ">= 1.22.0-0"
 maintainers:
   - name: rbren

--- a/stable/fairwinds-insights/templates/_env.yaml
+++ b/stable/fairwinds-insights/templates/_env.yaml
@@ -211,10 +211,4 @@ env:
 - name: CRON_JOB_IMAGE_TAG
   value: {{ include "fairwinds-insights.cronjobImageTag" $ | quote }}
 
-# Go environment variables for read-only filesystem compatibility
-- name: GOCACHE
-  value: /.cache/go-build
-- name: GOMODCACHE
-  value: /.cache/go-mod
-
 {{ end }}

--- a/stable/fairwinds-insights/templates/_env.yaml
+++ b/stable/fairwinds-insights/templates/_env.yaml
@@ -211,4 +211,10 @@ env:
 - name: CRON_JOB_IMAGE_TAG
   value: {{ include "fairwinds-insights.cronjobImageTag" $ | quote }}
 
+# Go environment variables for read-only filesystem compatibility
+- name: GOCACHE
+  value: /tmp/go-build-cache
+- name: GOMODCACHE
+  value: /tmp/go-mod-cache
+
 {{ end }}

--- a/stable/fairwinds-insights/templates/_env.yaml
+++ b/stable/fairwinds-insights/templates/_env.yaml
@@ -213,8 +213,8 @@ env:
 
 # Go environment variables for read-only filesystem compatibility
 - name: GOCACHE
-  value: /tmp/go-build-cache
+  value: /.cache/go-build
 - name: GOMODCACHE
-  value: /tmp/go-mod-cache
+  value: /.cache/go-mod
 
 {{ end }}

--- a/stable/fairwinds-insights/templates/deployment-api.yaml
+++ b/stable/fairwinds-insights/templates/deployment-api.yaml
@@ -56,6 +56,8 @@ spec:
           volumeMounts:
           - name: tmp
             mountPath: /tmp
+          - name: go-cache
+            mountPath: /.cache
           - name: go-build-cache
             mountPath: /.cache/go-build
           - name: go-mod-cache
@@ -83,6 +85,8 @@ spec:
       {{- end }}
       volumes:
       - name: tmp
+        emptyDir: {}
+      - name: go-cache
         emptyDir: {}
       - name: go-build-cache
         emptyDir: {}

--- a/stable/fairwinds-insights/templates/deployment-api.yaml
+++ b/stable/fairwinds-insights/templates/deployment-api.yaml
@@ -56,6 +56,10 @@ spec:
           volumeMounts:
           - name: tmp
             mountPath: /tmp
+          - name: go-build-cache
+            mountPath: /tmp/go-build-cache
+          - name: go-mod-cache
+            mountPath: /tmp/go-mod-cache
           - name: secrets
             mountPath: /var/run/secrets/github
           {{- if .Values.selfHostedSecret }}
@@ -79,6 +83,10 @@ spec:
       {{- end }}
       volumes:
       - name: tmp
+        emptyDir: {}
+      - name: go-build-cache
+        emptyDir: {}
+      - name: go-mod-cache
         emptyDir: {}
       - name: secrets
         secret:

--- a/stable/fairwinds-insights/templates/deployment-api.yaml
+++ b/stable/fairwinds-insights/templates/deployment-api.yaml
@@ -58,6 +58,12 @@ spec:
             mountPath: /tmp
           - name: go-cache
             mountPath: /.cache
+          - name: go-build-cache
+            mountPath: /.cache/go-build
+          - name: go-mod-cache
+            mountPath: /.cache/go-mod
+          - name: goimports-cache
+            mountPath: /.cache/goimports
           - name: secrets
             mountPath: /var/run/secrets/github
           {{- if .Values.selfHostedSecret }}
@@ -83,6 +89,12 @@ spec:
       - name: tmp
         emptyDir: {}
       - name: go-cache
+        emptyDir: {}
+      - name: go-build-cache
+        emptyDir: {}
+      - name: go-mod-cache
+        emptyDir: {}
+      - name: goimports-cache
         emptyDir: {}
       - name: secrets
         secret:

--- a/stable/fairwinds-insights/templates/deployment-api.yaml
+++ b/stable/fairwinds-insights/templates/deployment-api.yaml
@@ -58,10 +58,6 @@ spec:
             mountPath: /tmp
           - name: go-cache
             mountPath: /.cache
-          - name: go-build-cache
-            mountPath: /.cache/go-build
-          - name: go-mod-cache
-            mountPath: /.cache/go-mod
           - name: secrets
             mountPath: /var/run/secrets/github
           {{- if .Values.selfHostedSecret }}
@@ -87,10 +83,6 @@ spec:
       - name: tmp
         emptyDir: {}
       - name: go-cache
-        emptyDir: {}
-      - name: go-build-cache
-        emptyDir: {}
-      - name: go-mod-cache
         emptyDir: {}
       - name: secrets
         secret:

--- a/stable/fairwinds-insights/templates/deployment-api.yaml
+++ b/stable/fairwinds-insights/templates/deployment-api.yaml
@@ -58,12 +58,6 @@ spec:
             mountPath: /tmp
           - name: go-cache
             mountPath: /.cache
-          - name: go-build-cache
-            mountPath: /.cache/go-build
-          - name: go-mod-cache
-            mountPath: /.cache/go-mod
-          - name: goimports-cache
-            mountPath: /.cache/goimports
           - name: secrets
             mountPath: /var/run/secrets/github
           {{- if .Values.selfHostedSecret }}
@@ -89,12 +83,6 @@ spec:
       - name: tmp
         emptyDir: {}
       - name: go-cache
-        emptyDir: {}
-      - name: go-build-cache
-        emptyDir: {}
-      - name: go-mod-cache
-        emptyDir: {}
-      - name: goimports-cache
         emptyDir: {}
       - name: secrets
         secret:

--- a/stable/fairwinds-insights/templates/deployment-api.yaml
+++ b/stable/fairwinds-insights/templates/deployment-api.yaml
@@ -57,9 +57,9 @@ spec:
           - name: tmp
             mountPath: /tmp
           - name: go-build-cache
-            mountPath: /tmp/go-build-cache
+            mountPath: /.cache/go-build
           - name: go-mod-cache
-            mountPath: /tmp/go-mod-cache
+            mountPath: /.cache/go-mod
           - name: secrets
             mountPath: /var/run/secrets/github
           {{- if .Values.selfHostedSecret }}


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
