### PR TITLE
[stable/fairwinds-insights] - add additional environment variables for cronjobs

### DIFF
--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 6.1.0
+* Add support for `cronjobOptions.additionalEnvVars` and `cronjobs.<name>.additionalEnvVars`
+
 ## 6.0.0
 * Bumped timescale to pg17.7-ts2.24.0-all
 

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "18.2"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 6.0.0
+version: 6.1.0
 kubeVersion: ">= 1.22.0-0"
 maintainers:
   - name: rbren

--- a/stable/fairwinds-insights/README.md
+++ b/stable/fairwinds-insights/README.md
@@ -40,6 +40,7 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | options.ssoRequiredForAdminAPI | bool | `false` | Whether to require SSO for the admin API |
 | cronjobOptions.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":10324}` | Default security context for cronjobs |
 | cronjobOptions.resources | object | `{"limits":{"cpu":"250m","memory":"512Mi"},"requests":{"cpu":"250m","memory":"512Mi"}}` | Default resources for cronjobs |
+| cronjobOptions.additionalEnvVars | list | `[{"name":"POSTGRES_MAX_IDLE_CONNS","value":"1"},{"name":"POSTGRES_MAX_OPEN_CONNS","value":"1"}]` | Default additional env vars for all cronjobs (overridden per cronjob by cronjobs.<name>.additionalEnvVars) |
 | cronjobs.action-item-filters-refresh | object | `{"command":"action_items_filters_refresher","schedule":"0/15 * * * *"}` | Options for the action-items filters refresher job. |
 | cronjobs.action-items-statistics | object | `{"command":"action_items_statistics","schedule":"15 * * * *"}` | Options for the action item stats job |
 | cronjobs.benchmark | object | `{"command":"benchmark","schedule":""}` | Options for the benchmark job |

--- a/stable/fairwinds-insights/templates/cronjobs.yaml
+++ b/stable/fairwinds-insights/templates/cronjobs.yaml
@@ -29,6 +29,10 @@ spec:
                 - --interval={{ . }}
               {{- end }}
               {{- include "env" (dict "useReadReplica" $options.useReadReplica "root" $) | indent 14 }}
+              {{- $envVars := concat (default list $.Values.cronjobOptions.additionalEnvVars) ($options.additionalEnvVars | default list) }}
+              {{- with $envVars }}
+              {{- toYaml . | nindent 14 }}
+              {{- end }}
               imagePullPolicy: Always
               resources:
                 {{- toYaml (default $.Values.cronjobOptions.resources $options.resources) | nindent 16 }}

--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -92,6 +92,12 @@ cronjobOptions:
     limits:
       cpu: 250m
       memory: 512Mi
+  # -- Default additional env vars for all cronjobs (overridden per cronjob by cronjobs.<name>.additionalEnvVars)
+  additionalEnvVars:
+    - name: POSTGRES_MAX_IDLE_CONNS
+      value: "1"
+    - name: POSTGRES_MAX_OPEN_CONNS
+      value: "1"
 
 cronjobs:
   # -- Options for the action-items filters refresher job.


### PR DESCRIPTION
**Why This PR?**
Add additional environment variables support for cronjobs

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
