### PR TITLE
INS-1793: Add support to GPU utilization exporter in charts

### DIFF
--- a/scripts/ct.yaml
+++ b/scripts/ct.yaml
@@ -14,3 +14,5 @@ chart-repos:
   - "metrics-server=https://kubernetes-sigs.github.io/metrics-server"
   - "temporal=https://go.temporal.io/helm-charts"
   - "aquasecurity=https://aquasecurity.github.io/helm-charts"
+  - "nvidia=https://nvidia.github.io/dcgm-exporter/helm-charts"
+  - "rocm=https://rocm.github.io/device-metrics-exporter"

--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# 5.4.0
+* Support to collect GPU utilization
+
 ## 5.3.2
 * Bumped prometheus plugin to 1.7
 

--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-# 5.4.0
+## 5.4.0
 * Support to collect GPU utilization
 
 ## 5.3.2

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 5.3.2
+version: 5.4.0
 appVersion: 9.2.1
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png

--- a/stable/insights-agent/requirements.yaml
+++ b/stable/insights-agent/requirements.yaml
@@ -26,3 +26,12 @@ dependencies:
   repository: https://aquasecurity.github.io/helm-charts/
   condition: trivy.server.installTrivyServer
   alias: trivy-server
+- name: dcgm-exporter
+  version: '3.6.*'
+  repository: https://nvidia.github.io/dcgm-exporter/helm-charts
+  condition: dcgm-exporter.enabled
+- name: device-metrics-exporter
+  version: '1.*'
+  repository: https://rocm.github.io/device-metrics-exporter
+  condition: amd-device-metrics-exporter.enabled
+  alias: amd-device-metrics-exporter

--- a/stable/insights-agent/requirements.yaml
+++ b/stable/insights-agent/requirements.yaml
@@ -27,11 +27,11 @@ dependencies:
   condition: trivy.server.installTrivyServer
   alias: trivy-server
 - name: dcgm-exporter
-  version: '3.6.*'
+  version: '4.7.*'
   repository: https://nvidia.github.io/dcgm-exporter/helm-charts
   condition: dcgm-exporter.enabled
 - name: device-metrics-exporter-charts
-  version: '1.*'
+  version: '1.4.*'
   repository: https://rocm.github.io/device-metrics-exporter
   condition: amd-device-metrics-exporter.enabled
   alias: amd-device-metrics-exporter

--- a/stable/insights-agent/requirements.yaml
+++ b/stable/insights-agent/requirements.yaml
@@ -30,7 +30,7 @@ dependencies:
   version: '3.6.*'
   repository: https://nvidia.github.io/dcgm-exporter/helm-charts
   condition: dcgm-exporter.enabled
-- name: device-metrics-exporter
+- name: device-metrics-exporter-charts
   version: '1.*'
   repository: https://rocm.github.io/device-metrics-exporter
   condition: amd-device-metrics-exporter.enabled

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -349,6 +349,11 @@ prometheus-metrics:
       memory: 128Mi
   serviceAccount:
     annotations:
+  # GPU Metrics: GPU requests/limits are collected automatically via kube-state-metrics.
+  # For GPU utilization metrics, install the appropriate vendor exporter:
+  #   - NVIDIA: Enable dcgm-exporter (see below) or install DCGM Exporter separately
+  #   - AMD: Install AMD SMI Exporter (amd_smi_utilization_percentage metric)
+  #   - Intel: Install Intel GPU Plugin (intel_gpu_engine_render_active metric)
 
 prometheus:
   kubeStateMetrics:
@@ -395,6 +400,71 @@ prometheus:
       capabilities:
         drop:
           - ALL
+
+# GPU Metrics Support
+# -------------------
+# Insights supports GPU metrics from multiple vendors:
+#
+# Supported GPU/Accelerator Resource Types (via kube-state-metrics):
+#   - nvidia.com/gpu, nvidia.com/gpu.shared (NVIDIA, including time-sliced)
+#   - amd.com/gpu (AMD)
+#   - intel.com/gpu (Intel)
+#   - habana.ai/gaudi (Intel Habana Gaudi)
+#   - k8s.amazonaws.com/vgpu (AWS vGPU)
+#   - google.com/tpu (Google TPU)
+#
+# GPU Utilization Metrics (requires vendor-specific exporter):
+#   - NVIDIA: DCGM Exporter (DCGM_FI_DEV_GPU_UTIL)
+#   - AMD: AMD SMI Exporter (amd_smi_utilization_percentage)
+#   - Intel: Intel GPU Plugin (intel_gpu_engine_render_active)
+#
+# GPU requests/limits are collected automatically from kube-state-metrics.
+# GPU utilization requires the appropriate vendor exporter to be installed.
+
+# NVIDIA DCGM Exporter for GPU utilization metrics
+# See: https://nvidia.github.io/dcgm-exporter/
+dcgm-exporter:
+  # dcgm-exporter.enabled -- Enable NVIDIA DCGM Exporter for GPU utilization metrics.
+  # Only enable on clusters with NVIDIA GPUs.
+  enabled: false
+  # dcgm-exporter.serviceMonitor -- Enable ServiceMonitor for Prometheus Operator.
+  # If using the bundled prometheus server, set to false.
+  serviceMonitor:
+    enabled: false
+  # dcgm-exporter.arguments -- Command line arguments for dcgm-exporter
+  arguments:
+    - "-f"
+    - "/etc/dcgm-exporter/dcp-metrics-included.csv"
+  # dcgm-exporter.resources -- Resource requests and limits
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+# AMD ROCm Device Metrics Exporter for GPU utilization metrics
+# See: https://github.com/ROCm/device-metrics-exporter
+amd-device-metrics-exporter:
+  # amd-device-metrics-exporter.enabled -- Enable AMD Device Metrics Exporter for GPU utilization metrics.
+  # Only enable on clusters with AMD GPUs (MI200, MI300, etc.)
+  enabled: false
+  # amd-device-metrics-exporter.resources -- Resource requests and limits
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+# Intel GPU Metrics
+# -----------------
+# Intel does not provide an official standalone Prometheus exporter helm chart.
+# For Intel GPU metrics, install Intel XPU Manager or Intel GPU Plugin separately.
+# The prometheus-collector will scrape intel_gpu_engine_render_active metrics
+# if available from your Intel GPU monitoring solution.
 
 admission:
   enabled: false

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -431,6 +431,12 @@ dcgm-exporter:
   # If using the bundled prometheus server, set to false.
   serviceMonitor:
     enabled: false
+  # dcgm-exporter.service -- Service configuration for DCGM Exporter
+  service:
+    # dcgm-exporter.service.annotations -- Annotations for Prometheus auto-discovery
+    annotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "9400"
   # dcgm-exporter.arguments -- Command line arguments for dcgm-exporter
   arguments:
     - "-f"
@@ -450,6 +456,12 @@ amd-device-metrics-exporter:
   # amd-device-metrics-exporter.enabled -- Enable AMD Device Metrics Exporter for GPU utilization metrics.
   # Only enable on clusters with AMD GPUs (MI200, MI300, etc.)
   enabled: false
+  # amd-device-metrics-exporter.service -- Service configuration for AMD Device Metrics Exporter
+  service:
+    # amd-device-metrics-exporter.service.annotations -- Annotations for Prometheus auto-discovery
+    annotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "5000"
   # amd-device-metrics-exporter.resources -- Resource requests and limits
   resources:
     requests:


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
