### PR TITLE
INS-1863 - run migration post installation on any ephemeral env. 

### DIFF
--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 5.5.0
 * Fixed migration running before Timescale subchart when `timescale.ephemeral` is true; migration now runs post-install/post-upgrade in that case.
 * Added `dbMigration.overrideHook` to control the Helm hook: `""` (default, no override), `none` (no hook, run as normal Job), or comma-separated values (post-install, post-upgrade, pre-install, pre-upgrade).
+* Added `init-container` for `migrate-db-job` that tests the database connection before running the migration, this avoids backoffLimit being reached before the database is fully setup
 
 ## 5.4.7
 * Remove HubSpot integration (`cronjobs.hubspot`)

--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
 ## 5.5.0
-* Added `dbMigration.disableHook` (default `false`) to run database migration as a normal Job instead of a Helm hook.
 * Fixed migration running before Timescale subchart when `timescale.ephemeral` is true; migration now runs post-install/post-upgrade in that case.
+* Added `dbMigration.overrideHook` to control the Helm hook: `""` (default, no override), `none` (no hook, run as normal Job), or comma-separated values (post-install, post-upgrade, pre-install, pre-upgrade).
 
 ## 5.4.6
 * Bump insights-agent version to `5.3.0`

--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 5.5.0
+* Added `dbMigration.disableHook` (default `false`) to run database migration as a normal Job instead of a Helm hook.
+* Fixed migration running before Timescale subchart when `timescale.ephemeral` is true; migration now runs post-install/post-upgrade in that case.
+
 ## 5.4.6
 * Bump insights-agent version to `5.3.0`
 

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "18.2"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 5.4.6
+version: 5.5.0
 kubeVersion: ">= 1.22.0-0"
 maintainers:
   - name: rbren

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "18.2"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 5.5.0
+version: 5.6.0
 kubeVersion: ">= 1.22.0-0"
 maintainers:
   - name: rbren

--- a/stable/fairwinds-insights/README.md
+++ b/stable/fairwinds-insights/README.md
@@ -132,6 +132,7 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | openApi.topologySpreadConstraints[1].labelSelector.matchLabels."app.kubernetes.io/name" | string | `"fairwinds-insights"` |  |
 | openApi.ingress.enabled | bool | `true` | Enable the Open API ingress |
 | openApi.service.type | string | `nil` | Service type for Open API server |
+| dbMigration.disableHook | bool | `false` | Disable the hook for the database migration job. Set to true to disable the hook. |
 | dbMigration.resources | object | `{"limits":{"cpu":1,"memory":"1024Mi"},"requests":{"cpu":"80m","memory":"128Mi"}}` | Resources for the database migration job. |
 | dbMigration.securityContext.runAsUser | int | `10324` | The user ID to run the database migration job under. |
 | oneTimeMigration.resources | object | `{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"256Mi"}}` | Resources for the one time migration job. |

--- a/stable/fairwinds-insights/README.md
+++ b/stable/fairwinds-insights/README.md
@@ -132,6 +132,7 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | openApi.ingress.enabled | bool | `true` | Enable the Open API ingress |
 | openApi.service.type | string | `nil` | Service type for Open API server |
 | dbMigration.overrideHook | string | `""` | Override the Helm hook for the database migration job. Values: "" (no override, use default based on ephemeral/postMigrate config), "none" (no hook - run as normal Job), or one of: post-install, post-upgrade, pre-install, pre-upgrade (comma-separated for multiple). |
+| dbMigration.waitTimeout | int | `600` | Max seconds to wait for PostgreSQL and Timescale to be ready before migration runs before failing. 0 = no timeout. |
 | dbMigration.resources | object | `{"limits":{"cpu":1,"memory":"1024Mi"},"requests":{"cpu":"80m","memory":"128Mi"}}` | Resources for the database migration job. |
 | dbMigration.securityContext.runAsUser | int | `10324` | The user ID to run the database migration job under. |
 | oneTimeMigration.resources | object | `{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"256Mi"}}` | Resources for the one time migration job. |

--- a/stable/fairwinds-insights/README.md
+++ b/stable/fairwinds-insights/README.md
@@ -132,7 +132,7 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | openApi.topologySpreadConstraints[1].labelSelector.matchLabels."app.kubernetes.io/name" | string | `"fairwinds-insights"` |  |
 | openApi.ingress.enabled | bool | `true` | Enable the Open API ingress |
 | openApi.service.type | string | `nil` | Service type for Open API server |
-| dbMigration.disableHook | bool | `false` | Disable the hook for the database migration job. Set to true to disable the hook. |
+| dbMigration.overrideHook | string | `""` | Override the Helm hook. `""` = no override (default), `none` = no hook (run as normal Job), or comma-separated: post-install, post-upgrade, pre-install, pre-upgrade. |
 | dbMigration.resources | object | `{"limits":{"cpu":1,"memory":"1024Mi"},"requests":{"cpu":"80m","memory":"128Mi"}}` | Resources for the database migration job. |
 | dbMigration.securityContext.runAsUser | int | `10324` | The user ID to run the database migration job under. |
 | oneTimeMigration.resources | object | `{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"256Mi"}}` | Resources for the one time migration job. |

--- a/stable/fairwinds-insights/README.md
+++ b/stable/fairwinds-insights/README.md
@@ -132,7 +132,7 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | openApi.topologySpreadConstraints[1].labelSelector.matchLabels."app.kubernetes.io/name" | string | `"fairwinds-insights"` |  |
 | openApi.ingress.enabled | bool | `true` | Enable the Open API ingress |
 | openApi.service.type | string | `nil` | Service type for Open API server |
-| dbMigration.overrideHook | string | `""` | Override the Helm hook. `""` = no override (default), `none` = no hook (run as normal Job), or comma-separated: post-install, post-upgrade, pre-install, pre-upgrade. |
+| dbMigration.overrideHook | string | `""` | Override the Helm hook for the database migration job. Values: "" (no override, use default based on ephemeral/postMigrate config), "none" (no hook - run as normal Job), or one of: post-install, post-upgrade, pre-install, pre-upgrade (comma-separated for multiple). |
 | dbMigration.resources | object | `{"limits":{"cpu":1,"memory":"1024Mi"},"requests":{"cpu":"80m","memory":"128Mi"}}` | Resources for the database migration job. |
 | dbMigration.securityContext.runAsUser | int | `10324` | The user ID to run the database migration job under. |
 | oneTimeMigration.resources | object | `{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"256Mi"}}` | Resources for the one time migration job. |

--- a/stable/fairwinds-insights/templates/migrate-db-job.yaml
+++ b/stable/fairwinds-insights/templates/migrate-db-job.yaml
@@ -27,6 +27,37 @@ spec:
       imagePullSecrets:
         - name: {{ . }}
       {{- end }}
+      initContainers:
+      - name: wait-for-databases
+        image: postgres:18-alpine
+        command:
+        - sh
+        - -c
+        - |
+          set -e
+          PG_HOST="{{ .Values.postgresql.postgresqlHost | default (printf "%s-%s" .Release.Name "postgresql") }}"
+          PG_PORT="{{ .Values.postgresql.port | default 5432 }}"
+          TS_HOST="{{ .Values.timescale.postgresqlHost | default (printf "%s-%s" .Release.Name "timescale") }}"
+          TS_PORT="{{ .Values.timescale.service.primary.port | default 5433 }}"
+          TIMEOUT="{{ .Values.dbMigration.waitTimeout | default 600 }}"
+          wait_for() {
+            local host=$1 port=$2 name=$3
+            if [ "$TIMEOUT" -eq 0 ]; then
+              echo "Waiting for $name at $host:$port (no timeout)..."
+              until pg_isready -h "$host" -p "$port" 2>/dev/null; do sleep 2; done
+            else
+              MAX_ATTEMPTS=$((TIMEOUT / 2))
+              echo "Waiting for $name at $host:$port (timeout ${TIMEOUT}s)..."
+              for i in $(seq 1 $MAX_ATTEMPTS); do
+                if pg_isready -h "$host" -p "$port" 2>/dev/null; then break; fi
+                if [ $i -eq $MAX_ATTEMPTS ]; then echo "Timeout waiting for $name"; exit 1; fi
+                sleep 2
+              done
+            fi
+            echo "$name is ready"
+          }
+          wait_for "$PG_HOST" "$PG_PORT" "PostgreSQL"
+          wait_for "$TS_HOST" "$TS_PORT" "Timescale"
       containers:
       - name: fwinsights-db-migration
         image: "{{ .Values.migrationImage.repository }}:{{ include "fairwinds-insights.migrationImageTag" . }}"

--- a/stable/fairwinds-insights/templates/migrate-db-job.yaml
+++ b/stable/fairwinds-insights/templates/migrate-db-job.yaml
@@ -29,7 +29,7 @@ spec:
       {{- end }}
       initContainers:
       - name: wait-for-databases
-        image: postgres:18-alpine
+        image: alpine/psql:18.1
         command:
         - sh
         - -c

--- a/stable/fairwinds-insights/templates/migrate-db-job.yaml
+++ b/stable/fairwinds-insights/templates/migrate-db-job.yaml
@@ -4,10 +4,13 @@ metadata:
   name: migrate-database
   annotations:
     "helm.sh/hook-delete-policy": "before-hook-creation"
-  {{- if not (or .Values.postgresql.ephemeral .Values.postgresql.postMigrate) }}
-    "helm.sh/hook": "pre-install,pre-upgrade"
-  {{- else }}
+  {{- $usePostHook := or .Values.postgresql.ephemeral .Values.timescale.ephemeral .Values.postgresql.postMigrate -}}
+  {{- if .Values.dbMigration.disableHook }}
+    {{/* No hook - Job runs as normal resource */}}
+  {{- else if $usePostHook }}
     "helm.sh/hook": "post-install,post-upgrade"
+  {{- else }}
+    "helm.sh/hook": "pre-install,pre-upgrade"
   {{- end }}
   labels:
     {{- include "fairwinds-insights.labels" . | nindent 4 }}

--- a/stable/fairwinds-insights/templates/migrate-db-job.yaml
+++ b/stable/fairwinds-insights/templates/migrate-db-job.yaml
@@ -5,8 +5,10 @@ metadata:
   annotations:
     "helm.sh/hook-delete-policy": "before-hook-creation"
   {{- $usePostHook := or .Values.postgresql.ephemeral .Values.timescale.ephemeral .Values.postgresql.postMigrate -}}
-  {{- if .Values.dbMigration.disableHook }}
+  {{- if eq .Values.dbMigration.overrideHook "none" }}
     {{/* No hook - Job runs as normal resource */}}
+  {{- else if .Values.dbMigration.overrideHook }}
+    "helm.sh/hook": {{ .Values.dbMigration.overrideHook | quote }}
   {{- else if $usePostHook }}
     "helm.sh/hook": "post-install,post-upgrade"
   {{- else }}

--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -424,6 +424,8 @@ openApi:
     type:
 
 dbMigration:
+  # -- Disable the hook for the database migration job. Set to true to disable the hook.
+  disableHook: false
   # -- Resources for the database migration job.
   resources:
     limits:

--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -424,8 +424,10 @@ openApi:
     type:
 
 dbMigration:
-  # -- Disable the hook for the database migration job. Set to true to disable the hook.
-  disableHook: false
+  # -- Override the Helm hook for the database migration job.
+  # Values: "" (no override, use default based on ephemeral/postMigrate config), "none" (no hook - run as normal Job),
+  # or one of: post-install, post-upgrade, pre-install, pre-upgrade (comma-separated for multiple).
+  overrideHook: ""
   # -- Resources for the database migration job.
   resources:
     limits:

--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -422,6 +422,8 @@ dbMigration:
   # Values: "" (no override, use default based on ephemeral/postMigrate config), "none" (no hook - run as normal Job),
   # or one of: post-install, post-upgrade, pre-install, pre-upgrade (comma-separated for multiple).
   overrideHook: ""
+  # -- Max seconds to wait for PostgreSQL and Timescale to be ready before migration runs before failing. 0 = no timeout.
+  waitTimeout: 600
   # -- Resources for the database migration job.
   resources:
     limits:


### PR DESCRIPTION
**Why This PR?**
- run migration post installation on any ephemeral env. 
- added `dbMigration.disableHook` to disable hook altogether

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
