### PR TITLE
[stable/insights-admission] INS-1885: Warning in cert-manager for admission controller

### DIFF
--- a/stable/insights-admission/CHANGELOG.md
+++ b/stable/insights-admission/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.11.3
+## 1.12.0
 * Set explicit `spec.privateKey.rotationPolicy` on the cert-manager Certificate for cert-manager v1.18.0+ compatibility (configurable via `privateKeyRotationPolicy`).
 
 ## 1.11.2

--- a/stable/insights-admission/CHANGELOG.md
+++ b/stable/insights-admission/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.11.3
+* Set explicit `spec.privateKey.rotationPolicy` on the cert-manager Certificate for cert-manager v1.18.0+ compatibility (configurable via `privateKeyRotationPolicy`).
+
 ## 1.11.2
 * Bumped admission
 

--- a/stable/insights-admission/Chart.yaml
+++ b/stable/insights-admission/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: insights-admission
 description: A Validating Webhook Admission Controller that utilizes Fairwinds Insights.
 type: application
-version: 1.11.3
+version: 1.12.0
 appVersion: "2.2"
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-admission/icon.png

--- a/stable/insights-admission/Chart.yaml
+++ b/stable/insights-admission/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: insights-admission
 description: A Validating Webhook Admission Controller that utilizes Fairwinds Insights.
 type: application
-version: 1.11.2
+version: 1.11.3
 appVersion: "2.2"
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-admission/icon.png

--- a/stable/insights-admission/README.md
+++ b/stable/insights-admission/README.md
@@ -100,5 +100,6 @@ rules:
 | secretName | string | `""` | If you are providing your own certificate then this is the name of the secret holding the certificate. |
 | clusterDomain | string | `"cluster.local"` | The base domain to use for cluster DNS |
 | certManagerApiVersion | string | `""` | If secretName is empty, we assume that you use cert-manager to provision the admission controller certificates. This allows pinning the apiVersion rather than using helm capabilities detection. Useful for gitops tools such as ArgoCD |
+| privateKeyRotationPolicy | string | `"Never"` | cert-manager Certificate `spec.privateKey.rotationPolicy`. In cert-manager v1.18.0+ the default is `Always` (it was `Never` before). Set explicitly to silence warnings and pin behavior. Use `Always` to match the new default or `Never` for the pre-1.18 behavior. |
 | polaris.config | string | `nil` | Configuration for Polaris |
 | test | object | `{"enabled":false,"image":{"repository":"python","tag":"3.10-alpine"}}` | Used for chart CI only - deploys a test deployment |

--- a/stable/insights-admission/README.md
+++ b/stable/insights-admission/README.md
@@ -100,6 +100,6 @@ rules:
 | secretName | string | `""` | If you are providing your own certificate then this is the name of the secret holding the certificate. |
 | clusterDomain | string | `"cluster.local"` | The base domain to use for cluster DNS |
 | certManagerApiVersion | string | `""` | If secretName is empty, we assume that you use cert-manager to provision the admission controller certificates. This allows pinning the apiVersion rather than using helm capabilities detection. Useful for gitops tools such as ArgoCD |
-| privateKeyRotationPolicy | string | `"Never"` | cert-manager Certificate `spec.privateKey.rotationPolicy`. In cert-manager v1.18.0+ the default is `Always` (it was `Never` before). Set explicitly to silence warnings and pin behavior. Use `Always` to match the new default or `Never` for the pre-1.18 behavior. |
+| privateKeyRotationPolicy | string | `"Always"` | cert-manager Certificate `spec.privateKey.rotationPolicy`. In cert-manager v1.18.0+ the default is `Always` (it was `Never` before). Set explicitly to silence warnings and pin behavior. Use `Always` to match the new default or `Never` for the pre-1.18 behavior. |
 | polaris.config | string | `nil` | Configuration for Polaris |
 | test | object | `{"enabled":false,"image":{"repository":"python","tag":"3.10-alpine"}}` | Used for chart CI only - deploys a test deployment |

--- a/stable/insights-admission/templates/_helpers.tpl
+++ b/stable/insights-admission/templates/_helpers.tpl
@@ -83,3 +83,17 @@ Create the name of the ConfigMap to use
 {{- printf "%s-%s" (include "insights-admission.fullname" .) (default "configmap" .Values.insights.configmap.suffix) }}
 {{- end }}
 {{- end }}
+
+{{/*
+True when the Certificate uses cert-manager.io/v1 (spec.privateKey.rotationPolicy is only valid on v1).
+*/}}
+{{- define "insights-admission.certManagerCertificateIsV1" -}}
+{{- $api := default "" .Values.certManagerApiVersion -}}
+{{- if $api -}}
+{{- if eq $api "cert-manager.io/v1" -}}true{{- else -}}false{{- end -}}
+{{- else if .Capabilities.APIVersions.Has "cert-manager.io/v1" -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end -}}

--- a/stable/insights-admission/templates/cert.yaml
+++ b/stable/insights-admission/templates/cert.yaml
@@ -25,6 +25,10 @@ spec:
   secretName: {{ include "insights-admission.fullname" . }}
   duration: 2160h0m0s
   renewBefore: 360h0m0s
+  {{- if eq (include "insights-admission.certManagerCertificateIsV1" . | trim) "true" }}
+  privateKey:
+    rotationPolicy: {{ .Values.privateKeyRotationPolicy }}
+  {{- end }}
 ---
 {{- if .Values.certManagerApiVersion }}
 apiVersion: {{ .Values.certManagerApiVersion }}

--- a/stable/insights-admission/values.yaml
+++ b/stable/insights-admission/values.yaml
@@ -242,7 +242,7 @@ clusterDomain: cluster.local
 # certManagerApiVersion -- If secretName is empty, we assume that you use cert-manager to provision the admission controller certificates. This allows pinning the apiVersion rather than using helm capabilities detection. Useful for gitops tools such as ArgoCD
 certManagerApiVersion: ""
 # privateKeyRotationPolicy -- cert-manager Certificate `spec.privateKey.rotationPolicy`. In cert-manager v1.18.0+ the default is `Always` (it was `Never` before). Set explicitly to silence warnings and pin behavior. Use `Always` to match the new default or `Never` for the pre-1.18 behavior.
-privateKeyRotationPolicy: Never
+privateKeyRotationPolicy: Always
 
 polaris:
   # -- Configuration for Polaris

--- a/stable/insights-admission/values.yaml
+++ b/stable/insights-admission/values.yaml
@@ -241,6 +241,8 @@ secretName: ""
 clusterDomain: cluster.local
 # certManagerApiVersion -- If secretName is empty, we assume that you use cert-manager to provision the admission controller certificates. This allows pinning the apiVersion rather than using helm capabilities detection. Useful for gitops tools such as ArgoCD
 certManagerApiVersion: ""
+# privateKeyRotationPolicy -- cert-manager Certificate `spec.privateKey.rotationPolicy`. In cert-manager v1.18.0+ the default is `Always` (it was `Never` before). Set explicitly to silence warnings and pin behavior. Use `Always` to match the new default or `Never` for the pre-1.18 behavior.
+privateKeyRotationPolicy: Never
 
 polaris:
   # -- Configuration for Polaris


### PR DESCRIPTION
**Why This PR?**

This has changed and needs to be updated in our cert-manager issuer for admission controller:

W0211 12:08:15.943771   89931 warnings.go:70] spec.privateKey.rotationPolicy: In cert-manager >= v1.18.0, the default value changed from `Never` to `Always`
Fixes #

**Changes**
Add config for  spec.privateKey.rotationPolicy

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
