### PR TITLE
[stable/insights-agent] INS-1763: charts: add support for prometheus token and tenant ID params

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 5.3.1
+* Added multi-tenant Prometheus support (Grafana Mimir) with `tenantId` configuration
+
 ## 5.3.0
 * Upgraded all plugins to the latest versions with Kubernetes client libraries v0.35.0
 

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 5.3.0
+version: 5.3.1
 appVersion: 9.2.1
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png

--- a/stable/insights-agent/README.md
+++ b/stable/insights-agent/README.md
@@ -127,6 +127,10 @@ Parameter | Description | Default
 `goldilocks.dashboard.enabled` | Installs the Goldilocks Dashboard | false
 `prometheus-metrics.installPrometheusServer` | Install a new Prometheus server instance for the prometheus report | false
 `prometheus-metrics.address` | The address of an existing Prometheus instance to query in the form `<scheme>://<service-name>.<namespace>[:<port>]` for example `http://prometheus-server.prometheus` | `"http://prometheus-server"`
+`prometheus-metrics.bearerToken` | Bearer token for Prometheus authentication (not recommended for production, use bearerTokenSecretName instead) | `""`
+`prometheus-metrics.bearerTokenSecretName` | Name of an existing Secret containing the bearer token for Prometheus authentication | `""`
+`prometheus-metrics.bearerTokenSecretKey` | Key within the secret containing the bearer token | `"token"`
+`prometheus-metrics.tenantId` | Tenant ID for multi-tenant Prometheus backends like Grafana Mimir (sets `X-Scope-OrgID` header) | `""`
 `nova.logLevel` | The klog log-level to use when running Nova | `3`
 `pluto.targetVersions` | The versions to target, e.g. `k8s=1.21.0` | Defaults to current Kubernetes version
 `awscosts.secretName` | Kubernetes Secret name where AWS creds will be stored | ""

--- a/stable/insights-agent/templates/prometheus-metrics/cronjob.yaml
+++ b/stable/insights-agent/templates/prometheus-metrics/cronjob.yaml
@@ -27,6 +27,20 @@ spec:
               value: {{ (index .Values "prometheus-metrics"  "skipNonZeroMetricsCheck") | quote }}
             - name: SKIP_KSM_NON_ZERO_METRICS_CHECK
               value: {{ (index .Values "prometheus-metrics"  "sKipKsmNonZeroMetricsCheck") | quote }}
+            {{- if (index .Values "prometheus-metrics" "bearerTokenSecretName") }}
+            - name: PROMETHEUS_BEARER_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ (index .Values "prometheus-metrics" "bearerTokenSecretName") }}
+                  key: {{ (index .Values "prometheus-metrics" "bearerTokenSecretKey") | default "token" }}
+            {{- else if (index .Values "prometheus-metrics" "bearerToken") }}
+            - name: PROMETHEUS_BEARER_TOKEN
+              value: {{ (index .Values "prometheus-metrics" "bearerToken") | quote }}
+            {{- end }}
+            {{- if (index .Values "prometheus-metrics" "tenantId") }}
+            - name: PROMETHEUS_TENANT_ID
+              value: {{ (index .Values "prometheus-metrics" "tenantId") | quote }}
+            {{- end }}
             {{ include "proxy-env-spec" . | indent 12 | trim }}
             {{ include "security-context" . | indent 12 | trim }}
           {{ include "uploaderContainer" . | indent 10 | trim }}

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -333,6 +333,13 @@ prometheus-metrics:
   managedPrometheusClusterName: ""
   skipNonZeroMetricsCheck: false
   sKipKsmNonZeroMetricsCheck: true
+  # Bearer token for authentication (for Mimir or other secured backends)
+  # Use bearerTokenSecretName for production instead of inline bearerToken
+  bearerToken: ""
+  bearerTokenSecretName: ""
+  bearerTokenSecretKey: "token"
+  # Tenant ID for multi-tenant backends like Grafana Mimir (sets X-Scope-OrgID header)
+  tenantId: ""
   image:
     repository: quay.io/fairwinds/prometheus-collector
     tag: "1.6"


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
