### PR TITLE
[stable/insights-agent]  INS-1834: insights agent should support Workload Identity for Azure

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 5.4.3
+* Azure cloud costs to support Workload Identity
+
 ## 5.4.2
 * Cloud-costs: add Azure provider support (subscription + Service Principal credentials via secret)
 * Cloud-costs: add FOCUS format option for AWS/GCP (`cloudcosts.format`, `cloudcosts.gcp.focusview`)

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 5.4.2
+version: 5.4.3
 appVersion: 9.2.1
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png

--- a/stable/insights-agent/README.md
+++ b/stable/insights-agent/README.md
@@ -135,7 +135,7 @@ Parameter | Description | Default
 `pluto.targetVersions` | The versions to target, e.g. `k8s=1.21.0` | Defaults to current Kubernetes version
 `cloudcosts.enabled` | Enable the cloud-costs report (AWS, GCP, or Azure) | false
 `cloudcosts.provider` | Cloud provider: `aws`, `gcp`, or `azure` | aws
-`cloudcosts.secretName` | Kubernetes Secret name for provider credentials | ""
+`cloudcosts.secretName` | Kubernetes Secret name for provider credentials (AWS only; Azure uses Workload Identity, no secret) | ""
 `cloudcosts.tagkey` | Tag key to filter resources (e.g. kubernetes-cluster) | ""
 `cloudcosts.tagvalue` | Tag value to filter resources | ""
 `cloudcosts.format` | Output format: `standard` or `focus` (AWS/GCP only; Azure always uses FOCUS) | standard
@@ -152,9 +152,8 @@ Parameter | Description | Default
 `cloudcosts.gcp.table` | BigQuery table path (optional) | ""
 `cloudcosts.gcp.focusview` | BigQuery FOCUS view name (required when format is focus) | ""
 `cloudcosts.azure.subscription` | Azure subscription ID (required when provider is azure) | ""
-`cloudcosts.azure.clientId` | Azure Service Principal client ID (optional; or use existing secret) | ""
-`cloudcosts.azure.clientSecret` | Azure Service Principal client secret | ""
-`cloudcosts.azure.tenantId` | Azure tenant ID | ""
+`cloudcosts.azure.workloadIdentity.clientId` | Azure AD Workload Identity: client ID of the Azure AD app or user-assigned managed identity (required when provider is azure) | ""
+`cloudcosts.azure.workloadIdentity.tenantId` | Azure AD Workload Identity: tenant ID (optional; webhook can infer from cluster) | ""
 `cloudcosts.serviceAccount.annotations` | Annotations for the cloud-costs service account, e.g. `eks.amazonaws.com/role-arn` for IRSA (AWS) | nil
 `insights-event-watcher.enabled` | Enable the insights-event-watcher component | `true`
 `insights-event-watcher.image.repository` | Repository for the insights-event-watcher image | `quay.io/fairwinds/insights-event-watcher`

--- a/stable/insights-agent/ci/test-values.yaml
+++ b/stable/insights-agent/ci/test-values.yaml
@@ -157,10 +157,13 @@ cloudcosts:
     table: fairwinds_insights_cur_report
     catalog: AwsDataCatalog
     workgroup: cur_athena_workgroup
-  # Example for Azure (use existing secret with AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, AZURE_TENANT_ID, or set clientId/clientSecret/tenantId):
+  # Example for Azure (Azure AD Workload Identity; cluster must have workload identity and federated credential):
   # provider: azure
   # azure:
   #   subscription: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+  #   workloadIdentity:
+  #     clientId: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+  #     tenantId: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
   # Example for GCP FOCUS format:
   # provider: gcp
   # format: focus

--- a/stable/insights-agent/templates/_specs.yaml
+++ b/stable/insights-agent/templates/_specs.yaml
@@ -53,6 +53,9 @@ metadata:
     {{- with .Config.jobLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+    {{- if and (eq .Label "cloudcosts") (eq .Config.provider "azure") }}
+    azure.workload.identity/use: "true"
+    {{- end }}
     app.kubernetes.io/name: {{ .Label }}
     app.kubernetes.io/part-of: {{ include "insights-agent.fullname" . }}
   annotations:

--- a/stable/insights-agent/templates/cloud-costs/cronjob.yaml
+++ b/stable/insights-agent/templates/cloud-costs/cronjob.yaml
@@ -21,39 +21,6 @@ spec:
           - name: creds
             emptyDir: {}
           {{- end }}
-          {{- if eq .Values.cloudcosts.provider "azure" }}
-          - name: azureconfig
-            emptyDir: {}
-          {{- end }}
-          {{- if eq .Values.cloudcosts.provider "azure" }}
-          initContainers:
-          - name: azure-login
-            image: "{{ .Values.cloudcosts.image.repository }}:{{ .Values.cloudcosts.image.tag }}"
-            env:
-            - name: AZURE_CLIENT_ID
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.cloudcosts.secretName }}
-                  key: AZURE_CLIENT_ID
-            - name: AZURE_CLIENT_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.cloudcosts.secretName }}
-                  key: AZURE_CLIENT_SECRET
-            - name: AZURE_TENANT_ID
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.cloudcosts.secretName }}
-                  key: AZURE_TENANT_ID
-            volumeMounts:
-            - name: azureconfig
-              mountPath: /azureconfig
-            command: ["/bin/sh", "-ec"]
-            args:
-              - |
-                export AZURE_CONFIG_DIR=/azureconfig
-                az login --service-principal -u "$AZURE_CLIENT_ID" -p "$AZURE_CLIENT_SECRET" --tenant "$AZURE_TENANT_ID"
-          {{- end }}
           containers:
           - {{ include "container-spec" . | indent 12 | trim }}
             {{- if eq .Values.cloudcosts.provider "aws" }}
@@ -141,26 +108,7 @@ spec:
             {{- end }}
           {{- if eq .Values.cloudcosts.provider "azure" }}
           {{- $azure := .Values.cloudcosts.azure | default dict }}
-            - name: azureconfig
-              mountPath: /azureconfig
             env:
-            - name: AZURE_CONFIG_DIR
-              value: /azureconfig
-            - name: AZURE_CLIENT_ID
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.cloudcosts.secretName }}
-                  key: AZURE_CLIENT_ID
-            - name: AZURE_CLIENT_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.cloudcosts.secretName }}
-                  key: AZURE_CLIENT_SECRET
-            - name: AZURE_TENANT_ID
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.cloudcosts.secretName }}
-                  key: AZURE_TENANT_ID
             {{ include "proxy-env-spec" . | indent 12 | trim }}
             command: ["./cloud-costs.sh"]
             args:

--- a/stable/insights-agent/templates/cloud-costs/rbac.yaml
+++ b/stable/insights-agent/templates/cloud-costs/rbac.yaml
@@ -5,8 +5,15 @@ metadata:
   name: {{ include "insights-agent.fullname" . }}-cloudcosts
   labels:
     app: insights-agent
-  {{- with .Values.cloudcosts.serviceAccount.annotations }}
   annotations:
+    {{- with .Values.cloudcosts.serviceAccount.annotations }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- end }}
+    {{- if eq .Values.cloudcosts.provider "azure" }}
+    {{- $wi := .Values.cloudcosts.azure.workloadIdentity | default dict }}
+    azure.workload.identity/client-id: {{ required "cloudcosts.azure.workloadIdentity.clientId is required when provider is azure" $wi.clientId }}
+    {{- if $wi.tenantId }}
+    azure.workload.identity/tenant-id: {{ $wi.tenantId }}
+    {{- end }}
+    {{- end }}
 {{- end -}}

--- a/stable/insights-agent/templates/cloud-costs/secret.yaml
+++ b/stable/insights-agent/templates/cloud-costs/secret.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.cloudcosts .Values.cloudcosts.enabled -}}
-{{- if .Values.cloudcosts.aws -}}
+{{- if eq .Values.cloudcosts.provider "aws" -}}
 {{- if .Values.cloudcosts.aws.accessKeyId }}
 apiVersion: v1
 kind: Secret
@@ -9,27 +9,6 @@ type: Opaque
 data:
   AWS_ACCESS_KEY_ID: {{ .Values.cloudcosts.aws.accessKeyId | b64enc }}
   AWS_SECRET_ACCESS_KEY: {{ .Values.cloudcosts.aws.secretAccessKey | b64enc }}
-  {{- if .Values.cloudcosts.azure }}
-  {{- if and .Values.cloudcosts.azure.clientId .Values.cloudcosts.azure.clientSecret .Values.cloudcosts.azure.tenantId }}
-  AZURE_CLIENT_ID: {{ .Values.cloudcosts.azure.clientId | b64enc }}
-  AZURE_CLIENT_SECRET: {{ .Values.cloudcosts.azure.clientSecret | b64enc }}
-  AZURE_TENANT_ID: {{ .Values.cloudcosts.azure.tenantId | b64enc }}
-  {{- end }}
-  {{- end }}
-{{- end }}
-{{- else -}}
-{{- if .Values.cloudcosts.azure }}
-{{- if and .Values.cloudcosts.azure.clientId .Values.cloudcosts.azure.clientSecret .Values.cloudcosts.azure.tenantId }}
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ .Values.cloudcosts.secretName }}
-type: Opaque
-data:
-  AZURE_CLIENT_ID: {{ .Values.cloudcosts.azure.clientId | b64enc }}
-  AZURE_CLIENT_SECRET: {{ .Values.cloudcosts.azure.clientSecret | b64enc }}
-  AZURE_TENANT_ID: {{ .Values.cloudcosts.azure.tenantId | b64enc }}
-{{- end }}
 {{- end }}
 {{- end }}
 {{- end -}}

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -539,10 +539,11 @@ cloudcosts:
   azure:
     # subscription: Azure subscription ID (required when provider is azure)
     subscription: ""
-    # Optional: set clientId, clientSecret, tenantId to create a secret; otherwise use existing secret with keys AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, AZURE_TENANT_ID
-    clientId: ""
-    clientSecret: ""
-    tenantId: ""
+    # Workload Identity: Azure AD app (or user-assigned managed identity) client ID and tenant ID.
+    # Cluster must have Azure AD Workload Identity (e.g. AKS workload identity) and federated credential configured.
+    workloadIdentity:
+      clientId: ""   # required when provider is azure
+      tenantId: ""   # optional; webhook can infer from cluster
   schedule: "rand * * * *"
   timeout: 300
   image:


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
