### PR TITLE
[stable/fairwinds-insights] Bump temporal chart version to 0.73.2

### DIFF
--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 6.2.0
+* Bumped Temporal sub-chart to 0.73.2
+
 ## 6.1.1
 * Bumped CNPG
 

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "18.2"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 6.1.1
+version: 6.2.0
 kubeVersion: ">= 1.22.0-0"
 maintainers:
   - name: rbren

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -19,7 +19,7 @@ dependencies:
     condition: timescale.ephemeral
     alias: timescale
   - name: temporal
-    version: 0.65.0
+    version: 0.73.2
     repository: https://go.temporal.io/helm-charts
     condition: temporal.enabled
     alias: temporal


### PR DESCRIPTION
**Why This PR?**
Bump temporal sub-chart to latest version available

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
