### PR TITLE
[stable/insights-agent] pin amd-device-metrics-exporter to 1.4.1

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 5.6.2
+* Pinned amd-device-metrics-exporter to v1.4.1 to avoid a bug
+
 ## 5.6.1
 * Added GPU monitor config
 

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 5.6.1
+version: 5.6.2
 appVersion: 9.2.1
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png

--- a/stable/insights-agent/requirements.yaml
+++ b/stable/insights-agent/requirements.yaml
@@ -31,7 +31,7 @@ dependencies:
   repository: https://nvidia.github.io/dcgm-exporter/helm-charts
   condition: dcgm-exporter.enabled
 - name: device-metrics-exporter-charts
-  version: '1.4.*'
+  version: '1.4.1'
   repository: https://rocm.github.io/device-metrics-exporter
   condition: amd-device-metrics-exporter.enabled
   alias: amd-device-metrics-exporter


### PR DESCRIPTION
**Why This PR?**
Dependency chart `amd-device-metrics-exporter`'s latest version `1.4.2` does not render its `Service` manifest properly, failing `kubeconform` and failing to apply to a living cluster.  There is a [merged PR](https://github.com/ROCm/device-metrics-exporter/pull/435) that fixes this behavior, but it has not yet been released.  The previous version `1.4.1` renders properly.  This change pins the `amd-device-metrics-exporter` chart to `1.4.1` to avoid the misbehavior.


**Changes**

* This change pins `amd-device-metrics-exporter` to the last working version `1.4.1` until https://github.com/ROCm/device-metrics-exporter/pull/435 is released


**Testing**
Broken output using `1.4.*` of `amd-device-metrics-exporter`:
```
# Source: insights-agent/charts/amd-device-metrics-exporter/templates/metrics-exporter-service.yaml
apiVersion: v1
kind: Service
metadata:
  name: insights-agent-amd-metrics-exporter-svc
  labels:
  
  app: insights-agent-amdgpu-metrics-exporter
```

Fixed output using `1.4.1` of `amd-device-metrics-exporter`:
```
# Source: insights-agent/charts/amd-device-metrics-exporter/templates/metrics-exporter-service.yaml
apiVersion: v1
kind: Service
metadata:
  name: insights-agent-amd-metrics-exporter-svc
  labels:
    app: insights-agent-amdgpu-metrics-exporter
```

Output generated with `helm template insights-agent . -f values.manual-test.yaml --output-dir out` where `values.manual-test.yaml` contains only:
```
insights:
  host: https://whatever.zoinks
  organization: "zoinks"
  cluster: "whatever"
  base64token: "em9pbmtzCg=="

amd-device-metrics-exporter:
  enabled: true
```

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
