### PR TITLE
[stable/fairwinds-insights] move config.js to the correct path

### DIFF
--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 5.7.1
+* Move `config.*.js` to the correct path `/static/config.js`
+
 ## 5.7.0
 * Add `reportjob.additionalEnvVars` for report job-specific environment variable overrides
 

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "18.2"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 5.7.0
+version: 5.7.1
 kubeVersion: ">= 1.22.0-0"
 maintainers:
   - name: rbren

--- a/stable/fairwinds-insights/templates/deployment-dashboard.yaml
+++ b/stable/fairwinds-insights/templates/deployment-dashboard.yaml
@@ -36,7 +36,7 @@ spec:
           - |
             {{ with .Values.options.dashboardConfig -}}
             cd /etc/nginx/html
-            mv -f {{ . }} ./config.js || exit 1
+            mv -f {{ . }} ./static/config.js || exit 1
             {{ end -}}
             sed -i 's/SERVICE.NAMESPACE.svc/{{ include "fairwinds-insights.fullname" . }}-api.{{.Release.Namespace}}.svc/' /etc/nginx/nginx.conf
             sed -i 's/SERVICE-OPEN-API.NAMESPACE.svc/{{ include "fairwinds-insights.fullname" . }}-open-api.{{.Release.Namespace}}.svc/' /etc/nginx/nginx.conf


### PR DESCRIPTION
**Why This PR?**
* move `config.*.js` to the correct path `/static/config.js`

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
