### PR TITLE
[stable/insights-agent] INS-1996: Pin device-metrics-exporter-charts at v1.4.1 as v1.4.2 has a bug

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 5.5.4
+* Pin device-metrics-exporter-charts at v1.4.1 as v1.4.2 has a bug
+
 ## 5.5.3
 * Improve GPU exporters install
 

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 5.5.3
+version: 5.5.4
 appVersion: 9.2.1
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png

--- a/stable/insights-agent/requirements.yaml
+++ b/stable/insights-agent/requirements.yaml
@@ -31,7 +31,7 @@ dependencies:
   repository: https://nvidia.github.io/dcgm-exporter/helm-charts
   condition: dcgm-exporter.enabled
 - name: device-metrics-exporter-charts
-  version: '1.4.*'
+  version: '1.4.1'
   repository: https://rocm.github.io/device-metrics-exporter
   condition: amd-device-metrics-exporter.enabled
   alias: amd-device-metrics-exporter


### PR DESCRIPTION

**Why This PR?**
_a short description of why this PR is needed_

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
