### PR TITLE
[stable/fairwinds-insights] Add support for ingress.className

### DIFF
--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 5.5.0
+* Add support for `ingress.className` (default: `""`)
+
 ## 5.4.7
 * Remove HubSpot integration (`cronjobs.hubspot`)
 

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "18.2"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 5.4.7
+version: 5.5.0
 kubeVersion: ">= 1.22.0-0"
 maintainers:
   - name: rbren

--- a/stable/fairwinds-insights/README.md
+++ b/stable/fairwinds-insights/README.md
@@ -142,6 +142,7 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | sanitizedBranch | string | `nil` | Prefix to use on hostname. Generally not needed. |
 | sanitizedPrefixMaxLength | int | `12` | Maximum length for hostname prefix. |
 | ingress.enabled | bool | `false` | Enable Ingress |
+| ingress.className | string | `""` | Ingress class name (e.g. nginx, traefik). When set, adds spec.ingressClassName to all Ingress resources. |
 | ingress.tls | bool | `true` | Enable TLS |
 | ingress.hostedZones | list | `[]` | Hostnames to use for Ingress |
 | ingress.annotations | object | `{}` | Annotations to add to the API and Dashboard ingresses. |

--- a/stable/fairwinds-insights/templates/ingress.yaml
+++ b/stable/fairwinds-insights/templates/ingress.yaml
@@ -13,6 +13,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{ end }}
 spec:
+{{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className | quote }}
+{{- end }}
 {{- if .Values.ingress.tls }}
   tls:
     - secretName: {{ $fullName }}-cert
@@ -66,6 +69,9 @@ metadata:
     {{ end }}
     {{- end }}
 spec:
+{{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className | quote }}
+{{- end }}
 {{- if .Values.ingress.tls }}
   tls:
     - secretName: {{ $fullName }}-cert
@@ -101,6 +107,9 @@ metadata:
     {{ end }}
     {{- end }}
 spec:
+{{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className | quote }}
+{{- end }}
 {{- if .Values.ingress.tls }}
   tls:
     - secretName: {{ $fullName }}-cert
@@ -142,6 +151,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{ end }}
 spec:
+{{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className | quote }}
+{{- end }}
 {{- if .Values.ingress.tls }}
   tls:
     - secretName: {{ $fullName }}-cert
@@ -202,6 +214,9 @@ metadata:
     {{ end }}
     {{- end }}
 spec:
+{{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className | quote }}
+{{- end }}
 {{- if .Values.ingress.tls }}
   tls:
     - secretName: {{ $fullName }}-cert
@@ -241,6 +256,9 @@ metadata:
     {{ end }}
     {{- end }}
 spec:
+{{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className | quote }}
+{{- end }}
 {{- if .Values.ingress.tls }}
   tls:
     - secretName: {{ $fullName }}-cert

--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -466,6 +466,8 @@ sanitizedPrefixMaxLength: 12
 ingress:
   # -- Enable Ingress
   enabled: false
+  # -- Ingress class name (e.g. nginx, traefik). When set, adds spec.ingressClassName to all Ingress resources.
+  className: ""
   # -- Enable TLS
   tls: true
   # -- Hostnames to use for Ingress


### PR DESCRIPTION
**Why This PR?**
* Add support for `ingress.className`

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
