### PR TITLE
[incubator/datadog-apm] allow image update with upstream init container pattern

### DIFF
--- a/incubator/datadog-apm/Chart.yaml
+++ b/incubator/datadog-apm/Chart.yaml
@@ -3,7 +3,7 @@ name: datadog-apm
 description: A modified chart that only installs the datadog-apm agent
 type: application
 version: 1.1.1
-appVersion: 7.59.0
+appVersion: "7.73.0"
 maintainers:
   - name: sudermanjr
   - name: Azahorscak

--- a/incubator/datadog-apm/Chart.yaml
+++ b/incubator/datadog-apm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datadog-apm
 description: A modified chart that only installs the datadog-apm agent
 type: application
-version: 1.1.1
+version: 2.0.0
 appVersion: "7.73.0"
 maintainers:
   - name: sudermanjr

--- a/incubator/datadog-apm/README.md
+++ b/incubator/datadog-apm/README.md
@@ -34,11 +34,12 @@ A modified chart that only installs the datadog-apm agent
 | datadog.appKeySecretName | string | `nil` |  |
 | datadog.logLevel | string | `"INFO"` |  |
 | datadog.site | string | `"datadoghq.com"` |  |
-| clusterAgent.image.repository | string | `"datadog/agent"` |  |
+| clusterAgent.useInitContainersForConfig | bool | `true` | Use init containers to bootstrap config from image into emptyDir (config + tmpdir + apmsocket volumes) |
+| clusterAgent.image.repository | string | `"public.ecr.aws/datadog/agent"` |  |
 | clusterAgent.image.pullPolicy | string | `"Always"` |  |
 | clusterAgent.image.tag | string | `""` | Overrides the image tag whose default is {{ .Chart.AppVersion }} |
 | clusterAgent.command[0] | string | `"trace-agent"` |  |
-| clusterAgent.command[1] | string | `"--config=/etc/datadog-agent/datadog-cluster.yaml"` |  |
+| clusterAgent.command[1] | string | `"--config=/etc/datadog-agent/datadog.yaml"` |  |
 | clusterAgent.enabled | bool | `true` |  |
 | clusterAgent.token | string | `nil` |  |
 | clusterAgent.apm.enabled | bool | `true` |  |

--- a/incubator/datadog-apm/ci/test-values.yaml
+++ b/incubator/datadog-apm/ci/test-values.yaml
@@ -18,7 +18,6 @@ clusterAgent:
   image:
     repository: public.ecr.aws/datadog/agent
     pullPolicy: Always
-    # -- Overrides the image tag whose default is {{ .Chart.AppVersion }}
     tag: ""
   command:
     - trace-agent

--- a/incubator/datadog-apm/ci/test-values.yaml
+++ b/incubator/datadog-apm/ci/test-values.yaml
@@ -14,14 +14,15 @@ datadog:
   site: datadoghq.com
 
 clusterAgent:
+  useInitContainersForConfig: true
   image:
-    repository: datadog/agent
+    repository: public.ecr.aws/datadog/agent
     pullPolicy: Always
     # -- Overrides the image tag whose default is {{ .Chart.AppVersion }}
     tag: ""
   command:
     - trace-agent
-    - --config=/etc/datadog-agent/datadog-cluster.yaml
+    - --config=/etc/datadog-agent/datadog.yaml
   enabled: true
   # -- DATADOG_CLUSTER_AGENT_TOKEN
   token: XXXYYYXXXYYYXXXYYYXXXYYYXXX=

--- a/incubator/datadog-apm/templates/_helpers.tpl
+++ b/incubator/datadog-apm/templates/_helpers.tpl
@@ -58,6 +58,13 @@ Return secret name to be used based on provided values.
 {{- end -}}
 
 {{/*
+Return the cluster-agent image (repository:tag) for main and init containers.
+*/}}
+{{- define "clusterAgent.image" -}}
+{{- .Values.clusterAgent.image.repository }}:{{ default .Chart.AppVersion .Values.clusterAgent.image.tag }}
+{{- end -}}
+
+{{/*
 Correct `clusterAgent.metricsProvider.service.port` if Kubernetes <= 1.15
 */}}
 {{- define "clusterAgent.metricsProvider.port" -}}

--- a/incubator/datadog-apm/templates/cluster-agent-deployment.yaml
+++ b/incubator/datadog-apm/templates/cluster-agent-deployment.yaml
@@ -75,9 +75,38 @@ spec:
       dnsConfig:
 {{ toYaml .Values.clusterAgent.dnsConfig | indent 8 }}
       {{- end }}
+      {{- if .Values.clusterAgent.useInitContainersForConfig }}
+      initContainers:
+      - name: init-volume
+        image: "{{ include "clusterAgent.image" . }}"
+        imagePullPolicy: {{ .Values.clusterAgent.image.pullPolicy }}
+        command: ["bash", "-c"]
+        args:
+          - cp -r /etc/datadog-agent /opt
+        volumeMounts:
+          - name: config
+            mountPath: /opt/datadog-agent
+            readOnly: false
+        resources:
+          {}
+      - name: init-config
+        image: "{{ include "clusterAgent.image" . }}"
+        imagePullPolicy: {{ .Values.clusterAgent.image.pullPolicy }}
+        command:
+          - bash
+          - -c
+        args:
+          - for script in $(find /etc/cont-init.d/ -type f -name '*.sh' | sort) ; do bash $script ; done
+        volumeMounts:
+          - name: config
+            mountPath: /etc/datadog-agent
+            readOnly: false
+        resources:
+          {}
+      {{- end }}
       containers:
       - name: cluster-agent
-        image: "{{ .Values.clusterAgent.image.repository }}:{{ default .Chart.AppVersion .Values.clusterAgent.image.tag }}"
+        image: "{{ include "clusterAgent.image" . }}"
         {{- with .Values.clusterAgent.command }}
         command: {{ range . }}
           - {{ . | quote }}
@@ -164,7 +193,7 @@ spec:
                 name: {{ template "clusterAgent.tokenSecretName" . }}
                 key: token
           - name: DD_KUBE_RESOURCES_NAMESPACE
-            value: {{ .Release.Namespace }}
+            value: {{ default .Release.Namespace .Values.clusterAgent.kubeResourcesNamespace | quote }}
           - name: DD_HOSTNAME
             valueFrom:
               fieldRef:
@@ -191,6 +220,14 @@ spec:
         readinessProbe:
 {{ toYaml .Values.clusterAgent.readinessProbe | indent 10 }}
         volumeMounts:
+{{- if .Values.clusterAgent.useInitContainersForConfig }}
+          - name: config
+            mountPath: /etc/datadog-agent
+            readOnly: false
+          - name: tmpdir
+            mountPath: /tmp
+            readOnly: false
+{{- else }}
 {{- if .Values.clusterAgent.volumeMounts }}
 {{ toYaml .Values.clusterAgent.volumeMounts | indent 10 }}
 {{- end }}
@@ -204,8 +241,19 @@ spec:
             mountPath: /etc/datadog-agent/datadog-cluster.yaml
             subPath: datadog-cluster.yaml
             readOnly: true
-{{- end}}
+{{- end }}
+{{- end }}
       volumes:
+{{- if .Values.clusterAgent.useInitContainersForConfig }}
+        - name: config
+          emptyDir: {}
+        - name: tmpdir
+          emptyDir: {}
+        - hostPath:
+            path: /var/run/datadog
+            type: DirectoryOrCreate
+          name: apmsocket
+{{- else }}
 {{- if .Values.clusterAgent.confd }}
         - name: confd
           configMap:
@@ -215,10 +263,10 @@ spec:
         - name: cluster-agent-yaml
           configMap:
             name: {{ template "datadog-apm.fullname" . }}-cluster-agent-config
-{{- end}}
-
+{{- end }}
 {{- if .Values.clusterAgent.volumes }}
 {{ toYaml .Values.clusterAgent.volumes | indent 8 }}
+{{- end }}
 {{- end }}
       {{- if .Values.clusterAgent.tolerations }}
       tolerations:

--- a/incubator/datadog-apm/values.yaml
+++ b/incubator/datadog-apm/values.yaml
@@ -15,14 +15,16 @@ datadog:
   site: datadoghq.com
 
 clusterAgent:
+  # -- Use init containers to bootstrap config from image into emptyDir (config + tmpdir + apmsocket volumes)
+  useInitContainersForConfig: true
   image:
-    repository: datadog/agent
+    repository: public.ecr.aws/datadog/agent
     pullPolicy: Always
     # -- Overrides the image tag whose default is {{ .Chart.AppVersion }}
     tag: ""
   command:
     - trace-agent
-    - --config=/etc/datadog-agent/datadog-cluster.yaml
+    - --config=/etc/datadog-agent/datadog.yaml
   enabled: true
   token:   # <DATADOG_CLUSTER_AGENT_TOKEN>
   apm:


### PR DESCRIPTION

**Why This PR?**
The updated agent image changes how file creation is handled and prevents updates. This will allow be more flexible in the future as datadog continues to modify the initcontainers and file paths expected in the trace-agent. 

Fixes #

**Changes**
Changes proposed in this pull request:

* Adds `useInitContainersForConfig` var
* Uses dd aws ecr repo and image tag 7.73.0
* Updates the trace-agent container's command to `--config=/etc/datadog-agent/datadog.yaml`
* mounts necessary volumes

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
