### PR TITLE
[stable/insights-agent] INS-2061: Add GPU service monitor for prometheus

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 5.6.1
+* Added GPU monitor config
+
 ## 5.6.0
 * Major bump on dependencies
 

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 5.6.0
+version: 5.6.1
 appVersion: 9.2.1
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png

--- a/stable/insights-agent/templates/dcgm-servicemonitor.yaml
+++ b/stable/insights-agent/templates/dcgm-servicemonitor.yaml
@@ -1,0 +1,31 @@
+{{- if and .Values.dcgm-exporter.enabled (index .Values "prometheus-metrics" "installPrometheusServer" | not) }}
+# ServiceMonitor for DCGM Exporter when using an external Prometheus (e.g. kube-prometheus-stack).
+# Ensures Prometheus Operator scrapes the DCGM metrics endpoint. When using the bundled
+# Prometheus server (installPrometheusServer: true), annotation-based discovery is used instead.
+#
+# If your Prometheus only discovers ServiceMonitors with a specific label (e.g. release: fw-prometheus),
+# add that label under metadata.labels so this ServiceMonitor is selected.
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "insights-agent.fullname" . }}-dcgm-exporter
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: dcgm-exporter
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- with .Values.dcgm-exporter.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: dcgm-exporter
+  endpoints:
+    - port: "9400"
+      path: /metrics
+      interval: 30s
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+---
+{{- end }}

--- a/stable/insights-agent/templates/dcgm-servicemonitor.yaml
+++ b/stable/insights-agent/templates/dcgm-servicemonitor.yaml
@@ -21,9 +21,8 @@ spec:
     matchLabels:
       app.kubernetes.io/name: dcgm-exporter
   endpoints:
-    - port: "9400"
-      path: /metrics
-      interval: 30s
+    {{- $endpoints := (index .Values "dcgm-exporter").serviceMonitor.endpoints }}
+    {{- toYaml (default (list (dict "port" "9400" "path" "/metrics" "interval" "30s")) $endpoints) | nindent 4 }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}

--- a/stable/insights-agent/templates/dcgm-servicemonitor.yaml
+++ b/stable/insights-agent/templates/dcgm-servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.dcgm-exporter.enabled (index .Values "prometheus-metrics" "installPrometheusServer" | not) }}
+{{- if and (index .Values "dcgm-exporter").enabled (index .Values "prometheus-metrics" "installPrometheusServer" | not) }}
 # ServiceMonitor for DCGM Exporter when using an external Prometheus (e.g. kube-prometheus-stack).
 # Ensures Prometheus Operator scrapes the DCGM metrics endpoint. When using the bundled
 # Prometheus server (installPrometheusServer: true), annotation-based discovery is used instead.
@@ -13,7 +13,7 @@ metadata:
   labels:
     app.kubernetes.io/name: dcgm-exporter
     app.kubernetes.io/instance: {{ .Release.Name }}
-    {{- with .Values.dcgm-exporter.serviceMonitor.labels }}
+    {{- with (index .Values "dcgm-exporter").serviceMonitor.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -460,6 +460,11 @@ dcgm-exporter:
     enabled: false
     labels:
       release: fw-prometheus  # match your kube-prometheus-stack release
+    # dcgm-exporter.serviceMonitor.endpoints -- ServiceMonitor scrape endpoints (port must match service).
+    endpoints:
+      - port: "9400"
+        path: /metrics
+        interval: 30s
   # dcgm-exporter.service -- Service configuration for DCGM Exporter
   service:
     # dcgm-exporter.service.annotations -- Annotations for Prometheus auto-discovery

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -400,6 +400,21 @@ prometheus:
       capabilities:
         drop:
           - ALL
+  # extraScrapeConfigs: when using the bundled Prometheus server and dcgm-exporter (or
+  # amd-device-metrics-exporter), add a scrape job so GPU metrics are collected even if
+  # annotation-based discovery does not pick them up. Uncomment and set when dcgm-exporter.enabled
+  # (and/or installPrometheusServer) is true. Use the FQDN if Prometheus runs in another namespace.
+  # extraScrapeConfigs: |
+  #   - job_name: dcgm-exporter
+  #     metrics_path: /metrics
+  #     static_configs:
+  #       - targets:
+  #           - insights-agent-dcgm-exporter.insights-agent.svc.cluster.local:9400
+  #     relabel_configs:
+  #       - source_labels: [__address__]
+  #         target_label: instance
+  #       - replacement: dcgm-exporter
+  #         target_label: job
 
 # GPU Metrics Support
 # -------------------
@@ -438,10 +453,13 @@ dcgm-exporter:
   affinity: {}
   # dcgm-exporter.tolerations -- Tolerations for GPU nodes (if those nodes have taints).
   tolerations: []
-  # dcgm-exporter.serviceMonitor -- Enable ServiceMonitor for Prometheus Operator.
-  # If using the bundled prometheus server, set to false.
+  # dcgm-exporter.serviceMonitor -- When using external Prometheus (e.g. kube-prometheus-stack),
+  # the chart creates a ServiceMonitor so Prometheus Operator scrapes DCGM. Add labels here so
+  # your Prometheus selects it (e.g. release: fw-prometheus to match serviceMonitorSelector).
   serviceMonitor:
-    enabled: false
+    enabled: false    
+    labels:
+      release: fw-prometheus # match your kube-prometheus-stack release
   # dcgm-exporter.service -- Service configuration for DCGM Exporter
   service:
     # dcgm-exporter.service.annotations -- Annotations for Prometheus auto-discovery

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -457,9 +457,9 @@ dcgm-exporter:
   # the chart creates a ServiceMonitor so Prometheus Operator scrapes DCGM. Add labels here so
   # your Prometheus selects it (e.g. release: fw-prometheus to match serviceMonitorSelector).
   serviceMonitor:
-    enabled: false    
+    enabled: false
     labels:
-      release: fw-prometheus # match your kube-prometheus-stack release
+      release: fw-prometheus  # match your kube-prometheus-stack release
   # dcgm-exporter.service -- Service configuration for DCGM Exporter
   service:
     # dcgm-exporter.service.annotations -- Annotations for Prometheus auto-discovery


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
